### PR TITLE
feat: add expected_status_code validator and enhance drift reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-03-02
+
+### Added
+
+- **`hyperping_monitor`**: Plan-time validator for `expected_status_code` — catches invalid
+  patterns before they reach the API. Accepts specific codes (`200`), wildcards (`2xx`),
+  and ranges (`1xx-3xx`).
+
+### Changed
+
+- **`hyperping_monitor`**: Updated `expected_status_code` description to document multi-range
+  patterns (`1xx-3xx`) newly revealed by Hyperping API docs.
+- **API drift detection**: Enhanced drift issue reports to include field-level change details
+  (added/removed/modified properties with description, type, default, and enum diffs).
+  Previously only listed modified endpoint names.
+
 ## [1.3.9] - 2026-03-01
 
 ### Fixed
@@ -645,7 +661,12 @@ This provider is production-ready with comprehensive test coverage (45.8% overal
 - Operations guide for production deployments
 - Troubleshooting guide with common issues and solutions
 
-[Unreleased]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.5...HEAD
+[Unreleased]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.9...v1.4.0
+[1.3.9]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.8...v1.3.9
+[1.3.8]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.7...v1.3.8
+[1.3.7]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.6...v1.3.7
+[1.3.6]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.5...v1.3.6
 [1.3.5]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/develeap/terraform-provider-hyperping/compare/v1.3.2...v1.3.3

--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -59,7 +59,7 @@ resource "hyperping_incident" "outage" {
 - `check_frequency` (Number) Check frequency in seconds.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
-- `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`).
+- `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
 - `follow_redirects` (Boolean) Whether the monitor follows HTTP redirects.
 - `http_method` (String) HTTP method used for checks (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS).
 - `name` (String) The name of the monitor.

--- a/docs/data-sources/monitors.md
+++ b/docs/data-sources/monitors.md
@@ -85,7 +85,7 @@ Read-Only:
 - `check_frequency` (Number) Check frequency in seconds.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
-- `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`).
+- `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
 - `follow_redirects` (Boolean) Whether to follow HTTP redirects.
 - `http_method` (String) HTTP method used for the check (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS).
 - `id` (String) The unique identifier (UUID) of the monitor.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -70,7 +70,7 @@ resource "hyperping_monitor" "maintenance" {
 - `alerts_wait` (Number) Seconds to wait before sending alerts after an outage is detected. Allows time for transient issues to resolve.
 - `check_frequency` (Number) Check frequency in seconds. Valid values: `10`, `20`, `30`, `60`, `120`, `180`, `300`, `600`, `1800`, `3600`, `21600`, `43200`, `86400`. Defaults to `60`.
 - `escalation_policy` (String) UUID of the escalation policy to link to this monitor.
-- `expected_status_code` (String) Expected HTTP status code pattern. Use `2xx` for any 2xx status, or specific like `200`, `201`. Defaults to `2xx`.
+- `expected_status_code` (String) Expected HTTP status code pattern. Use a specific code like `200`, a wildcard like `2xx` (200-299), or a range like `1xx-3xx` (100-399). Defaults to `2xx`.
 - `follow_redirects` (Boolean) Whether to follow HTTP redirects. Defaults to `true`.
 - `http_method` (String) HTTP method to use. Valid values: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`. Defaults to `GET`.
 - `paused` (Boolean) Whether the monitor is paused. Defaults to `false`.

--- a/internal/provider/monitor_data_source.go
+++ b/internal/provider/monitor_data_source.go
@@ -116,7 +116,7 @@ func (d *MonitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Computed:            true,
 			},
 			"expected_status_code": schema.StringAttribute{
-				MarkdownDescription: "Expected HTTP status code or pattern (e.g., `200`, `2xx`).",
+				MarkdownDescription: "Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).",
 				Computed:            true,
 			},
 			"follow_redirects": schema.BoolAttribute{

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -163,10 +163,15 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:            true,
 			},
 			"expected_status_code": schema.StringAttribute{
-				MarkdownDescription: "Expected HTTP status code pattern. Use `2xx` for any 2xx status, or specific like `200`, `201`. Defaults to `2xx`.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString("2xx"),
+				MarkdownDescription: "Expected HTTP status code pattern. " +
+					"Use a specific code like `200`, a wildcard like `2xx` (200-299), " +
+					"or a range like `1xx-3xx` (100-399). Defaults to `2xx`.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("2xx"),
+				Validators: []validator.String{
+					StatusCodePattern(),
+				},
 			},
 			"follow_redirects": schema.BoolAttribute{
 				MarkdownDescription: "Whether to follow HTTP redirects. Defaults to `true`.",

--- a/internal/provider/monitor_resource_edge_cases_test.go
+++ b/internal/provider/monitor_resource_edge_cases_test.go
@@ -157,6 +157,20 @@ func TestAccMonitorResource_statusCodeRanges(t *testing.T) {
 					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "expected_status_code", "404"),
 				),
 			},
+			// Test multi-range pattern (1xx-3xx)
+			{
+				Config: testAccMonitorResourceConfigWithStatusCode(server.URL, "1xx-3xx"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "expected_status_code", "1xx-3xx"),
+				),
+			},
+			// Test multi-range pattern (2xx-5xx)
+			{
+				Config: testAccMonitorResourceConfigWithStatusCode(server.URL, "2xx-5xx"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "expected_status_code", "2xx-5xx"),
+				),
+			},
 		},
 	})
 }

--- a/internal/provider/monitors_data_source.go
+++ b/internal/provider/monitors_data_source.go
@@ -129,7 +129,7 @@ func (d *MonitorsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 							Computed:            true,
 						},
 						"expected_status_code": schema.StringAttribute{
-							MarkdownDescription: "Expected HTTP status code or pattern (e.g., `200`, `2xx`).",
+							MarkdownDescription: "Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).",
 							Computed:            true,
 						},
 						"follow_redirects": schema.BoolAttribute{

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -429,3 +429,56 @@ func (v emailFormatValidator) ValidateString(_ context.Context, req validator.St
 func EmailFormat() validator.String {
 	return emailFormatValidator{}
 }
+
+// statusCodePattern matches valid expected_status_code values:
+// - Specific code: "200", "404", "503" (3-digit, 100-599)
+// - Single wildcard: "2xx", "5xx" (digit 1-5 followed by "xx")
+// - Multi-range: "1xx-3xx", "2xx-5xx" (two wildcards joined by "-", left <= right)
+var statusCodePattern = regexp.MustCompile(`^(?:[1-5]\d{2}|[1-5]xx(?:-[1-5]xx)?)$`)
+
+// statusCodePatternValidator validates expected_status_code against the patterns
+// that the Hyperping API accepts.
+type statusCodePatternValidator struct{}
+
+func (v statusCodePatternValidator) Description(_ context.Context) string {
+	return "value must be a valid status code pattern (e.g., \"200\", \"2xx\", \"1xx-3xx\")"
+}
+
+func (v statusCodePatternValidator) MarkdownDescription(_ context.Context) string {
+	return "value must be a valid status code pattern (e.g., `200`, `2xx`, `1xx-3xx`)"
+}
+
+func (v statusCodePatternValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	if !statusCodePattern.MatchString(value) {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Status Code Pattern",
+			fmt.Sprintf("The value %q is not a valid status code pattern. "+
+				"Use a specific code (\"200\"), a wildcard (\"2xx\"), "+
+				"or a range (\"1xx-3xx\").", value),
+		)
+		return
+	}
+
+	// For range patterns (e.g., "2xx-5xx"), verify left <= right
+	if len(value) == 7 && value[3] == '-' {
+		if value[0] > value[4] {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Invalid Status Code Range",
+				fmt.Sprintf("The range %q is inverted — the start class (%cxx) must be "+
+					"less than or equal to the end class (%cxx).", value, value[0], value[4]),
+			)
+		}
+	}
+}
+
+// StatusCodePattern returns a validator that checks for valid HTTP status code patterns.
+func StatusCodePattern() validator.String {
+	return statusCodePatternValidator{}
+}

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -947,3 +947,119 @@ func TestEmailFormat_Description(t *testing.T) {
 		t.Error("description and markdown description should match")
 	}
 }
+
+func TestStatusCodePatternValidator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+	}{
+		// Valid specific codes
+		{"valid specific 200", "200", false},
+		{"valid specific 404", "404", false},
+		{"valid specific 599", "599", false},
+		{"valid specific 100", "100", false},
+		{"valid specific 503", "503", false},
+
+		// Valid single wildcards
+		{"valid wildcard 2xx", "2xx", false},
+		{"valid wildcard 5xx", "5xx", false},
+		{"valid wildcard 1xx", "1xx", false},
+		{"valid wildcard 3xx", "3xx", false},
+		{"valid wildcard 4xx", "4xx", false},
+
+		// Valid multi-range patterns
+		{"valid range 1xx-3xx", "1xx-3xx", false},
+		{"valid range 2xx-5xx", "2xx-5xx", false},
+		{"valid range same class 2xx-2xx", "2xx-2xx", false},
+		{"valid range 1xx-5xx", "1xx-5xx", false},
+		{"valid range 3xx-4xx", "3xx-4xx", false},
+
+		// Invalid: inverted range
+		{"invalid inverted range 3xx-1xx", "3xx-1xx", true},
+		{"invalid inverted range 5xx-2xx", "5xx-2xx", true},
+
+		// Invalid: class out of range
+		{"invalid class 6xx", "6xx", true},
+		{"invalid class 0xx", "0xx", true},
+		{"invalid code 600", "600", true},
+		{"invalid code 099", "099", true},
+
+		// Invalid: malformed patterns
+		{"invalid text abc", "abc", true},
+		{"invalid too long 2xxx", "2xxx", true},
+		{"invalid too short 20", "20", true},
+		{"invalid incomplete 2x", "2x", true},
+		{"invalid empty string", "", true},
+		{"invalid spaces", "2 xx", true},
+		{"invalid mixed 2xX", "2xX", true},
+		{"invalid range with specific 200-3xx", "200-3xx", true},
+		{"invalid uppercase 2XX", "2XX", true},
+		{"invalid trailing dash 1xx-", "1xx-", true},
+		{"invalid leading dash -3xx", "-3xx", true},
+		{"invalid range endpoint 1xx-6xx", "1xx-6xx", true},
+		{"invalid trailing dash after wildcard 2xx-", "2xx-", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := StatusCodePattern()
+			req := validator.StringRequest{
+				Path:        path.Root("expected_status_code"),
+				ConfigValue: types.StringValue(tt.value),
+			}
+			resp := &validator.StringResponse{}
+			v.ValidateString(context.Background(), req, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tt.wantError {
+				t.Errorf("StatusCodePattern(%q): got error=%v, want error=%v", tt.value, hasError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestStatusCodePattern_Null(t *testing.T) {
+	v := StatusCodePattern()
+	req := validator.StringRequest{
+		Path:        path.Root("test"),
+		ConfigValue: types.StringNull(),
+	}
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("StatusCodePattern(null): unexpected error for null value: %v", resp.Diagnostics.Errors())
+	}
+}
+
+func TestStatusCodePattern_Unknown(t *testing.T) {
+	v := StatusCodePattern()
+	req := validator.StringRequest{
+		Path:        path.Root("test"),
+		ConfigValue: types.StringUnknown(),
+	}
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("StatusCodePattern(unknown): unexpected error: %v", resp.Diagnostics.Errors())
+	}
+}
+
+func TestStatusCodePattern_Description(t *testing.T) {
+	v := StatusCodePattern()
+	ctx := context.Background()
+
+	desc := v.Description(ctx)
+	if desc == "" {
+		t.Error("expected non-empty description")
+	}
+
+	mdDesc := v.MarkdownDescription(ctx)
+	if mdDesc == "" {
+		t.Error("expected non-empty markdown description")
+	}
+}

--- a/tools/cmd/scraper/diff/diff.go
+++ b/tools/cmd/scraper/diff/diff.go
@@ -7,6 +7,7 @@ package diff
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -61,6 +62,7 @@ func Compare(basePath, currPath string) (*Result, error) {
 }
 
 // FormatMarkdown converts a diff.Diff to a human-readable markdown string.
+// Includes field-level change details for modified endpoints.
 func FormatMarkdown(d *diff.Diff) string {
 	if d == nil || d.Empty() {
 		return "No API changes detected."
@@ -93,12 +95,180 @@ func FormatMarkdown(d *diff.Diff) string {
 	}
 
 	if len(pd.Modified) > 0 {
-		sb.WriteString("### Modified Endpoints\n")
-		for path := range pd.Modified {
-			sb.WriteString("- `" + path + "`\n")
+		sb.WriteString("### Modified Endpoints\n\n")
+		paths := sortedKeys(pd.Modified)
+		for _, path := range paths {
+			pathDiff := pd.Modified[path]
+			formatPathDiff(&sb, path, pathDiff)
 		}
-		sb.WriteString("\n")
 	}
 
 	return sb.String()
+}
+
+// formatPathDiff writes operation-level details for a single modified path.
+func formatPathDiff(sb *strings.Builder, path string, pd *diff.PathDiff) {
+	if pd.OperationsDiff == nil {
+		sb.WriteString("#### `" + path + "`\n_No operation changes._\n\n")
+		return
+	}
+
+	for _, method := range pd.OperationsDiff.Added {
+		sb.WriteString("- `" + strings.ToUpper(method) + " " + path + "` (new method)\n")
+	}
+
+	for _, method := range pd.OperationsDiff.Deleted {
+		sb.WriteString("- `" + strings.ToUpper(method) + " " + path + "` (removed method, BREAKING)\n")
+	}
+
+	methods := sortedKeys(pd.OperationsDiff.Modified)
+	for _, method := range methods {
+		methodDiff := pd.OperationsDiff.Modified[method]
+		sb.WriteString("#### `" + strings.ToUpper(method) + " " + path + "`\n")
+		formatMethodDiff(sb, methodDiff)
+		sb.WriteString("\n")
+	}
+}
+
+// formatMethodDiff writes field-level details for a single operation change.
+func formatMethodDiff(sb *strings.Builder, md *diff.MethodDiff) {
+	hasDetail := false
+
+	// Parameter changes (path, query, header, cookie)
+	if md.ParametersDiff != nil {
+		if formatParametersDiff(sb, md.ParametersDiff) {
+			hasDetail = true
+		}
+	}
+
+	// Request body property changes
+	if md.RequestBodyDiff != nil && md.RequestBodyDiff.ContentDiff != nil {
+		if formatContentDiff(sb, md.RequestBodyDiff.ContentDiff) {
+			hasDetail = true
+		}
+	}
+
+	// Response body property changes (sorted by status code)
+	if md.ResponsesDiff != nil {
+		for _, statusCode := range sortedKeys(md.ResponsesDiff.Modified) {
+			respDiff := md.ResponsesDiff.Modified[statusCode]
+			if respDiff != nil && respDiff.ContentDiff != nil {
+				if formatContentDiff(sb, respDiff.ContentDiff) {
+					hasDetail = true
+				}
+			}
+		}
+	}
+
+	if !hasDetail {
+		sb.WriteString("- _operation metadata changed_\n")
+	}
+}
+
+// formatContentDiff writes property-level details from a content diff.
+// Returns true if any detail was written.
+func formatContentDiff(sb *strings.Builder, cd *diff.ContentDiff) bool {
+	wrote := false
+	for _, mediaType := range sortedKeys(cd.MediaTypeModified) {
+		mtDiff := cd.MediaTypeModified[mediaType]
+		if mtDiff.SchemaDiff != nil && mtDiff.SchemaDiff.PropertiesDiff != nil {
+			if formatPropertiesDiff(sb, mtDiff.SchemaDiff.PropertiesDiff) {
+				wrote = true
+			}
+		}
+	}
+	return wrote
+}
+
+// formatPropertiesDiff writes added, deleted, and modified property details.
+// Returns true if any detail was written.
+func formatPropertiesDiff(sb *strings.Builder, pd *diff.SchemasDiff) bool {
+	wrote := false
+
+	for _, name := range pd.Added {
+		sb.WriteString("- `+ " + name + "` (new property)\n")
+		wrote = true
+	}
+
+	for _, name := range pd.Deleted {
+		sb.WriteString("- `- " + name + "` (removed property)\n")
+		wrote = true
+	}
+
+	names := sortedKeys(pd.Modified)
+	for _, name := range names {
+		schemaDiff := pd.Modified[name]
+		detail := describePropertyChange(schemaDiff)
+		sb.WriteString("- `~ " + name + "`: " + detail + "\n")
+		wrote = true
+	}
+
+	return wrote
+}
+
+// formatParametersDiff writes added, deleted, and modified parameter details.
+// Returns true if any detail was written.
+func formatParametersDiff(sb *strings.Builder, pd *diff.ParametersDiffByLocation) bool {
+	wrote := false
+
+	for _, location := range sortedKeys(pd.Added) {
+		for _, name := range pd.Added[location] {
+			sb.WriteString("- `+ " + name + "` (" + location + " parameter, new)\n")
+			wrote = true
+		}
+	}
+
+	for _, location := range sortedKeys(pd.Deleted) {
+		for _, name := range pd.Deleted[location] {
+			sb.WriteString("- `- " + name + "` (" + location + " parameter, removed)\n")
+			wrote = true
+		}
+	}
+
+	for _, location := range sortedKeys(pd.Modified) {
+		for _, name := range sortedKeys(pd.Modified[location]) {
+			sb.WriteString("- `~ " + name + "` (" + location + " parameter, changed)\n")
+			wrote = true
+		}
+	}
+
+	return wrote
+}
+
+// describePropertyChange returns a concise description of what changed in a property.
+func describePropertyChange(sd *diff.SchemaDiff) string {
+	if sd == nil {
+		return "schema changed"
+	}
+
+	var parts []string
+
+	if sd.DescriptionDiff != nil {
+		parts = append(parts, "description updated")
+	}
+	if sd.TypeDiff != nil {
+		parts = append(parts, fmt.Sprintf("type changed (added: %v, removed: %v)", sd.TypeDiff.Added, sd.TypeDiff.Deleted))
+	}
+	if sd.DefaultDiff != nil {
+		parts = append(parts, fmt.Sprintf("default %v → %v", sd.DefaultDiff.From, sd.DefaultDiff.To))
+	}
+	if sd.EnumDiff != nil {
+		parts = append(parts, "enum values changed")
+	}
+
+	if len(parts) == 0 {
+		return "schema changed"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// sortedKeys returns the keys of a map sorted alphabetically.
+// Works with any map[string]V type.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/tools/cmd/scraper/diff/diff_test.go
+++ b/tools/cmd/scraper/diff/diff_test.go
@@ -1,0 +1,445 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tufin/oasdiff/diff"
+	"github.com/tufin/oasdiff/utils"
+)
+
+func TestFormatMarkdown_NilDiff(t *testing.T) {
+	result := FormatMarkdown(nil)
+	if result != "No API changes detected." {
+		t.Errorf("expected no changes message, got: %s", result)
+	}
+}
+
+func TestFormatMarkdown_EmptyDiff(t *testing.T) {
+	d := &diff.Diff{}
+	result := FormatMarkdown(d)
+	if result != "No API changes detected." {
+		t.Errorf("expected no changes message, got: %s", result)
+	}
+}
+
+func TestFormatMarkdown_AddedEndpoints(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Added: utils.StringList{"/v1/new-endpoint"},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "### New Endpoints") {
+		t.Error("expected New Endpoints section")
+	}
+	if !strings.Contains(result, "`/v1/new-endpoint`") {
+		t.Error("expected new endpoint path in output")
+	}
+}
+
+func TestFormatMarkdown_DeletedEndpoints(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Deleted: utils.StringList{"/v1/removed-endpoint"},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "### Removed Endpoints (BREAKING)") {
+		t.Error("expected Removed Endpoints section")
+	}
+	if !strings.Contains(result, "`/v1/removed-endpoint`") {
+		t.Error("expected removed endpoint path in output")
+	}
+}
+
+func TestFormatMarkdown_ModifiedWithPropertyDescriptionChange(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"post": {
+								RequestBodyDiff: &diff.RequestBodyDiff{
+									ContentDiff: &diff.ContentDiff{
+										MediaTypeModified: map[string]*diff.MediaTypeDiff{
+											"application/json": {
+												SchemaDiff: &diff.SchemaDiff{
+													PropertiesDiff: &diff.SchemasDiff{
+														Modified: map[string]*diff.SchemaDiff{
+															"expected_status_code": {
+																DescriptionDiff: &diff.ValueDiff{
+																	From: "old description",
+																	To:   "new description",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "### Modified Endpoints") {
+		t.Error("expected Modified Endpoints section")
+	}
+	if !strings.Contains(result, "#### `POST /v1/monitors`") {
+		t.Error("expected POST /v1/monitors heading")
+	}
+	if !strings.Contains(result, "`~ expected_status_code`: description updated") {
+		t.Error("expected field-level description change detail")
+	}
+}
+
+func TestFormatMarkdown_ModifiedWithAddedAndDeletedProperties(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors/{uuid}": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"put": {
+								RequestBodyDiff: &diff.RequestBodyDiff{
+									ContentDiff: &diff.ContentDiff{
+										MediaTypeModified: map[string]*diff.MediaTypeDiff{
+											"application/json": {
+												SchemaDiff: &diff.SchemaDiff{
+													PropertiesDiff: &diff.SchemasDiff{
+														Added:   utils.StringList{"new_field"},
+														Deleted: utils.StringList{"old_field"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "`+ new_field` (new property)") {
+		t.Error("expected added property detail")
+	}
+	if !strings.Contains(result, "`- old_field` (removed property)") {
+		t.Error("expected deleted property detail")
+	}
+}
+
+func TestFormatMarkdown_ModifiedWithTypeChange(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"get": {
+								ResponsesDiff: &diff.ResponsesDiff{
+									Modified: map[string]*diff.ResponseDiff{
+										"200": {
+											ContentDiff: &diff.ContentDiff{
+												MediaTypeModified: map[string]*diff.MediaTypeDiff{
+													"application/json": {
+														SchemaDiff: &diff.SchemaDiff{
+															PropertiesDiff: &diff.SchemasDiff{
+																Modified: map[string]*diff.SchemaDiff{
+																	"count": {
+																		TypeDiff: &diff.StringsDiff{
+																			Added:   utils.StringList{"integer"},
+																			Deleted: utils.StringList{"string"},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "`~ count`: type changed") {
+		t.Error("expected type change detail")
+	}
+}
+
+func TestFormatMarkdown_OperationMetadataOnly(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"get": {
+								TagsDiff: &diff.StringsDiff{
+									Added: utils.StringList{"new-tag"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "_operation metadata changed_") {
+		t.Error("expected fallback metadata message when no property changes")
+	}
+}
+
+func TestFormatMarkdown_AllSections(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Added:   utils.StringList{"/v1/new"},
+			Deleted: utils.StringList{"/v1/removed"},
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"post": {
+								RequestBodyDiff: &diff.RequestBodyDiff{
+									ContentDiff: &diff.ContentDiff{
+										MediaTypeModified: map[string]*diff.MediaTypeDiff{
+											"application/json": {
+												SchemaDiff: &diff.SchemaDiff{
+													PropertiesDiff: &diff.SchemasDiff{
+														Modified: map[string]*diff.SchemaDiff{
+															"field": {
+																DescriptionDiff: &diff.ValueDiff{
+																	From: "old",
+																	To:   "new",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "### New Endpoints") {
+		t.Error("expected New Endpoints section")
+	}
+	if !strings.Contains(result, "### Removed Endpoints (BREAKING)") {
+		t.Error("expected Removed Endpoints section")
+	}
+	if !strings.Contains(result, "### Modified Endpoints") {
+		t.Error("expected Modified Endpoints section")
+	}
+	if !strings.Contains(result, "`~ field`: description updated") {
+		t.Error("expected field-level detail in Modified section")
+	}
+}
+
+func TestDescribePropertyChange_MultipleChanges(t *testing.T) {
+	sd := &diff.SchemaDiff{
+		DescriptionDiff: &diff.ValueDiff{From: "old", To: "new"},
+		DefaultDiff:     &diff.ValueDiff{From: "2xx", To: "200"},
+	}
+
+	result := describePropertyChange(sd)
+
+	if !strings.Contains(result, "description updated") {
+		t.Error("expected description updated")
+	}
+	if !strings.Contains(result, "default 2xx → 200") {
+		t.Error("expected default change")
+	}
+}
+
+func TestDescribePropertyChange_NoKnownChanges(t *testing.T) {
+	sd := &diff.SchemaDiff{
+		CircularRefDiff: true,
+	}
+
+	result := describePropertyChange(sd)
+	if result != "schema changed" {
+		t.Errorf("expected 'schema changed' fallback, got: %s", result)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	keys := sortedKeys(m)
+
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(keys))
+	}
+	if keys[0] != "a" || keys[1] != "b" || keys[2] != "c" {
+		t.Errorf("expected [a b c], got %v", keys)
+	}
+}
+
+func TestSortedKeys_EmptyMap(t *testing.T) {
+	m := map[string]int{}
+	keys := sortedKeys(m)
+	if len(keys) != 0 {
+		t.Errorf("expected empty slice, got %v", keys)
+	}
+}
+
+func TestDescribePropertyChange_Nil(t *testing.T) {
+	result := describePropertyChange(nil)
+	if result != "schema changed" {
+		t.Errorf("expected 'schema changed' for nil, got: %s", result)
+	}
+}
+
+func TestDescribePropertyChange_EnumDiff(t *testing.T) {
+	sd := &diff.SchemaDiff{
+		EnumDiff: &diff.EnumDiff{
+			Added:   diff.EnumValues{"active"},
+			Deleted: diff.EnumValues{"disabled"},
+		},
+	}
+	result := describePropertyChange(sd)
+	if result != "enum values changed" {
+		t.Errorf("expected 'enum values changed', got: %s", result)
+	}
+}
+
+func TestFormatPathDiff_NilOperationsDiff(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/test": {OperationsDiff: nil},
+			},
+		},
+	}
+	result := FormatMarkdown(d)
+	if !strings.Contains(result, "_No operation changes._") {
+		t.Error("expected 'No operation changes' message")
+	}
+}
+
+func TestFormatPathDiff_AddedAndDeletedOperations(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors/{uuid}": {
+					OperationsDiff: &diff.OperationsDiff{
+						Added:   utils.StringList{"delete"},
+						Deleted: utils.StringList{"patch"},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "`DELETE /v1/monitors/{uuid}` (new method)") {
+		t.Error("expected new method listing for added operation")
+	}
+	if !strings.Contains(result, "`PATCH /v1/monitors/{uuid}` (removed method, BREAKING)") {
+		t.Error("expected removed method listing for deleted operation")
+	}
+}
+
+func TestFormatMethodDiff_ParameterChanges(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors": {
+					OperationsDiff: &diff.OperationsDiff{
+						Modified: map[string]*diff.MethodDiff{
+							"get": {
+								ParametersDiff: &diff.ParametersDiffByLocation{
+									Added: diff.ParamNamesByLocation{
+										"query": utils.StringList{"page", "per_page"},
+									},
+									Deleted: diff.ParamNamesByLocation{
+										"query": utils.StringList{"offset"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	if !strings.Contains(result, "`+ page` (query parameter, new)") {
+		t.Error("expected added query parameter")
+	}
+	if !strings.Contains(result, "`+ per_page` (query parameter, new)") {
+		t.Error("expected added per_page parameter")
+	}
+	if !strings.Contains(result, "`- offset` (query parameter, removed)") {
+		t.Error("expected removed query parameter")
+	}
+}
+
+func TestFormatMarkdown_MultiplePathsSorted(t *testing.T) {
+	d := &diff.Diff{
+		PathsDiff: &diff.PathsDiff{
+			Modified: map[string]*diff.PathDiff{
+				"/v1/monitors/{uuid}": {OperationsDiff: nil},
+				"/v1/healthchecks":    {OperationsDiff: nil},
+				"/v1/monitors":        {OperationsDiff: nil},
+			},
+		},
+	}
+
+	result := FormatMarkdown(d)
+
+	// Verify deterministic ordering
+	idx1 := strings.Index(result, "/v1/healthchecks")
+	idx2 := strings.Index(result, "/v1/monitors`")
+	idx3 := strings.Index(result, "/v1/monitors/{uuid}")
+
+	if idx1 < 0 || idx2 < 0 || idx3 < 0 {
+		t.Fatalf("expected all three paths in output, got: %s", result)
+	}
+	if !(idx1 < idx2 && idx2 < idx3) {
+		t.Errorf("expected paths in alphabetical order, got indices: healthchecks=%d, monitors=%d, monitors/{uuid}=%d", idx1, idx2, idx3)
+	}
+}


### PR DESCRIPTION
Closes #51

## Summary

- Add plan-time `StatusCodePattern()` validator for `expected_status_code` — catches invalid patterns before they reach the API. Accepts specific codes (`200`), wildcards (`2xx`), and ranges (`1xx-3xx`).
- Enhance the scraper's `FormatMarkdown` to show field-level change details (added/removed/modified properties, parameter changes, type/default/enum diffs) in drift issue reports. Previously only listed modified endpoint names.
- Update `expected_status_code` descriptions across resource and data sources to document multi-range pattern syntax.

## Changes

| File | Change |
|------|--------|
| `validators.go` | New `StatusCodePattern()` validator with regex + range ordering check |
| `validators_test.go` | 34 table-driven test cases + null/unknown/description tests |
| `monitor_resource.go` | Wire validator, update description |
| `monitor_data_source.go` | Update description |
| `monitors_data_source.go` | Update description |
| `monitor_resource_edge_cases_test.go` | Add multi-range acceptance test steps |
| `diff/diff.go` | New `formatPathDiff`, `formatMethodDiff`, `formatContentDiff`, `formatPropertiesDiff`, `formatParametersDiff`, `describePropertyChange` functions |
| `diff/diff_test.go` | 19 unit tests covering all formatting paths |
| `CHANGELOG.md` | v1.4.0 entry |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./internal/...` — all pass (client 58s, provider 121s)
- [x] `go test -race ./...` — all packages pass
- [x] `TF_ACC=1` acceptance tests pass (including new multi-range steps)
- [x] `govulncheck` — no vulnerabilities
- [x] `gosec ./internal/...` — 0 new findings (1 pre-existing LOW)
- [x] Pre-commit hooks pass (go-fmt, go-mod-tidy, generate-docs)
- [x] Pre-push hooks pass (vet, build, govulncheck, lint, test)