### PR TITLE
fix: preserve show_response_times=false when API returns true

### DIFF
--- a/internal/provider/statuspage_writeonly_booleans.go
+++ b/internal/provider/statuspage_writeonly_booleans.go
@@ -181,18 +181,20 @@ func applyServicesWriteOnlyBooleans(servicesList types.List, serviceMap map[stri
 		newAttrs := copyAttrs(svcAttrs)
 		modified := false
 
-		// Apply boolean overrides if we have plan values for this UUID
+		// Apply boolean overrides if we have plan values for this UUID.
+		// The API ignores these booleans on write and always returns its own
+		// value, so we trust the plan value whenever it differs from the API.
 		if uuid != "" {
 			if wb, ok := serviceMap[uuid]; ok {
-				if wb.showUptime != nil && *wb.showUptime {
-					if apiVal, ok := svcAttrs["show_uptime"].(types.Bool); ok && !apiVal.IsNull() && !apiVal.ValueBool() {
-						newAttrs["show_uptime"] = types.BoolValue(true)
+				if wb.showUptime != nil {
+					if apiVal, ok := svcAttrs["show_uptime"].(types.Bool); ok && !apiVal.IsNull() && apiVal.ValueBool() != *wb.showUptime {
+						newAttrs["show_uptime"] = types.BoolValue(*wb.showUptime)
 						modified = true
 					}
 				}
-				if wb.showResponseTimes != nil && *wb.showResponseTimes {
-					if apiVal, ok := svcAttrs["show_response_times"].(types.Bool); ok && !apiVal.IsNull() && !apiVal.ValueBool() {
-						newAttrs["show_response_times"] = types.BoolValue(true)
+				if wb.showResponseTimes != nil {
+					if apiVal, ok := svcAttrs["show_response_times"].(types.Bool); ok && !apiVal.IsNull() && apiVal.ValueBool() != *wb.showResponseTimes {
+						newAttrs["show_response_times"] = types.BoolValue(*wb.showResponseTimes)
 						modified = true
 					}
 				}

--- a/internal/provider/statuspage_writeonly_booleans_test.go
+++ b/internal/provider/statuspage_writeonly_booleans_test.go
@@ -376,6 +376,46 @@ func TestApplyWriteOnlyBooleans_MixedPreservation(t *testing.T) {
 	}
 }
 
+func TestApplyWriteOnlyBooleans_PlanFalseApiTrue(t *testing.T) {
+	r := &StatusPageResource{}
+	var diags diag.Diagnostics
+
+	// API always returns true for show_response_times (the bug)
+	apiSvc := buildTestService("mon_abc123", true, true, false, types.ListNull(types.ObjectType{AttrTypes: NestedServiceAttrTypes()}))
+	apiSvcList := buildServicesList(apiSvc)
+	apiSection := buildTestSection(false, apiSvcList)
+	apiSections := buildSectionsList(apiSection)
+
+	// Plan had false — user explicitly set show_response_times = false
+	serviceMap := map[string]writeOnlyBooleans{
+		"mon_abc123": {
+			showUptime:        boolPtr(false),
+			showResponseTimes: boolPtr(false),
+		},
+	}
+	sectionIsSplit := map[int]bool{}
+
+	result := r.applyWriteOnlyBooleans(apiSections, serviceMap, sectionIsSplit, &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected errors: %v", diags.Errors())
+	}
+
+	secObj := result.Elements()[0].(types.Object)
+	svcList := secObj.Attributes()["services"].(types.List)
+	svcAttrs := svcList.Elements()[0].(types.Object).Attributes()
+
+	showUptime := svcAttrs["show_uptime"].(types.Bool)
+	if showUptime.ValueBool() {
+		t.Error("expected show_uptime=false (plan should override API true)")
+	}
+
+	showRT := svcAttrs["show_response_times"].(types.Bool)
+	if showRT.ValueBool() {
+		t.Error("expected show_response_times=false (plan should override API true)")
+	}
+}
+
 func boolPtr(v bool) *bool {
 	return &v
 }


### PR DESCRIPTION
## Summary

- Fix write-only boolean preservation to work bidirectionally — previously only overrode API values when plan=`true` and API=`false`, now also handles plan=`false` and API=`true`
- Fixes `show_response_times = false` being silently ignored by the Hyperping API, causing perpetual Terraform drift
- Same fix applied to `show_uptime`

## Test plan

- [x] New unit test `TestApplyWriteOnlyBooleans_PlanFalseApiTrue` covers the exact bug scenario
- [x] All 7 write-only boolean tests pass
- [x] Full test suite passes with race detector
- [x] Lint clean (0 issues)