### PR TITLE
fix: handle escalation_policy object shape returned by API on read

### DIFF
--- a/internal/client/models_monitor.go
+++ b/internal/client/models_monitor.go
@@ -3,12 +3,29 @@
 
 package client
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // =============================================================================
 // Monitor Models
 // =============================================================================
 
+// escalationPolicyShape is used internally to unmarshal escalation_policy from
+// the read API, which returns an object {"uuid":"...","name":"..."} rather than
+// a plain string.
+type escalationPolicyShape struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name,omitempty"`
+}
+
 // Monitor represents a Hyperping monitor.
 // API: GET /v1/monitors, GET /v1/monitors/{uuid}
+//
+// The escalation_policy field is polymorphic: the read API returns an object
+// {"uuid":"...","name":"..."}, while POST/PUT send a plain UUID string.
+// UnmarshalJSON handles both shapes and normalises to a UUID string.
 type Monitor struct {
 	UUID               string          `json:"uuid"`
 	Name               string          `json:"name"`
@@ -29,6 +46,57 @@ type Monitor struct {
 	EscalationPolicy   *string         `json:"escalation_policy,omitempty"`
 	Status             string          `json:"status,omitempty"`         // up, down (read-only)
 	SSLExpiration      *int            `json:"ssl_expiration,omitempty"` // Days until SSL cert expiration (read-only)
+}
+
+// monitorAlias is used to prevent infinite recursion in Monitor.UnmarshalJSON.
+type monitorAlias Monitor
+
+// monitorWire is the raw JSON shape for Monitor, with escalation_policy as a
+// raw message so we can handle both the string and object forms.
+type monitorWire struct {
+	monitorAlias
+	EscalationPolicy json.RawMessage `json:"escalation_policy,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler for Monitor.
+// It handles the escalation_policy field being either a plain UUID string or an
+// object {"uuid":"...","name":"..."} as returned by the Hyperping read API.
+func (m *Monitor) UnmarshalJSON(data []byte) error {
+	var wire monitorWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+
+	*m = Monitor(wire.monitorAlias)
+
+	if len(wire.EscalationPolicy) == 0 || string(wire.EscalationPolicy) == "null" {
+		m.EscalationPolicy = nil
+		return nil
+	}
+
+	// Try plain string first (e.g. "policy_uuid_here")
+	var uuidStr string
+	if err := json.Unmarshal(wire.EscalationPolicy, &uuidStr); err == nil {
+		if uuidStr == "" {
+			m.EscalationPolicy = nil
+		} else {
+			m.EscalationPolicy = &uuidStr
+		}
+		return nil
+	}
+
+	// Try object form {"uuid":"...","name":"..."}
+	var obj escalationPolicyShape
+	if err := json.Unmarshal(wire.EscalationPolicy, &obj); err == nil {
+		if obj.UUID == "" {
+			m.EscalationPolicy = nil
+		} else {
+			m.EscalationPolicy = &obj.UUID
+		}
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal escalation_policy: %s", string(wire.EscalationPolicy))
 }
 
 // CreateMonitorRequest represents a request to create a monitor.

--- a/internal/client/models_test.go
+++ b/internal/client/models_test.go
@@ -189,6 +189,78 @@ func TestFlexibleString_Integration(t *testing.T) {
 	})
 }
 
+// TestMonitor_UnmarshalJSON_escalationPolicy verifies the custom unmarshaler
+// for Monitor.escalation_policy, which the real API returns as an object
+// {"uuid":"...","name":"..."} on GET even though POST/PUT send a plain string.
+func TestMonitor_UnmarshalJSON_escalationPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantUUID string // empty string means nil
+		wantErr  bool
+	}{
+		{
+			name:     "object shape (real API GET response)",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200","escalation_policy":{"uuid":"policy_abc123","name":"Core-Escalation"}}`,
+			wantUUID: "policy_abc123",
+		},
+		{
+			name:     "plain string (legacy / write path)",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200","escalation_policy":"policy_abc123"}`,
+			wantUUID: "policy_abc123",
+		},
+		{
+			name:     "null value",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200","escalation_policy":null}`,
+			wantUUID: "",
+		},
+		{
+			name:     "field absent",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200"}`,
+			wantUUID: "",
+		},
+		{
+			name:     "object with empty UUID",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200","escalation_policy":{"uuid":"","name":"Unnamed"}}`,
+			wantUUID: "",
+		},
+		{
+			name:     "empty string value",
+			json:     `{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS","http_method":"GET","check_frequency":60,"follow_redirects":true,"expected_status_code":"200","escalation_policy":""}`,
+			wantUUID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m Monitor
+			err := json.Unmarshal([]byte(tt.json), &m)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantUUID == "" {
+				if m.EscalationPolicy != nil {
+					t.Errorf("expected nil EscalationPolicy, got %q", *m.EscalationPolicy)
+				}
+			} else {
+				if m.EscalationPolicy == nil {
+					t.Errorf("expected EscalationPolicy = %q, got nil", tt.wantUUID)
+				} else if *m.EscalationPolicy != tt.wantUUID {
+					t.Errorf("EscalationPolicy = %q, want %q", *m.EscalationPolicy, tt.wantUUID)
+				}
+			}
+		})
+	}
+}
+
 func TestCreateMonitorRequest_Validate(t *testing.T) {
 	t.Run("valid request", func(t *testing.T) {
 		req := CreateMonitorRequest{Name: "test", URL: "https://example.com"}

--- a/internal/provider/monitor_resource_drift_test.go
+++ b/internal/provider/monitor_resource_drift_test.go
@@ -174,3 +174,40 @@ func testAccExternallyChangeMonitorKeyword(server *mockHyperpingServer, newKeywo
 		return nil
 	}
 }
+
+// testAccExternallyRemoveEscalationPolicy simulates an external removal of escalation_policy
+func testAccExternallyRemoveEscalationPolicy(server *mockHyperpingServer) tfresource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for id, monitor := range server.monitors {
+			monitor["escalation_policy"] = nil
+			server.monitors[id] = monitor
+		}
+		return nil
+	}
+}
+
+// TestAccMonitorResource_driftDetection_escalationPolicy tests that removing
+// escalation_policy externally is detected as drift.
+// Also validates that reading the object-shape response does not crash (the core bug fix).
+func TestAccMonitorResource_driftDetection_escalationPolicy(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Create with escalation_policy. The mock returns it as the object shape
+			// {"uuid":"policy_abc123","name":"Mock Policy"} — the crash scenario.
+			{
+				Config: testAccMonitorResourceConfigWithEscalationPolicy(server.URL, "policy_abc123"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "escalation_policy", "policy_abc123"),
+					tfresource.TestCheckResourceAttrSet("hyperping_monitor.test", "id"),
+					// Externally remove the escalation policy
+					testAccExternallyRemoveEscalationPolicy(server),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/internal/provider/monitor_resource_edge_cases_test.go
+++ b/internal/provider/monitor_resource_edge_cases_test.go
@@ -359,9 +359,53 @@ func TestAccMonitorResource_escalationPolicy(t *testing.T) {
 					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "escalation_policy", "policy_def456"),
 				),
 			},
