### PR TITLE
feat: add reusable GitHub Actions workflow for Terraform

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,10 @@ provider "hyperping" {
 - [Rate Limits Guide](guides/rate-limits.md) - Capacity planning for large deployments
 - [Validation Guide](guides/validation.md) - Catch configuration errors early with `terraform validate`
 
+## CI/CD
+
+- [GitHub Actions Workflows](https://github.com/develeap/terraform-provider-hyperping/tree/main/examples/github-actions) - Ready-to-use workflows for automated Terraform deployments
+
 ## Troubleshooting
 
 See the [Troubleshooting Guide](TROUBLESHOOTING.md) for common issues and solutions.

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,0 +1,172 @@
+# GitHub Actions Workflows for Terraform Hyperping
+
+Ready-to-use GitHub Actions workflows for managing Hyperping resources with Terraform.
+
+## Quick Start
+
+### 1. Copy the Workflow
+
+Copy `terraform-hyperping.yml` to your repository:
+
+```bash
+mkdir -p .github/workflows
+cp terraform-hyperping.yml .github/workflows/
+```
+
+### 2. Set Up Secrets
+
+Add your Hyperping API key to repository secrets:
+
+1. Go to **Settings** > **Secrets and variables** > **Actions**
+2. Click **New repository secret**
+3. Name: `HYPERPING_API_KEY`
+4. Value: Your API key (starts with `sk_`)
+
+### 3. Configure State Backend (Recommended)
+
+For team environments, configure a remote backend. Add to your `main.tf`:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "your-terraform-state-bucket"
+    key            = "hyperping/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+```
+
+Or use Terraform Cloud:
+
+```hcl
+terraform {
+  cloud {
+    organization = "your-org"
+    workspaces {
+      name = "hyperping-production"
+    }
+  }
+}
+```
+
+## Workflow Behavior
+
+### Triggers
+
+| Event | Action |
+|-------|--------|
+| Push to `main` | Plan + Apply (if changes) |
+| Pull Request | Plan only (comment on PR) |
+| Manual (workflow_dispatch) | Choose: plan, apply, or destroy |
+
+### Jobs
+
+| Job | Purpose | When |
+|-----|---------|------|
+| `validate` | Format check, syntax validation | Always |
+| `plan` | Generate execution plan | Always |
+| `apply` | Apply changes | Main branch or manual |
+| `destroy` | Destroy all resources | Manual only |
+| `drift-check` | Detect configuration drift | Scheduled (disabled by default) |
+
+## Configuration Options
+
+### Change Parallelism
+
+Edit the environment variables to adjust rate limiting:
+
+```yaml
+env:
+  TF_CLI_ARGS_plan: '-parallelism=5'   # Reduce for large deployments
+  TF_CLI_ARGS_apply: '-parallelism=5'
+```
+
+### Enable Drift Detection
+
+Uncomment the schedule trigger and enable the drift-check job:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 3 AM UTC
+
+jobs:
+  drift-check:
+    if: github.event_name == 'schedule'  # Change from 'false'
+```
+
+### Require Approval for Apply
+
+The workflow uses the `production` environment. Configure approval in:
+
+**Settings** > **Environments** > **production** > **Required reviewers**
+
+### Filter Paths
+
+By default, the workflow only runs when `.tf` files change:
+
+```yaml
+paths:
+  - '**.tf'
+  - '.github/workflows/terraform-hyperping.yml'
+```
+
+## Example Repository Structure
+
+```
+your-repo/
+├── .github/
+│   └── workflows/
+│       └── terraform-hyperping.yml
+├── main.tf
+├── monitors.tf
+├── statuspages.tf
+├── variables.tf
+├── outputs.tf
+└── README.md
+```
+
+## Workflow Files
+
+| File | Description |
+|------|-------------|
+| `terraform-hyperping.yml` | Full CI/CD workflow with plan, apply, destroy, and drift detection |
+
+## Security Best Practices
+
+1. **Never commit API keys** - Always use secrets
+2. **Enable branch protection** - Require PR reviews before merging to main
+3. **Use environment protection** - Require approval for production applies
+4. **Limit secret access** - Only allow workflows on protected branches to access secrets
+
+## Troubleshooting
+
+### Error: 429 Too Many Requests
+
+Reduce parallelism in the workflow:
+
+```yaml
+env:
+  TF_CLI_ARGS_plan: '-parallelism=2'
+  TF_CLI_ARGS_apply: '-parallelism=2'
+```
+
+### Error: State Lock Timeout
+
+Another workflow is running. Wait for it to complete or manually unlock:
+
+```bash
+terraform force-unlock LOCK_ID
+```
+
+### Plan Comment Too Long
+
+GitHub has a 65,535 character limit for comments. The workflow truncates long plans automatically.
+
+## Additional Resources
+
+- [Rate Limits Guide](../../docs/guides/rate-limits.md)
+- [Migration Guide](../../docs/guides/migration.md)
+- [Troubleshooting Guide](../../docs/TROUBLESHOOTING.md)

--- a/examples/github-actions/terraform-hyperping.yml
+++ b/examples/github-actions/terraform-hyperping.yml
@@ -1,0 +1,262 @@
+# Terraform Hyperping CI/CD Workflow
+# Copy this file to your repository: .github/workflows/terraform-hyperping.yml
+#
+# Prerequisites:
+# 1. Set HYPERPING_API_KEY secret in your repository settings
+# 2. (Optional) Configure Terraform Cloud/S3 backend for state management
+#
+# Usage:
+# - Push to main: Plan and apply changes
+# - Pull request: Plan only (no apply)
+# - Manual trigger: Choose to plan or apply
+
+name: Terraform Hyperping
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.tf'
+      - '.github/workflows/terraform-hyperping.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.tf'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+# Prevent concurrent runs on the same branch
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false  # Never cancel running applies!
+
+env:
+  TF_VERSION: '1.8.0'
+  TF_IN_AUTOMATION: 'true'
+  # Reduce parallelism to avoid rate limits
+  TF_CLI_ARGS_plan: '-parallelism=5'
+  TF_CLI_ARGS_apply: '-parallelism=5'
+
+jobs:
+  # ============================================
+  # VALIDATE: Check Terraform configuration
+  # ============================================
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+  # ============================================
+  # PLAN: Generate execution plan
+  # ============================================
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    needs: validate
+    outputs:
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+    env:
+      HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform plan -detailed-exitcode -out=tfplan || exit_code=$?
+
+          if [ "$exit_code" == "0" ]; then
+            echo "No changes detected"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          elif [ "$exit_code" == "2" ]; then
+            echo "Changes detected"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "Plan failed"
+            exit 1
+          fi
+
+      - name: Upload Plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: tfplan
+          retention-days: 5
+
+      - name: Comment Plan on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const plan = execSync('terraform show -no-color tfplan').toString();
+
+            const output = `#### Terraform Plan
+
+            <details>
+            <summary>Show Plan</summary>
+
+            \`\`\`hcl
+            ${plan.substring(0, 65000)}
+            \`\`\`
+
+            </details>
+
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+  # ============================================
+  # APPLY: Apply changes (main branch only)
+  # ============================================
+  apply:
+    name: Apply
+    runs-on: ubuntu-latest
+    needs: plan
+    if: |
+      (github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.plan.outputs.has_changes == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+    environment: production  # Requires approval if configured
+    env:
+      HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Download Plan
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve tfplan
+
+      - name: Post-Apply Verification
+        run: |
+          echo "Verifying state..."
+          terraform state list
+          echo "Apply completed successfully!"
+
+  # ============================================
+  # DESTROY: Destroy resources (manual only)
+  # ============================================
+  destroy:
+    name: Destroy
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
+    environment: production  # Requires approval
+    env:
+      HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve
+
+  # ============================================
+  # DRIFT: Check for configuration drift
+  # ============================================
+  drift-check:
+    name: Drift Check
+    runs-on: ubuntu-latest
+    # Run on schedule (uncomment to enable)
+    # if: github.event_name == 'schedule'
+    if: false  # Disabled by default - enable for scheduled runs
+    env:
+      HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Check for Drift
+        id: drift
+        run: |
+          terraform plan -detailed-exitcode || exit_code=$?
+
+          if [ "$exit_code" == "2" ]; then
+            echo "Configuration drift detected!"
+            echo "drift_detected=true" >> $GITHUB_OUTPUT
+          else
+            echo "No drift detected"
+            echo "drift_detected=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Issue on Drift
+        if: steps.drift.outputs.drift_detected == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Terraform Drift Detected',
+              body: 'Configuration drift was detected in Hyperping resources. Please review and reconcile.',
+              labels: ['terraform', 'drift']
+            });


### PR DESCRIPTION
## Summary
- Add complete CI/CD workflow for users to copy into their repos
- Include validate, plan, apply, and destroy jobs
- Add drift detection (disabled by default, scheduled)
- Configure concurrency control and parallelism for rate limits
- Include comprehensive README with setup instructions

## Features
- PR plan commenting
- Environment-based approval for production applies
- Manual workflow dispatch for plan/apply/destroy
- State lock awareness

## Test plan
- [x] YAML syntax is valid
- [x] Pre-push hooks pass (build, lint, test)
- [x] README links work correctly
- [x] Documentation updated with CI/CD section

## Files Changed
- `examples/github-actions/terraform-hyperping.yml` (new - 262 lines)
- `examples/github-actions/README.md` (new - 172 lines)
- `docs/index.md` (updated - added CI/CD section)