### PR TITLE
feat(analyzer): add nested field mapping support

### DIFF
--- a/tools/cmd/scraper/analyzer/analyzer.go
+++ b/tools/cmd/scraper/analyzer/analyzer.go
@@ -169,6 +169,9 @@ func (a *Analyzer) analyzeResource(mapping ResourceMapping, apiParams []extracto
 		} else if _, exists := tfFieldSet[apiName]; exists {
 			// Also check direct match
 			coverage.ImplementedFields++
+		} else if IsNestedField(apiName, &mapping) {
+			// Field is implemented but nested inside another TF attribute (e.g., settings.website)
+			coverage.ImplementedFields++
 		} else {
 			coverage.MissingFields++
 		}
@@ -244,6 +247,12 @@ func (a *Analyzer) findResourceGaps(mapping ResourceMapping, apiParams []extract
 		}
 
 		tfName := MapAPIFieldToTerraform(apiParam.Name, &mapping)
+
+		// Check if field is implemented via nested mapping (e.g., API "website" -> TF "settings.website")
+		if IsNestedField(apiParam.Name, &mapping) {
+			// Field is implemented but nested - not a gap
+			continue
+		}
 
 		if _, exists := tfFieldMap[tfName]; !exists {
 			// Also try direct match


### PR DESCRIPTION
## Summary
- Enhance the coverage analyzer to understand when API fields are implemented via nested Terraform attributes
- Fix false positives for statuspage where 17 fields were incorrectly flagged as missing

## Problem
The analyzer was comparing API fields (flat structure) against TF schema fields (top-level only). For statuspage, the API has fields like `website`, `theme`, `description` at the top level, but the provider organizes these inside a `settings` nested attribute for better UX.

## Solution
Add `NestedFieldMappings` to `ResourceMapping` struct that explicitly maps API fields to their nested TF paths:

```go
NestedFieldMappings: map[string]string{
    "website":      "settings.website",
    "theme":        "settings.theme",
    "description":  "settings.description",
    // ... 14 more fields
}
```

## Changes
- Add `NestedFieldMappings` field to `ResourceMapping` struct
- Add `GetNestedFieldMapping()` and `IsNestedField()` helper functions
- Update `analyzeResource()` to count nested fields as implemented
- Update `findResourceGaps()` to skip nested fields from gap detection
- Add statuspage-specific nested mappings

## Results
Before: `hyperping_statuspage: 19.0% (4/21)` with 17 "missing" fields
After: `hyperping_statuspage: 100.0% (21/21)` - all fields correctly identified

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Analyzer correctly shows 100% coverage for statuspage

Closes #6