+			// Crash reproduction: API returns object shape {"uuid":"...","name":"..."}, must not panic
+			{
+				RefreshState: true,
+				Check: tfresource.ComposeTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "escalation_policy", "policy_def456"),
+				),
+			},
 			// Clear escalation_policy
 			{
 				Config: testAccMonitorResourceConfigBasic(server.URL, "escalation-test"),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_escalationPolicyStateRefresh verifies the crash fix for escalation_policy.
+// The real API returns escalation_policy as {"uuid":"...","name":"..."} on GET, not a plain string.
+// Before the fix, this caused a panic. This test reproduces the crash condition by triggering
+// a state refresh after create, where the mock server returns the object shape.
+func TestAccMonitorResource_escalationPolicyStateRefresh(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Step 1: Create monitor with escalation_policy set (POST sends string UUID)
+			{
+				Config: testAccMonitorResourceConfigWithEscalationPolicy(server.URL, "policy_abc123"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "escalation_policy", "policy_abc123"),
+					tfresource.TestCheckResourceAttrSet("hyperping_monitor.test", "id"),
+				),
+			},
+			// Step 2: Crash reproduction — RefreshState forces a GET which returns the object shape.
+			// UnmarshalJSON must decode {"uuid":"policy_abc123","name":"Mock Policy"} without panic.
+			{
+				RefreshState: true,
+				Check: tfresource.ComposeTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "escalation_policy", "policy_abc123"),
+				),
+			},
+			// Step 3: ImportState verify — confirms zero-drift after object-shape round-trip.
+			{
+				ResourceName:      "hyperping_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/monitor_resource_test_helpers.go
+++ b/internal/provider/monitor_resource_test_helpers.go
@@ -433,8 +433,13 @@ func (m *mockHyperpingServer) createMonitor(w http.ResponseWriter, r *http.Reque
 		monitor["alerts_wait"] = int(alertsWait)
 	}
 
-	if escalationPolicy, ok := req["escalation_policy"].(string); ok {
-		monitor["escalation_policy"] = escalationPolicy
+	if ep, ok := req["escalation_policy"].(string); ok && ep != "" {
+		monitor["escalation_policy"] = map[string]interface{}{
+			"uuid": ep,
+			"name": "Mock Policy",
+		}
+	} else {
+		monitor["escalation_policy"] = nil
 	}
 
 	if requiredKeyword, ok := req["required_keyword"].(string); ok {
@@ -521,8 +526,8 @@ func applyHeadersField(monitor map[string]interface{}, key string, value interfa
 var monitorStringFields = map[string]bool{
 	"name": true, "url": true, "protocol": true, "http_method": true,
 	"request_body": true, "expected_status_code": true,
-	"escalation_policy": true, "required_keyword": true,
-	"status": true, "projectUuid": true,
+	"required_keyword": true,
+	"status":           true, "projectUuid": true,
 }
 
 // intFields are monitor fields that map from JSON numbers.
@@ -548,6 +553,16 @@ func applyMonitorField(monitor map[string]interface{}, key string, value interfa
 		applyRegionsField(monitor, key, value)
 	case key == "request_headers":
 		applyHeadersField(monitor, key, value)
+	case key == "escalation_policy":
+		// Store as object to match real API GET response shape.
+		if ep, ok := value.(string); ok && ep != "" {
+			monitor[key] = map[string]interface{}{
+				"uuid": ep,
+				"name": "Mock Policy",
+			}
+		} else {
+			monitor[key] = nil
+		}
 	}
 }
 

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -629,29 +629,35 @@ func (r *StatusPageResource) preserveServiceBooleans(planSections, apiSections t
 	return newList
 }
 
-// preserveSectionServiceBooleans preserves boolean values in a single section's services.
+// preserveSectionServiceBooleans preserves boolean values in a single section.
+// It handles two independent API limitations:
+//  1. is_split: accepted on write but never returned on read (always false).
+//  2. show_response_times / show_uptime on services: accepted but not persisted by the API.
 func (r *StatusPageResource) preserveSectionServiceBooleans(planSection, apiSection types.Object, diags *diag.Diagnostics) types.Object {
 	planAttrs := planSection.Attributes()
 	apiAttrs := apiSection.Attributes()
 
-	planServices, planOk := planAttrs["services"].(types.List)
-	apiServices, apiOk := apiAttrs["services"].(types.List)
-
-	if !planOk || !apiOk || planServices.IsNull() || apiServices.IsNull() {
-		return apiSection
-	}
-
-	// Preserve booleans in each service
-	newServices := r.preserveServicesListBooleans(planServices, apiServices, diags)
-
-	// Build new section with preserved services
+	// Start from API attrs, then selectively override with plan values.
 	newAttrs := make(map[string]attr.Value, len(apiAttrs))
 	for k, v := range apiAttrs {
-		if k == "services" {
-			newAttrs[k] = newServices
-		} else {
-			newAttrs[k] = v
+		newAttrs[k] = v
+	}
+
+	// Preserve is_split: API accepts it on write but never returns it (always false on read).
+	// This must run even for sections with no services.
+	if planIsSplit, ok := planAttrs["is_split"].(types.Bool); ok && !planIsSplit.IsNull() {
+		if apiIsSplit, ok := apiAttrs["is_split"].(types.Bool); ok && !apiIsSplit.IsNull() {
+			if planIsSplit.ValueBool() && !apiIsSplit.ValueBool() {
+				newAttrs["is_split"] = planIsSplit
+			}
 		}
+	}
+
+	// Preserve service-level booleans when services are present in both plan and API response.
+	planServices, planOk := planAttrs["services"].(types.List)
+	apiServices, apiOk := apiAttrs["services"].(types.List)
+	if planOk && apiOk && !planServices.IsNull() && !apiServices.IsNull() {
+		newAttrs["services"] = r.preserveServicesListBooleans(planServices, apiServices, diags)
 	}
 
 	newSection, newDiags := types.ObjectValue(SectionAttrTypes(), newAttrs)

--- a/internal/provider/statuspage_resource_helpers_test.go
+++ b/internal/provider/statuspage_resource_helpers_test.go
@@ -360,7 +360,9 @@ func buildMockSections(sectionsReq []interface{}) []map[string]interface{} {
 		}
 
 		section := map[string]interface{}{
-			"is_split": false,
+			// is_split is intentionally omitted from the response to match real API behaviour:
+			// the Hyperping v2 API accepts is_split on write but never returns it on read.
+			// The provider's preserveSectionServiceBooleans workaround handles this.
 			"services": nil,
 		}
 
@@ -375,9 +377,6 @@ func buildMockSections(sectionsReq []interface{}) []map[string]interface{} {
 				}
 			}
 			section["name"] = nameStrMap
-		}
-		if isSplit, ok := secMap["is_split"].(bool); ok {
-			section["is_split"] = isSplit
 		}
 
 		if servicesReq, ok := secMap["services"].([]interface{}); ok {


### PR DESCRIPTION
## Summary

- **Bug**: `terraform plan`/`terraform refresh` crashes with `cannot unmarshal object into Go struct field Monitor.escalation_policy of type string` for any monitor with an escalation policy set. The Hyperping API returns `escalation_policy` as `{"uuid":"...","name":"..."}` on GET but the client typed it as `*string`.
- **Fix**: Custom `UnmarshalJSON` on `Monitor` transparently handles both the object shape (API read) and plain string (write path), normalising both to `*string` UUID. Write side (POST/PUT) is unchanged.
- **Also fixed**: `is_split` perpetual drift on status page sections — `preserveSectionServiceBooleans` now restores the plan value independently of whether services are present.

## Changes

- `internal/client/models_monitor.go` — custom `UnmarshalJSON` for `Monitor.escalation_policy` polymorphic field
- `internal/client/models_test.go` — 6-case unit test covering object, plain string, null, absent, empty UUID, empty string shapes
- `internal/provider/monitor_resource_edge_cases_test.go` — `RefreshState` step added to existing test; new `TestAccMonitorResource_escalationPolicyStateRefresh` crash-repro test
- `internal/provider/monitor_resource_drift_test.go` — `TestAccMonitorResource_driftDetection_escalationPolicy` verifies external policy removal is detected
- `internal/provider/monitor_resource_test_helpers.go` — mock returns object shape on GET to match real API behaviour
- `internal/provider/statuspage_resource.go` — `is_split` preservation runs before early return
- `internal/provider/statuspage_resource_helpers_test.go` — mock no longer echoes `is_split` (matches real API)

## Test Plan

- [ ] `go build ./...` — clean
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `TF_ACC=1 go test -race ./internal/...` — all green (verified locally)
- [ ] `TestMonitor_UnmarshalJSON_escalationPolicy` — 6 sub-cases all pass
- [ ] `TestAccMonitorResource_escalationPolicyStateRefresh` — crash repro passes without panic
- [ ] `TestAccMonitorResource_driftDetection_escalationPolicy` — drift detected after external removal