### PR TITLE
fix: resolve 5 Hyperping status page API bugs (v1.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+## [1.3.9] - 2026-03-01
+
+### Fixed
+
+- **Status page renderer**: Services now use numeric v1 monitor IDs instead of UUID strings,
+  fixing the critical bug where the renderer showed "up" status for all monitors regardless
+  of actual state. The provider transparently translates UUIDs to numeric IDs on write and
+  back on read — no HCL changes needed.
+- **Status page boolean preservation**: `show_response_times`, `show_uptime`, and `is_split`
+  now use UUID-based matching instead of fragile index-based matching. Fixes perpetual drift
+  when API reorders services, and adds support for nested services inside groups.
+- **Status page isProtected drift**: Every status page PUT now includes authentication settings
+  (similar to the `dns_record_type: "A"` workaround for monitors). This triggers ISR cache
+  revalidation on the Hyperping renderer, fixing the admin UI regression where editing any
+  setting via the Hyperping dashboard resets an internal `isProtected` flag to `true`. The
+  provider also emits a warning diagnostic when `password_protected` and
+  `authentication.password_protection` disagree. **Known limitation**: if no Terraform fields
+  changed, no PUT is sent, so the flag stays stale until the next apply that touches the page.
+- **Description localization**: `extractLocalizedString` now skips empty string values when
+  searching for a non-empty localized value, preventing drift when the API returns
+  `{"en":"","fr":"texte"}`.
+
 ## [1.3.8] - 2026-02-27
 
 ### Fixed

--- a/internal/client/contract_test.go
+++ b/internal/client/contract_test.go
@@ -574,10 +574,6 @@ func strPtr(s string) *string {
 	return &s
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func intPtr(i int) *int {
 	return &i
 }

--- a/internal/client/models_common.go
+++ b/internal/client/models_common.go
@@ -54,6 +54,11 @@ func (fs FlexibleString) String() string {
 	return string(fs)
 }
 
+// boolPtr returns a pointer to the given bool value.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 // Input length limits to prevent resource exhaustion (VULN-007).
 const (
 	maxNameLength    = 255

--- a/internal/client/models_monitor.go
+++ b/internal/client/models_monitor.go
@@ -27,6 +27,7 @@ type escalationPolicyShape struct {
 // {"uuid":"...","name":"..."}, while POST/PUT send a plain UUID string.
 // UnmarshalJSON handles both shapes and normalises to a UUID string.
 type Monitor struct {
+	ID                 int             `json:"id"` // v1 numeric ID (used by status page renderer)
 	UUID               string          `json:"uuid"`
 	Name               string          `json:"name"`
 	URL                string          `json:"url"`

--- a/internal/client/models_statuspage.go
+++ b/internal/client/models_statuspage.go
@@ -67,12 +67,14 @@ type StatusPageSection struct {
 }
 
 // StatusPageService represents a service (monitor or component) in a section.
-// The ID field uses interface{} because the Hyperping API returns:
-//   - a string UUID (e.g. "mon_abc123") for flat services in sections
-//   - an integer (e.g. 117122) for nested child services inside groups
+// The ID field uses interface{} because the Hyperping v2 API returns different
+// types depending on how the service was created:
+//   - a string UUID (e.g. "mon_abc123") when set via v2 API with UUID strings
+//   - an integer (e.g. 117122) when set via v1 admin UI or numeric ID workaround
 //   - absent entirely for group header entries (which have no top-level monitor)
 //
-// UUID is empty for group header entries; only their nested children carry UUIDs.
+// The provider writes numeric IDs (translated from UUIDs) for renderer compatibility,
+// so read responses typically contain integers. UUID is empty for group headers.
 type StatusPageService struct {
 	ID                interface{}         `json:"id,omitempty"`
 	UUID              string              `json:"uuid,omitempty"`

--- a/internal/client/monitors_test.go
+++ b/internal/client/monitors_test.go
@@ -1344,3 +1344,41 @@ func TestUpdateMonitor_DNSRecordType_PreservesExplicitValue(t *testing.T) {
 		t.Errorf("expected dns_record_type \"CNAME\" (explicitly set), got %v", decoded["dns_record_type"])
 	}
 }
+
+// TestMonitor_NumericID_Deserialization verifies that the v1 numeric "id" field
+// is properly captured alongside the UUID during JSON deserialization.
+// The status page renderer uses numeric IDs to resolve monitor status.
+func TestMonitor_NumericID_Deserialization(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{"id": 115746, "uuid": "mon_abc123", "name": "API Monitor", "url": "https://api.example.com", "protocol": "http", "check_frequency": 60},
+			{"id": 115747, "uuid": "mon_def456", "name": "Web Monitor", "url": "https://web.example.com", "protocol": "http", "check_frequency": 60}
+		]`))
+	}))
+	defer server.Close()
+
+	c := NewClient("test_key", WithBaseURL(server.URL), WithMaxRetries(0))
+	monitors, err := c.ListMonitors(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(monitors) != 2 {
+		t.Fatalf("expected 2 monitors, got %d", len(monitors))
+	}
+
+	if monitors[0].ID != 115746 {
+		t.Errorf("expected ID 115746, got %d", monitors[0].ID)
+	}
+	if monitors[0].UUID != "mon_abc123" {
+		t.Errorf("expected UUID 'mon_abc123', got %q", monitors[0].UUID)
+	}
+
+	if monitors[1].ID != 115747 {
+		t.Errorf("expected ID 115747, got %d", monitors[1].ID)
+	}
+	if monitors[1].UUID != "mon_def456" {
+		t.Errorf("expected UUID 'mon_def456', got %q", monitors[1].UUID)
+	}
+}

--- a/internal/client/statuspages.go
+++ b/internal/client/statuspages.go
@@ -79,11 +79,29 @@ func (c *Client) CreateStatusPage(ctx context.Context, req CreateStatusPageReque
 	return &response.StatusPage, nil
 }
 
+// authenticationWorkaround is a default authentication settings value sent in
+// every PUT to work around a Hyperping API bug. The admin UI uses an internal
+// v1 API that resets an internal isProtected flag to true on any change,
+// causing a "Sign In" wall even when password_protection is false. Including
+// authentication settings in every PUT triggers ISR revalidation, which
+// recomputes isProtected from the v2 auth settings.
+var authenticationWorkaround = &CreateStatusPageAuthenticationSettings{
+	PasswordProtection: boolPtr(false),
+	GoogleSSO:          boolPtr(false),
+	SAMLSSO:            boolPtr(false),
+}
+
 // UpdateStatusPage updates an existing status page.
 // Only provided fields will be updated.
 func (c *Client) UpdateStatusPage(ctx context.Context, uuid string, req UpdateStatusPageRequest) (*StatusPage, error) {
 	if err := ValidateResourceID(uuid); err != nil {
 		return nil, fmt.Errorf("UpdateStatusPage: %w", err)
+	}
+
+	// Always include authentication settings to work around the Hyperping
+	// isProtected regression. See authenticationWorkaround doc for details.
+	if req.Authentication == nil {
+		req.Authentication = authenticationWorkaround
 	}
 
 	// API returns: {"message": "Status page updated", "statuspage": {...}}

--- a/internal/provider/statuspage_id_translation.go
+++ b/internal/provider/statuspage_id_translation.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+
+	"github.com/develeap/terraform-provider-hyperping/internal/client"
+)
+
+// buildMonitorIDMaps fetches all monitors and builds bidirectional lookup maps
+// between UUID strings (e.g. "mon_abc123") and v1 numeric IDs (e.g. 115746).
+// On error, adds a warning diagnostic and returns empty maps (graceful fallback).
+func buildMonitorIDMaps(ctx context.Context, apiClient client.HyperpingAPI, diags *diag.Diagnostics) (uuidToID map[string]int, idToUUID map[string]string) {
+	uuidToID = make(map[string]int)
+	idToUUID = make(map[string]string)
+
+	monitors, err := apiClient.ListMonitors(ctx)
+	if err != nil {
+		diags.AddWarning(
+			"Unable to fetch monitor list for ID translation",
+			fmt.Sprintf("Status page services will use UUIDs as-is (renderer may not resolve status): %s", err),
+		)
+		return uuidToID, idToUUID
+	}
+
+	for _, mon := range monitors {
+		if mon.UUID != "" && mon.ID != 0 {
+			uuidToID[mon.UUID] = mon.ID
+			idToUUID[strconv.Itoa(mon.ID)] = mon.UUID
+		}
+	}
+
+	return uuidToID, idToUUID
+}
+
+// translateSectionsToNumericIDs walks sections and replaces UUID strings with
+// numeric ID strings for renderer compatibility. Creates new slices (immutable).
+// Unknown UUIDs are left as-is (graceful fallback).
+func translateSectionsToNumericIDs(sections []client.CreateStatusPageSection, uuidToID map[string]int) []client.CreateStatusPageSection {
+	if len(uuidToID) == 0 {
+		return sections
+	}
+
+	translated := make([]client.CreateStatusPageSection, len(sections))
+	for i, section := range sections {
+		translated[i] = client.CreateStatusPageSection{
+			Name:     section.Name,
+			IsSplit:  section.IsSplit,
+			Services: translateServicesToNumericIDs(section.Services, uuidToID),
+		}
+	}
+
+	return translated
+}
+
+// translateServicesToNumericIDs translates service UUIDs to numeric IDs.
+func translateServicesToNumericIDs(services []client.CreateStatusPageService, uuidToID map[string]int) []client.CreateStatusPageService {
+	if len(services) == 0 {
+		return services
+	}
+
+	translated := make([]client.CreateStatusPageService, len(services))
+	for i, svc := range services {
+		translated[i] = translateServiceToNumericID(svc, uuidToID)
+	}
+
+	return translated
+}
+
+// translateServiceToNumericID translates a single service's UUID to numeric ID.
+func translateServiceToNumericID(svc client.CreateStatusPageService, uuidToID map[string]int) client.CreateStatusPageService {
+	result := client.CreateStatusPageService{
+		NameShown:         svc.NameShown,
+		Name:              svc.Name,
+		ShowUptime:        svc.ShowUptime,
+		ShowResponseTimes: svc.ShowResponseTimes,
+		IsGroup:           svc.IsGroup,
+	}
+
+	// Top-level services use MonitorUUID
+	if svc.MonitorUUID != nil {
+		if numID, ok := uuidToID[*svc.MonitorUUID]; ok {
+			idStr := strconv.Itoa(numID)
+			result.MonitorUUID = &idStr
+		} else {
+			result.MonitorUUID = svc.MonitorUUID
+		}
+	}
+
+	// Nested services use UUID
+	if svc.UUID != nil {
+		if numID, ok := uuidToID[*svc.UUID]; ok {
+			idStr := strconv.Itoa(numID)
+			result.UUID = &idStr
+		} else {
+			result.UUID = svc.UUID
+		}
+	}
+
+	// Recurse into nested services for groups
+	if len(svc.Services) > 0 {
+		result.Services = translateServicesToNumericIDs(svc.Services, uuidToID)
+	}
+
+	return result
+}
+
+// translateStatusPageToUUIDs walks the StatusPage response and replaces numeric
+// ID strings with UUIDs in-place. This ensures Terraform always stores UUIDs
+// regardless of what the API returned.
+func translateStatusPageToUUIDs(sp *client.StatusPage, idToUUID map[string]string) {
+	if sp == nil || len(idToUUID) == 0 {
+		return
+	}
+
+	for i := range sp.Sections {
+		translateSectionServicesToUUIDs(sp.Sections[i].Services, idToUUID)
+	}
+}
+
+// translateSectionServicesToUUIDs translates services within a section from numeric IDs to UUIDs.
+func translateSectionServicesToUUIDs(services []client.StatusPageService, idToUUID map[string]string) {
+	for i := range services {
+		svc := &services[i]
+
+		// Check if UUID field is a numeric string that needs translation
+		if svc.UUID != "" {
+			if uuid, ok := idToUUID[svc.UUID]; ok {
+				svc.UUID = uuid
+			}
+		}
+
+		// Check if ID field is a numeric value that needs translation
+		idStr := serviceIDToNumericString(svc.ID)
+		if idStr != "" {
+			if uuid, ok := idToUUID[idStr]; ok {
+				svc.UUID = uuid
+			}
+		}
+
+		// Recurse into nested services
+		if len(svc.Services) > 0 {
+			translateSectionServicesToUUIDs(svc.Services, idToUUID)
+		}
+	}
+}
+
+// serviceIDToNumericString extracts a numeric string from the flexible ID field.
+func serviceIDToNumericString(id interface{}) string {
+	switch v := id.(type) {
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	case string:
+		if _, err := strconv.Atoi(v); err == nil {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/provider/statuspage_id_translation_test.go
+++ b/internal/provider/statuspage_id_translation_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/internal/client"
+)
+
+func TestTranslateSectionsToNumericIDs_TopLevelService(t *testing.T) {
+	uuid := "mon_abc123"
+	uuidToID := map[string]int{"mon_abc123": 115746}
+
+	sections := []client.CreateStatusPageSection{
+		{
+			Name: "API",
+			Services: []client.CreateStatusPageService{
+				{MonitorUUID: &uuid},
+			},
+		},
+	}
+
+	result := translateSectionsToNumericIDs(sections, uuidToID)
+
+	if result[0].Services[0].MonitorUUID == nil {
+		t.Fatal("expected MonitorUUID to be set")
+	}
+	if *result[0].Services[0].MonitorUUID != "115746" {
+		t.Errorf("expected '115746', got %q", *result[0].Services[0].MonitorUUID)
+	}
+
+	// Verify original was not mutated
+	if *sections[0].Services[0].MonitorUUID != "mon_abc123" {
+		t.Error("original section was mutated")
+	}
+}
+
+func TestTranslateSectionsToNumericIDs_NestedService(t *testing.T) {
+	uuid := "mon_def456"
+	isGroup := true
+	uuidToID := map[string]int{"mon_def456": 115747}
+
+	sections := []client.CreateStatusPageSection{
+		{
+			Name: "Group",
+			Services: []client.CreateStatusPageService{
+				{
+					IsGroup: &isGroup,
+					Services: []client.CreateStatusPageService{
+						{UUID: &uuid},
+					},
+				},
+			},
+		},
+	}
+
+	result := translateSectionsToNumericIDs(sections, uuidToID)
+
+	nested := result[0].Services[0].Services[0]
+	if nested.UUID == nil {
+		t.Fatal("expected UUID to be set on nested service")
+	}
+	if *nested.UUID != "115747" {
+		t.Errorf("expected '115747', got %q", *nested.UUID)
+	}
+}
+
+func TestTranslateSectionsToNumericIDs_UnknownUUID(t *testing.T) {
+	unknownUUID := "mon_unknown"
+	uuidToID := map[string]int{"mon_abc123": 115746}
+
+	sections := []client.CreateStatusPageSection{
+		{
+			Name: "API",
+			Services: []client.CreateStatusPageService{
+				{MonitorUUID: &unknownUUID},
+			},
+		},
+	}
+
+	result := translateSectionsToNumericIDs(sections, uuidToID)
+
+	if *result[0].Services[0].MonitorUUID != "mon_unknown" {
+		t.Errorf("expected unknown UUID to pass through, got %q", *result[0].Services[0].MonitorUUID)
+	}
+}
+
+func TestTranslateSectionsToNumericIDs_EmptyMap(t *testing.T) {
+	uuid := "mon_abc123"
+	sections := []client.CreateStatusPageSection{
+		{
+			Name: "API",
+			Services: []client.CreateStatusPageService{
+				{MonitorUUID: &uuid},
+			},
+		},
+	}
+
+	result := translateSectionsToNumericIDs(sections, map[string]int{})
+
+	// Should return original sections unchanged
+	if *result[0].Services[0].MonitorUUID != "mon_abc123" {
+		t.Errorf("expected UUID unchanged, got %q", *result[0].Services[0].MonitorUUID)
+	}
+}
+
+func TestTranslateStatusPageToUUIDs_NumericString(t *testing.T) {
+	idToUUID := map[string]string{"115746": "mon_abc123"}
+
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "115746", ID: float64(115746)},
+				},
+			},
+		},
+	}
+
+	translateStatusPageToUUIDs(sp, idToUUID)
+
+	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
+		t.Errorf("expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
+	}
+}
+
+func TestTranslateStatusPageToUUIDs_Float64ID(t *testing.T) {
+	idToUUID := map[string]string{"115746": "mon_abc123"}
+
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "", ID: float64(115746)},
+				},
+			},
+		},
+	}
+
+	translateStatusPageToUUIDs(sp, idToUUID)
+
+	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
+		t.Errorf("expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
+	}
+}
+
+func TestTranslateStatusPageToUUIDs_NestedServices(t *testing.T) {
+	idToUUID := map[string]string{"115747": "mon_def456"}
+
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{
+						IsGroup: true,
+						Services: []client.StatusPageService{
+							{UUID: "115747", ID: float64(115747)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	translateStatusPageToUUIDs(sp, idToUUID)
+
+	nested := sp.Sections[0].Services[0].Services[0]
+	if nested.UUID != "mon_def456" {
+		t.Errorf("expected 'mon_def456', got %q", nested.UUID)
+	}
+}
+
+func TestTranslateStatusPageToUUIDs_EmptyMap(t *testing.T) {
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "115746", ID: float64(115746)},
+				},
+			},
+		},
+	}
+
+	translateStatusPageToUUIDs(sp, map[string]string{})
+
+	// Should remain unchanged
+	if sp.Sections[0].Services[0].UUID != "115746" {
+		t.Errorf("expected '115746' unchanged, got %q", sp.Sections[0].Services[0].UUID)
+	}
+}
+
+func TestTranslateRoundTrip(t *testing.T) {
+	uuid := "mon_abc123"
+	uuidToID := map[string]int{"mon_abc123": 115746}
+	idToUUID := map[string]string{"115746": "mon_abc123"}
+
+	// Forward: UUID -> numeric ID
+	sections := []client.CreateStatusPageSection{
+		{
+			Name: "API",
+			Services: []client.CreateStatusPageService{
+				{MonitorUUID: &uuid},
+			},
+		},
+	}
+
+	translated := translateSectionsToNumericIDs(sections, uuidToID)
+	numericID := *translated[0].Services[0].MonitorUUID
+
+	if numericID != "115746" {
+		t.Fatalf("forward translation failed: expected '115746', got %q", numericID)
+	}
+
+	// Reverse: numeric ID -> UUID
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: numericID, ID: numericID},
+				},
+			},
+		},
+	}
+
+	translateStatusPageToUUIDs(sp, idToUUID)
+
+	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
+		t.Errorf("round-trip failed: expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
+	}
+}
+
+func TestServiceIDToNumericString(t *testing.T) {
+	tests := []struct {
+		name string
+		id   interface{}
+		want string
+	}{
+		{"float64", float64(115746), "115746"},
+		{"numeric string", "115746", "115746"},
+		{"uuid string", "mon_abc123", ""},
+		{"nil", nil, ""},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := serviceIDToNumericString(tt.id)
+			if got != tt.want {
+				t.Errorf("serviceIDToNumericString(%v) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/statuspage_mapping.go
+++ b/internal/provider/statuspage_mapping.go
@@ -600,20 +600,32 @@ func mapTFToNestedServices(list types.List, diags *diag.Diagnostics) []client.Cr
 // The API returns description as a map (e.g. {"en":"text","fr":"texte"}) but only
 // accepts a plain string on write. We extract the "en" value by default; if absent,
 // we fall back to the first value of configuredLangs, then to the first non-empty value.
+// Empty strings are treated as "no value" — the function skips them and falls through
+// to the next candidate, preventing drift when the API returns {"en":"","fr":"texte"}.
 func extractLocalizedString(m map[string]string, configuredLangs []string) types.String {
 	if len(m) == 0 {
 		return types.StringNull()
 	}
-	if v, ok := m["en"]; ok {
+	// Prefer "en" if present and non-empty
+	if v, ok := m["en"]; ok && v != "" {
 		return types.StringValue(v)
 	}
+	// Fall back to configured languages
 	for _, lang := range configuredLangs {
-		if v, ok := m[lang]; ok {
+		if v, ok := m[lang]; ok && v != "" {
 			return types.StringValue(v)
 		}
 	}
+	// Fall back to first non-empty value from any language
 	for _, v := range m {
-		return types.StringValue(v)
+		if v != "" {
+			return types.StringValue(v)
+		}
+	}
+	// All values are empty — return empty string to match the API's "en" key
+	// if it exists (prevents null vs "" mismatch), otherwise null.
+	if _, hasEn := m["en"]; hasEn {
+		return types.StringValue("")
 	}
 	return types.StringNull()
 }

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -389,6 +389,12 @@ func (r *StatusPageResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Translate UUIDs to numeric IDs for status page renderer compatibility
+	if len(createReq.Sections) > 0 {
+		uuidToID, _ := buildMonitorIDMaps(ctx, r.client, &resp.Diagnostics)
+		createReq.Sections = translateSectionsToNumericIDs(createReq.Sections, uuidToID)
+	}
+
 	// Create status page via API
 	statusPage, err := r.client.CreateStatusPage(ctx, *createReq)
 	if err != nil {
@@ -397,7 +403,7 @@ func (r *StatusPageResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Map response to state
-	r.mapStatusPageToModel(statusPage, &plan, &resp.Diagnostics)
+	r.mapStatusPageToModel(ctx, statusPage, &plan, &resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -428,7 +434,7 @@ func (r *StatusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Map response to state
-	r.mapStatusPageToModel(statusPage, &state, &resp.Diagnostics)
+	r.mapStatusPageToModel(ctx, statusPage, &state, &resp.Diagnostics)
 
 	// Restore password: API never returns this field, so preserve prior state value
 	// to prevent perpetual drift on every plan/apply cycle.
@@ -457,6 +463,12 @@ func (r *StatusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Translate UUIDs to numeric IDs for status page renderer compatibility
+	if len(updateReq.Sections) > 0 {
+		uuidToID, _ := buildMonitorIDMaps(ctx, r.client, &resp.Diagnostics)
+		updateReq.Sections = translateSectionsToNumericIDs(updateReq.Sections, uuidToID)
+	}
+
 	// Update status page via API
 	statusPage, err := r.client.UpdateStatusPage(ctx, state.ID.ValueString(), *updateReq)
 	if err != nil {
@@ -465,7 +477,7 @@ func (r *StatusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Map response to state
-	r.mapStatusPageToModel(statusPage, &plan, &resp.Diagnostics)
+	r.mapStatusPageToModel(ctx, statusPage, &plan, &resp.Diagnostics)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -507,7 +519,25 @@ func (r *StatusPageResource) ImportState(ctx context.Context, req resource.Impor
 // mapStatusPageToModel maps API response to Terraform model.
 // It extracts configured languages from the model's settings to filter API response localized fields,
 // preventing drift from API auto-population of all supported languages.
-func (r *StatusPageResource) mapStatusPageToModel(sp *client.StatusPage, model *StatusPageResourceModel, diags *diag.Diagnostics) {
+func (r *StatusPageResource) mapStatusPageToModel(ctx context.Context, sp *client.StatusPage, model *StatusPageResourceModel, diags *diag.Diagnostics) {
+	// Reverse-translate numeric IDs to UUIDs for TF state consistency
+	_, idToUUID := buildMonitorIDMaps(ctx, r.client, diags)
+	translateStatusPageToUUIDs(sp, idToUUID)
+
+	// Detect isProtected drift: the Hyperping admin UI can reset an internal
+	// isProtected flag to true via v1 writes, causing a "Sign In" wall even when
+	// password_protection is false. The top-level PasswordProtected field reflects
+	// the actual isProtected state; if it disagrees with the auth settings, warn.
+	if sp.PasswordProtected && !sp.Settings.Authentication.PasswordProtection {
+		diags.AddWarning(
+			"Status page isProtected drift detected",
+			fmt.Sprintf("Status page %q has password_protected=true at the API level but "+
+				"authentication.password_protection=false in settings. This typically happens "+
+				"when someone edits the page in the Hyperping admin UI, which resets an internal "+
+				"isProtected flag. Run 'terraform apply' to send a PUT that fixes this.", sp.UUID),
+		)
+	}
+
 	// Extract configured languages from the model's settings
 	// This is used to filter localized fields in the API response
 	configuredLangs := r.extractConfiguredLanguages(model.Settings, diags)
@@ -522,8 +552,8 @@ func (r *StatusPageResource) mapStatusPageToModel(sp *client.StatusPage, model *
 		}
 	}
 
-	// 2. sections - needed to preserve show_response_times boolean values
-	planSections := model.Sections
+	// 2. Extract write-only booleans BEFORE API overwrites them
+	serviceMap, sectionIsSplit := extractWriteOnlyBooleans(model.Sections)
 
 	// Map with language filtering to prevent drift
 	commonFields := MapStatusPageCommonFieldsWithFilter(sp, configuredLangs, diags)
@@ -542,10 +572,9 @@ func (r *StatusPageResource) mapStatusPageToModel(sp *client.StatusPage, model *
 	// Map sections from API
 	model.Sections = commonFields.Sections
 
-	// Preserve show_response_times and show_uptime boolean values from plan
-	// API may return false even when true was set (API bug or default value issue)
-	if !planSections.IsNull() && !planSections.IsUnknown() {
-		model.Sections = r.preserveServiceBooleans(planSections, model.Sections, diags)
+	// Apply write-only boolean values using UUID-based matching
+	if len(serviceMap) > 0 || len(sectionIsSplit) > 0 {
+		model.Sections = r.applyWriteOnlyBooleans(model.Sections, serviceMap, sectionIsSplit, diags)
 	}
 }
 
@@ -589,139 +618,6 @@ func (r *StatusPageResource) replaceSettingsName(settings types.Object, name typ
 	diags.Append(newDiags...)
 
 	return newSettings
-}
-
-// preserveServiceBooleans preserves boolean field values from plan when API returns false.
-// This handles API bugs where show_response_times and show_uptime may not persist correctly.
-func (r *StatusPageResource) preserveServiceBooleans(planSections, apiSections types.List, diags *diag.Diagnostics) types.List {
-	if planSections.IsNull() || planSections.IsUnknown() || apiSections.IsNull() || apiSections.IsUnknown() {
-		return apiSections
-	}
-
-	planElements := planSections.Elements()
-	apiElements := apiSections.Elements()
-
-	// If lengths don't match, something is very wrong - just return API sections
-	if len(planElements) != len(apiElements) {
-		return apiSections
-	}
-
-	// Build new sections list with preserved boolean values
-	newSections := make([]attr.Value, len(apiElements))
-
-	for i := range apiElements {
-		planSection, planOk := planElements[i].(types.Object)
-		apiSection, apiOk := apiElements[i].(types.Object)
-
-		if !planOk || !apiOk {
-			newSections[i] = apiElements[i]
-			continue
-		}
-
-		// Preserve booleans in services list
-		newSection := r.preserveSectionServiceBooleans(planSection, apiSection, diags)
-		newSections[i] = newSection
-	}
-
-	newList, newDiags := types.ListValue(apiSections.ElementType(context.Background()), newSections)
-	diags.Append(newDiags...)
-
-	return newList
-}
-
-// preserveSectionServiceBooleans preserves boolean values in a single section.
-// It handles two independent API limitations:
-//  1. is_split: accepted on write but never returned on read (always false).
-//  2. show_response_times / show_uptime on services: accepted but not persisted by the API.
-func (r *StatusPageResource) preserveSectionServiceBooleans(planSection, apiSection types.Object, diags *diag.Diagnostics) types.Object {
-	planAttrs := planSection.Attributes()
-	apiAttrs := apiSection.Attributes()
-
-	// Start from API attrs, then selectively override with plan values.
-	newAttrs := make(map[string]attr.Value, len(apiAttrs))
-	for k, v := range apiAttrs {
-		newAttrs[k] = v
-	}
-
-	// Preserve is_split: API accepts it on write but never returns it (always false on read).
-	// This must run even for sections with no services.
-	if planIsSplit, ok := planAttrs["is_split"].(types.Bool); ok && !planIsSplit.IsNull() {
-		if apiIsSplit, ok := apiAttrs["is_split"].(types.Bool); ok && !apiIsSplit.IsNull() {
-			if planIsSplit.ValueBool() && !apiIsSplit.ValueBool() {
-				newAttrs["is_split"] = planIsSplit
-			}
-		}
-	}
-
-	// Preserve service-level booleans when services are present in both plan and API response.
-	planServices, planOk := planAttrs["services"].(types.List)
-	apiServices, apiOk := apiAttrs["services"].(types.List)
-	if planOk && apiOk && !planServices.IsNull() && !apiServices.IsNull() {
-		newAttrs["services"] = r.preserveServicesListBooleans(planServices, apiServices, diags)
-	}
-
-	newSection, newDiags := types.ObjectValue(SectionAttrTypes(), newAttrs)
-	diags.Append(newDiags...)
-
-	return newSection
-}
-
-// preserveServicesListBooleans preserves boolean values in a services list.
-func (r *StatusPageResource) preserveServicesListBooleans(planServices, apiServices types.List, diags *diag.Diagnostics) types.List {
-	planElements := planServices.Elements()
-	apiElements := apiServices.Elements()
-
-	if len(planElements) != len(apiElements) {
-		return apiServices
-	}
-
-	newServices := make([]attr.Value, len(apiElements))
-
-	for i := range apiElements {
-		planService, planOk := planElements[i].(types.Object)
-		apiService, apiOk := apiElements[i].(types.Object)
-
-		if !planOk || !apiOk {
-			newServices[i] = apiElements[i]
-			continue
-		}
-
-		planAttrs := planService.Attributes()
-		apiAttrs := apiService.Attributes()
-
-		// Check show_response_times: if plan=true and api=false, keep plan value
-		needsPreservation := false
-		newAttrs := make(map[string]attr.Value, len(apiAttrs))
-		for k, v := range apiAttrs {
-			if k == "show_response_times" || k == "show_uptime" {
-				planVal, planHas := planAttrs[k].(types.Bool)
-				apiVal, apiHas := v.(types.Bool)
-
-				if planHas && apiHas && !planVal.IsNull() && !apiVal.IsNull() {
-					// If plan had true but API returned false, preserve plan value
-					if planVal.ValueBool() && !apiVal.ValueBool() {
-						newAttrs[k] = planVal
-						needsPreservation = true
-						continue
-					}
-				}
-			}
-			newAttrs[k] = v
-		}
-
-		if needsPreservation {
-			newService, newDiags := types.ObjectValue(ServiceAttrTypes(), newAttrs)
-			diags.Append(newDiags...)
-			newServices[i] = newService
-		} else {
-			newServices[i] = apiElements[i]
-		}
-	}
-
-	newList, newDiags := types.ListValue(apiServices.ElementType(context.Background()), newServices)
-	diags.Append(newDiags...)
-
-	return newList
 }
 
 // buildCreateRequest builds a CreateStatusPageRequest from the Terraform plan.

--- a/internal/provider/statuspage_resource_helpers_test.go
+++ b/internal/provider/statuspage_resource_helpers_test.go
@@ -216,6 +216,8 @@ func (m *mockStatusPageServer) handleRequest(w http.ResponseWriter, r *http.Requ
 	isSubscriber := isSubscriberPath(r.URL.Path)
 
 	switch {
+	case r.Method == "GET" && r.URL.Path == client.MonitorsBasePath:
+		m.listMonitors(w)
 	case r.Method == "GET" && r.URL.Path == basePath:
 		m.listStatusPages(w, r)
 	case r.Method == "POST" && r.URL.Path == basePath:
@@ -249,6 +251,16 @@ func (m *mockStatusPageServer) handleSubscriberRequest(w http.ResponseWriter, r 
 	}
 }
 
+// listMonitors returns a mock monitor list for UUID-to-numeric-ID translation.
+func (m *mockStatusPageServer) listMonitors(w http.ResponseWriter) {
+	monitors := []map[string]interface{}{
+		{"id": 115746, "uuid": "mon_abc123", "name": "Test Monitor 1", "url": "https://example1.com", "protocol": "http"},
+		{"id": 115747, "uuid": "mon_def456", "name": "Test Monitor 2", "url": "https://example2.com", "protocol": "http"},
+		{"id": 115748, "uuid": "mon_ghi789", "name": "Test Monitor 3", "url": "https://example3.com", "protocol": "http"},
+	}
+	json.NewEncoder(w).Encode(monitors)
+}
+
 func (m *mockStatusPageServer) listStatusPages(w http.ResponseWriter, _ *http.Request) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -271,9 +283,10 @@ func (m *mockStatusPageServer) listStatusPages(w http.ResponseWriter, _ *http.Re
 // the children to exercise the real API behavior where nested child IDs are integers.
 func buildMockService(svcMap map[string]interface{}) map[string]interface{} {
 	isGroup := getOrDefaultBool(svcMap, "is_group", false)
+	monitorID := getOrDefault(svcMap, "monitor_uuid", "mon_default")
 	service := map[string]interface{}{
-		"id":                  "svc_001",
-		"uuid":                getOrDefault(svcMap, "monitor_uuid", "mon_default"),
+		"id":                  monitorID,
+		"uuid":                monitorID,
 		"is_group":            isGroup,
 		"show_uptime":         getOrDefaultBool(svcMap, "show_uptime", true),
 		"show_response_times": getOrDefaultBool(svcMap, "show_response_times", true),

--- a/internal/provider/statuspage_writeonly_booleans.go
+++ b/internal/provider/statuspage_writeonly_booleans.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// writeOnlyBooleans holds the plan values for booleans the API doesn't persist.
+type writeOnlyBooleans struct {
+	showUptime        *bool
+	showResponseTimes *bool
+}
+
+// extractWriteOnlyBooleans walks the plan sections tree and extracts write-only
+// boolean values keyed by service UUID. Also extracts is_split per section index.
+// Returns empty maps for null/unknown plans (e.g. import scenarios).
+func extractWriteOnlyBooleans(planSections types.List) (serviceMap map[string]writeOnlyBooleans, sectionIsSplit map[int]bool) {
+	serviceMap = make(map[string]writeOnlyBooleans)
+	sectionIsSplit = make(map[int]bool)
+
+	if planSections.IsNull() || planSections.IsUnknown() {
+		return serviceMap, sectionIsSplit
+	}
+
+	for secIdx, secElem := range planSections.Elements() {
+		secObj, ok := secElem.(types.Object)
+		if !ok {
+			continue
+		}
+		secAttrs := secObj.Attributes()
+
+		// Extract is_split for this section
+		if isSplit, isSplitOK := secAttrs["is_split"].(types.Bool); isSplitOK && !isSplit.IsNull() && isSplit.ValueBool() {
+			sectionIsSplit[secIdx] = true
+		}
+
+		// Extract service booleans
+		servicesList, svcOK := secAttrs["services"].(types.List)
+		if !svcOK || servicesList.IsNull() || servicesList.IsUnknown() {
+			continue
+		}
+
+		extractServicesWriteOnlyBooleans(servicesList, serviceMap)
+	}
+
+	return serviceMap, sectionIsSplit
+}
+
+// extractServicesWriteOnlyBooleans extracts write-only booleans from a services list.
+func extractServicesWriteOnlyBooleans(servicesList types.List, serviceMap map[string]writeOnlyBooleans) {
+	for _, svcElem := range servicesList.Elements() {
+		svcObj, ok := svcElem.(types.Object)
+		if !ok {
+			continue
+		}
+		svcAttrs := svcObj.Attributes()
+
+		// Get UUID for this service
+		uuid := ""
+		if uuidAttr, ok := svcAttrs["uuid"].(types.String); ok && !uuidAttr.IsNull() {
+			uuid = uuidAttr.ValueString()
+		}
+
+		if uuid != "" {
+			wb := writeOnlyBooleans{}
+			if su, ok := svcAttrs["show_uptime"].(types.Bool); ok && !su.IsNull() {
+				val := su.ValueBool()
+				wb.showUptime = &val
+			}
+			if srt, ok := svcAttrs["show_response_times"].(types.Bool); ok && !srt.IsNull() {
+				val := srt.ValueBool()
+				wb.showResponseTimes = &val
+			}
+			serviceMap[uuid] = wb
+		}
+
+		// Recurse into nested services (groups)
+		if nestedList, ok := svcAttrs["services"].(types.List); ok && !nestedList.IsNull() && !nestedList.IsUnknown() {
+			extractNestedServicesWriteOnlyBooleans(nestedList, serviceMap)
+		}
+	}
+}
+
+// extractNestedServicesWriteOnlyBooleans extracts write-only booleans from nested services.
+func extractNestedServicesWriteOnlyBooleans(nestedList types.List, serviceMap map[string]writeOnlyBooleans) {
+	for _, nestedElem := range nestedList.Elements() {
+		nestedObj, ok := nestedElem.(types.Object)
+		if !ok {
+			continue
+		}
+		nestedAttrs := nestedObj.Attributes()
+
+		uuid := ""
+		if uuidAttr, ok := nestedAttrs["uuid"].(types.String); ok && !uuidAttr.IsNull() {
+			uuid = uuidAttr.ValueString()
+		}
+
+		if uuid != "" {
+			wb := writeOnlyBooleans{}
+			if su, ok := nestedAttrs["show_uptime"].(types.Bool); ok && !su.IsNull() {
+				val := su.ValueBool()
+				wb.showUptime = &val
+			}
+			if srt, ok := nestedAttrs["show_response_times"].(types.Bool); ok && !srt.IsNull() {
+				val := srt.ValueBool()
+				wb.showResponseTimes = &val
+			}
+			serviceMap[uuid] = wb
+		}
+	}
+}
+
+// applyWriteOnlyBooleans walks the API response sections and overrides write-only
+// boolean values using UUID-based matching from the plan. This is resilient to
+// reordering and length mismatches.
+func (r *StatusPageResource) applyWriteOnlyBooleans(apiSections types.List, serviceMap map[string]writeOnlyBooleans, sectionIsSplit map[int]bool, diags *diag.Diagnostics) types.List {
+	if apiSections.IsNull() || apiSections.IsUnknown() {
+		return apiSections
+	}
+
+	apiElements := apiSections.Elements()
+	newSections := make([]attr.Value, len(apiElements))
+
+	for i, secElem := range apiElements {
+		secObj, ok := secElem.(types.Object)
+		if !ok {
+			newSections[i] = secElem
+			continue
+		}
+
+		secAttrs := secObj.Attributes()
+		newAttrs := copyAttrs(secAttrs)
+
+		// Preserve is_split by section index
+		if sectionIsSplit[i] {
+			if apiIsSplit, ok := secAttrs["is_split"].(types.Bool); ok && !apiIsSplit.IsNull() && !apiIsSplit.ValueBool() {
+				newAttrs["is_split"] = types.BoolValue(true)
+			}
+		}
+
+		// Preserve service-level booleans
+		if servicesList, ok := secAttrs["services"].(types.List); ok && !servicesList.IsNull() && !servicesList.IsUnknown() {
+			newAttrs["services"] = applyServicesWriteOnlyBooleans(servicesList, serviceMap, ServiceAttrTypes(), diags)
+		}
+
+		newSection, newDiags := types.ObjectValue(SectionAttrTypes(), newAttrs)
+		diags.Append(newDiags...)
+		newSections[i] = newSection
+	}
+
+	newList, newDiags := types.ListValue(apiSections.ElementType(context.Background()), newSections)
+	diags.Append(newDiags...)
+
+	return newList
+}
+
+// applyServicesWriteOnlyBooleans applies write-only boolean preservation to a services list.
+func applyServicesWriteOnlyBooleans(servicesList types.List, serviceMap map[string]writeOnlyBooleans, attrTypes map[string]attr.Type, diags *diag.Diagnostics) types.List {
+	elements := servicesList.Elements()
+	newServices := make([]attr.Value, len(elements))
+
+	for i, svcElem := range elements {
+		svcObj, ok := svcElem.(types.Object)
+		if !ok {
+			newServices[i] = svcElem
+			continue
+		}
+
+		svcAttrs := svcObj.Attributes()
+		uuid := ""
+		if uuidAttr, ok := svcAttrs["uuid"].(types.String); ok && !uuidAttr.IsNull() {
+			uuid = uuidAttr.ValueString()
+		}
+
+		newAttrs := copyAttrs(svcAttrs)
+		modified := false
+
+		// Apply boolean overrides if we have plan values for this UUID
+		if uuid != "" {
+			if wb, ok := serviceMap[uuid]; ok {
+				if wb.showUptime != nil && *wb.showUptime {
+					if apiVal, ok := svcAttrs["show_uptime"].(types.Bool); ok && !apiVal.IsNull() && !apiVal.ValueBool() {
+						newAttrs["show_uptime"] = types.BoolValue(true)
+						modified = true
+					}
+				}
+				if wb.showResponseTimes != nil && *wb.showResponseTimes {
+					if apiVal, ok := svcAttrs["show_response_times"].(types.Bool); ok && !apiVal.IsNull() && !apiVal.ValueBool() {
+						newAttrs["show_response_times"] = types.BoolValue(true)
+						modified = true
+					}
+				}
+			}
+		}
+
+		// Recurse into nested services for groups
+		if nestedList, ok := svcAttrs["services"].(types.List); ok && !nestedList.IsNull() && !nestedList.IsUnknown() {
+			preservedNested := applyServicesWriteOnlyBooleans(nestedList, serviceMap, NestedServiceAttrTypes(), diags)
+			newAttrs["services"] = preservedNested
+			modified = true
+		}
+
+		if modified {
+			newSvc, newDiags := types.ObjectValue(attrTypes, newAttrs)
+			diags.Append(newDiags...)
+			newServices[i] = newSvc
+		} else {
+			newServices[i] = svcElem
+		}
+	}
+
+	newList, newDiags := types.ListValue(servicesList.ElementType(context.Background()), newServices)
+	diags.Append(newDiags...)
+
+	return newList
+}
+
+// copyAttrs creates a shallow copy of an attribute map.
+func copyAttrs(attrs map[string]attr.Value) map[string]attr.Value {
+	newAttrs := make(map[string]attr.Value, len(attrs))
+	for k, v := range attrs {
+		newAttrs[k] = v
+	}
+	return newAttrs
+}

--- a/internal/provider/statuspage_writeonly_booleans_test.go
+++ b/internal/provider/statuspage_writeonly_booleans_test.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// buildTestService builds a TF service object for testing.
+func buildTestService(uuid string, showUptime, showResponseTimes bool, isGroup bool, nested types.List) types.Object {
+	attrs := map[string]attr.Value{
+		"id":                  types.StringValue(""),
+		"uuid":                types.StringValue(uuid),
+		"name":                types.MapNull(types.StringType),
+		"is_group":            types.BoolValue(isGroup),
+		"show_uptime":         types.BoolValue(showUptime),
+		"show_response_times": types.BoolValue(showResponseTimes),
+		"services":            nested,
+	}
+	obj, _ := types.ObjectValue(ServiceAttrTypes(), attrs)
+	return obj
+}
+
+// buildTestNestedService builds a TF nested service object for testing.
+func buildTestNestedService(uuid string, showUptime, showResponseTimes bool) types.Object {
+	attrs := map[string]attr.Value{
+		"id":                  types.StringValue(""),
+		"uuid":                types.StringValue(uuid),
+		"name":                types.MapNull(types.StringType),
+		"is_group":            types.BoolValue(false),
+		"show_uptime":         types.BoolValue(showUptime),
+		"show_response_times": types.BoolValue(showResponseTimes),
+	}
+	obj, _ := types.ObjectValue(NestedServiceAttrTypes(), attrs)
+	return obj
+}
+
+// buildTestSection builds a TF section object for testing.
+func buildTestSection(isSplit bool, services types.List) types.Object {
+	attrs := map[string]attr.Value{
+		"name":     types.MapNull(types.StringType),
+		"is_split": types.BoolValue(isSplit),
+		"services": services,
+	}
+	obj, _ := types.ObjectValue(SectionAttrTypes(), attrs)
+	return obj
+}
+
+// buildServicesList builds a types.List of services from objects.
+func buildServicesList(services ...types.Object) types.List {
+	values := make([]attr.Value, len(services))
+	for i, s := range services {
+		values[i] = s
+	}
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: ServiceAttrTypes()}, values)
+	return list
+}
+
+// buildNestedServicesList builds a types.List of nested services from objects.
+func buildNestedServicesList(services ...types.Object) types.List {
+	values := make([]attr.Value, len(services))
+	for i, s := range services {
+		values[i] = s
+	}
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}, values)
+	return list
+}
+
+// buildSectionsList builds a types.List of sections from objects.
+func buildSectionsList(sections ...types.Object) types.List {
+	values := make([]attr.Value, len(sections))
+	for i, s := range sections {
+		values[i] = s
+	}
+	list, _ := types.ListValue(types.ObjectType{AttrTypes: SectionAttrTypes()}, values)
+	return list
+}
+
+func TestExtractWriteOnlyBooleans_BasicService(t *testing.T) {
+	svc := buildTestService("mon_abc123", true, true, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	svcList := buildServicesList(svc)
+	section := buildTestSection(true, svcList)
+	sections := buildSectionsList(section)
+
+	serviceMap, sectionIsSplit := extractWriteOnlyBooleans(sections)
+
+	// Check service booleans
+	wb, ok := serviceMap["mon_abc123"]
+	if !ok {
+		t.Fatal("expected mon_abc123 in serviceMap")
+	}
+	if wb.showUptime == nil || !*wb.showUptime {
+		t.Error("expected showUptime=true")
+	}
+	if wb.showResponseTimes == nil || !*wb.showResponseTimes {
+		t.Error("expected showResponseTimes=true")
+	}
+
+	// Check section is_split
+	if !sectionIsSplit[0] {
+		t.Error("expected sectionIsSplit[0]=true")
+	}
+}
+
+func TestExtractWriteOnlyBooleans_NestedService(t *testing.T) {
+	nested := buildTestNestedService("mon_nested1", true, true)
+	nestedList := buildNestedServicesList(nested)
+	group := buildTestService("", false, false, true, nestedList)
+	svcList := buildServicesList(group)
+	section := buildTestSection(false, svcList)
+	sections := buildSectionsList(section)
+
+	serviceMap, _ := extractWriteOnlyBooleans(sections)
+
+	wb, ok := serviceMap["mon_nested1"]
+	if !ok {
+		t.Fatal("expected mon_nested1 in serviceMap from nested services")
+	}
+	if wb.showUptime == nil || !*wb.showUptime {
+		t.Error("expected showUptime=true for nested service")
+	}
+}
+
+func TestExtractWriteOnlyBooleans_NullSections(t *testing.T) {
+	nullSections := types.ListNull(types.ObjectType{AttrTypes: SectionAttrTypes()})
+	serviceMap, sectionIsSplit := extractWriteOnlyBooleans(nullSections)
+
+	if len(serviceMap) != 0 {
+		t.Errorf("expected empty serviceMap, got %d entries", len(serviceMap))
+	}
+	if len(sectionIsSplit) != 0 {
+		t.Errorf("expected empty sectionIsSplit, got %d entries", len(sectionIsSplit))
+	}
+}
+
+func TestApplyWriteOnlyBooleans_PlanTrueApiFalse(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API returns false for booleans
+	apiSvc := buildTestService("mon_abc123", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan had true
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_abc123": {
+			showUptime:        boolPtr(true),
+			showResponseTimes: boolPtr(true),
+		},
+	}
+	sectionIsSplit := map[int]bool{0: true}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	// Check that booleans were preserved
+	secObj := result.Elements()[0].(types.Object)
+	secAttrs := secObj.Attributes()
+
+	// is_split should be overridden to true
+	isSplit := secAttrs["is_split"].(types.Bool)
+	if !isSplit.ValueBool() {
+		t.Error("expected is_split=true after preservation")
+	}
+
+	// Check service booleans
+	svcList := secAttrs["services"].(types.List)
+	svcObj := svcList.Elements()[0].(types.Object)
+	svcAttrs := svcObj.Attributes()
+
+	showUptime := svcAttrs["show_uptime"].(types.Bool)
+	if !showUptime.ValueBool() {
+		t.Error("expected show_uptime=true after preservation")
+	}
+
+	showRT := svcAttrs["show_response_times"].(types.Bool)
+	if !showRT.ValueBool() {
+		t.Error("expected show_response_times=true after preservation")
+	}
+}
+
+func TestApplyWriteOnlyBooleans_UUIDBasedReordering(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API returns services in different order than plan
+	apiSvc1 := buildTestService("mon_def456", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvc2 := buildTestService("mon_abc123", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc1, apiSvc2)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan had mon_abc123=true, mon_def456=false
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_abc123": {showUptime: boolPtr(true), showResponseTimes: boolPtr(true)},
+		"mon_def456": {showUptime: boolPtr(false), showResponseTimes: boolPtr(false)},
+	}
+	sectionIsSplit := map[int]bool{}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+
+	// First service (mon_def456) should NOT be overridden (plan=false)
+	svc1Attrs := svcList.Elements()[0].(types.Object).Attributes()
+	if svc1Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_def456 show_uptime should remain false")
+	}
+
+	// Second service (mon_abc123) should be overridden (plan=true)
+	svc2Attrs := svcList.Elements()[1].(types.Object).Attributes()
+	if !svc2Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_abc123 show_uptime should be true after preservation")
+	}
+}
+
+func TestApplyWriteOnlyBooleans_NestedServices(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API returns nested service with false
+	nestedSvc := buildTestNestedService("mon_nested1", false, false)
+	nestedList := buildNestedServicesList(nestedSvc)
+	groupSvc := buildTestService("", false, false, true, nestedList)
+	apiSvcList := buildServicesList(groupSvc)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan had true for nested service
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_nested1": {showUptime: boolPtr(true), showResponseTimes: boolPtr(true)},
+	}
+	sectionIsSplit := map[int]bool{}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+	groupObj := svcList.Elements()[0].(types.Object)
+	nestedSvcList := groupObj.Attributes()["services"].(types.List)
+	nestedAttrs := nestedSvcList.Elements()[0].(types.Object).Attributes()
+
+	if !nestedAttrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("nested service show_uptime should be true after preservation")
+	}
+	if !nestedAttrs["show_response_times"].(types.Bool).ValueBool() {
+		t.Error("nested service show_response_times should be true after preservation")
+	}
+}
+
+func TestApplyWriteOnlyBooleans_LengthMismatch(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API returns 2 services, plan had 3 — UUID matching should still work
+	apiSvc1 := buildTestService("mon_abc123", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvc2 := buildTestService("mon_def456", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc1, apiSvc2)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan had 3 services including mon_ghi789 which API didn't return
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_abc123": {showUptime: boolPtr(true)},
+		"mon_def456": {showUptime: boolPtr(true)},
+		"mon_ghi789": {showUptime: boolPtr(true)},
+	}
+	sectionIsSplit := map[int]bool{}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+
+	// Both existing services should be preserved
+	svc1Attrs := svcList.Elements()[0].(types.Object).Attributes()
+	if !svc1Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_abc123 show_uptime should be true")
+	}
+
+	svc2Attrs := svcList.Elements()[1].(types.Object).Attributes()
+	if !svc2Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_def456 show_uptime should be true")
+	}
+}
+
+func TestApplyWriteOnlyBooleans_EmptyServiceMap(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	apiSvc := buildTestService("mon_abc123", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Empty maps (import scenario)
+	result := r.applyWriteOnlyBooleans(apiSections, map[string]writeOnlyBooleans{}, map[int]bool{}, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	// Values should remain as API returned them
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+	svcAttrs := svcList.Elements()[0].(types.Object).Attributes()
+
+	if svcAttrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("show_uptime should remain false with empty serviceMap")
+	}
+}
+
+func TestApplyWriteOnlyBooleans_MixedPreservation(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API returns false for all
+	apiSvc1 := buildTestService("mon_abc123", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvc2 := buildTestService("mon_def456", false, false, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc1, apiSvc2)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan: mon_abc123=true, mon_def456=false
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_abc123": {showUptime: boolPtr(true), showResponseTimes: boolPtr(false)},
+		"mon_def456": {showUptime: boolPtr(false), showResponseTimes: boolPtr(false)},
+	}
+	sectionIsSplit := map[int]bool{}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+
+	// mon_abc123: showUptime preserved (plan=true), showResponseTimes NOT preserved (plan=false)
+	svc1Attrs := svcList.Elements()[0].(types.Object).Attributes()
+	if !svc1Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_abc123 show_uptime should be true")
+	}
+	if svc1Attrs["show_response_times"].(types.Bool).ValueBool() {
+		t.Error("mon_abc123 show_response_times should remain false (plan=false)")
+	}
+
+	// mon_def456: both should remain false
+	svc2Attrs := svcList.Elements()[1].(types.Object).Attributes()
+	if svc2Attrs["show_uptime"].(types.Bool).ValueBool() {
+		t.Error("mon_def456 show_uptime should remain false")
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}


### PR DESCRIPTION
## Summary

Fixes 5 bugs reported against the Hyperping status page API and documents 3 known server-side issues the provider is already safe from.

- **Bug 1 (CRITICAL)**: Status page renderer showed "All Systems Operational" for DOWN monitors — UUID strings replaced with numeric v1 IDs via transparent translation
- **Bug 2**: Admin UI changes reset `isProtected` to `true` — every PUT now includes auth settings to trigger ISR revalidation; added drift detection warning
- **Bug 3**: `extractLocalizedString` returned empty strings instead of falling through to non-empty values in other languages
- **Bugs 4+5**: `show_response_times`, `show_uptime`, `is_split` perpetual drift — replaced index-based matching with UUID-based matching; added recursion for nested services
- **Bug 8**: Fixed incorrect doc comment on `StatusPageService.ID`
- **Bugs 6+7**: Hyperping server-side issues — provider already safe (Go `*string` prevents integer crash; v1 API gap worked around by Bug 1 fix)

## Changes

### New files
- `statuspage_id_translation.go` — UUID-to-numeric-ID translation (6 functions)
- `statuspage_writeonly_booleans.go` — UUID-based boolean preservation (replaces old index-based chain)
- `statuspage_id_translation_test.go` — 10 tests
- `statuspage_writeonly_booleans_test.go` — 9 tests

### Modified files
- `models_monitor.go` — Added `ID int` field for v1 numeric ID
- `statuspages.go` — Authentication workaround in every PUT (like `dns_record_type: "A"`)
- `statuspage_resource.go` — Wired translation + booleans + isProtected warning; removed old preserve chain (~130 lines)
- `statuspage_mapping.go` — Fixed `extractLocalizedString` empty string handling
- `statuspage_resource_helpers_test.go` — Added `/v1/monitors` to mock server
- `monitors_test.go` — Added `Monitor.ID` deserialization test

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] All 10 translation tests pass
- [x] All 9 boolean preservation tests pass
- [x] Monitor.ID deserialization test passes
- [x] All 9 status page acceptance tests pass (TF_ACC=1)
- [x] `go test -race ./internal/... -timeout=5m` — all pass, no race conditions
- [x] Pre-push hooks pass (vet, build, lint, govulncheck, test)