### PR TITLE
fix(statuspage): stop translating UUIDs to numeric IDs on write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`hyperping_statuspage`**: Fixed critical UUID drift bug where status page services had their
+  `uuid` field set to the service's own numeric ID instead of the linked monitor UUID. This caused
+  all status pages to show orphaned entries with no live data. The provider no longer translates
+  `mon_xxx` UUIDs to numeric IDs on write — the API preserves them correctly when sent directly.
+  Existing broken status pages will self-heal on the next `terraform apply`.
+
+### Added
+
+- **`hyperping_statuspage`**: Read-time warning when services have unresolved numeric UUIDs from
+  legacy drift, guiding users to re-apply to fix the data.
+
 ## [1.4.3] - 2026-03-04
 
 ### Fixed

--- a/internal/client/models_statuspage.go
+++ b/internal/client/models_statuspage.go
@@ -73,8 +73,9 @@ type StatusPageSection struct {
 //   - an integer (e.g. 117122) when set via v1 admin UI or numeric ID workaround
 //   - absent entirely for group header entries (which have no top-level monitor)
 //
-// The provider writes numeric IDs (translated from UUIDs) for renderer compatibility,
-// so read responses typically contain integers. UUID is empty for group headers.
+// The provider sends mon_xxx UUIDs directly. Legacy data from older provider
+// versions (< 1.5.0) may still have numeric IDs, which are translated back to
+// UUIDs on read via buildMonitorIDToUUIDMap.
 type StatusPageService struct {
 	ID                interface{}         `json:"id,omitempty"`
 	UUID              string              `json:"uuid,omitempty"`

--- a/internal/provider/statuspage_id_translation.go
+++ b/internal/provider/statuspage_id_translation.go
@@ -7,108 +7,36 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
 )
 
-// buildMonitorIDMaps fetches all monitors and builds bidirectional lookup maps
-// between UUID strings (e.g. "mon_abc123") and v1 numeric IDs (e.g. 115746).
-// On error, adds a warning diagnostic and returns empty maps (graceful fallback).
-func buildMonitorIDMaps(ctx context.Context, apiClient client.HyperpingAPI, diags *diag.Diagnostics) (uuidToID map[string]int, idToUUID map[string]string) {
-	uuidToID = make(map[string]int)
-	idToUUID = make(map[string]string)
+// buildMonitorIDToUUIDMap fetches all monitors and builds a lookup map from
+// v1 numeric IDs (e.g. "115746") to UUID strings (e.g. "mon_abc123").
+// Used on the read path to translate numeric IDs in API responses back to UUIDs.
+// On error, adds a warning diagnostic and returns an empty map (graceful fallback).
+func buildMonitorIDToUUIDMap(ctx context.Context, apiClient client.MonitorAPI, diags *diag.Diagnostics) map[string]string {
+	idToUUID := make(map[string]string)
 
 	monitors, err := apiClient.ListMonitors(ctx)
 	if err != nil {
 		diags.AddWarning(
 			"Unable to fetch monitor list for ID translation",
-			fmt.Sprintf("Status page services will use UUIDs as-is (renderer may not resolve status): %s", err),
+			fmt.Sprintf("Status page services may show numeric IDs instead of UUIDs: %s", err),
 		)
-		return uuidToID, idToUUID
+		return idToUUID
 	}
 
 	for _, mon := range monitors {
 		if mon.UUID != "" && mon.ID != 0 {
-			uuidToID[mon.UUID] = mon.ID
 			idToUUID[strconv.Itoa(mon.ID)] = mon.UUID
 		}
 	}
 
-	return uuidToID, idToUUID
-}
-
-// translateSectionsToNumericIDs walks sections and replaces UUID strings with
-// numeric ID strings for renderer compatibility. Creates new slices (immutable).
-// Unknown UUIDs are left as-is (graceful fallback).
-func translateSectionsToNumericIDs(sections []client.CreateStatusPageSection, uuidToID map[string]int) []client.CreateStatusPageSection {
-	if len(uuidToID) == 0 {
-		return sections
-	}
-
-	translated := make([]client.CreateStatusPageSection, len(sections))
-	for i, section := range sections {
-		translated[i] = client.CreateStatusPageSection{
-			Name:     section.Name,
-			IsSplit:  section.IsSplit,
-			Services: translateServicesToNumericIDs(section.Services, uuidToID),
-		}
-	}
-
-	return translated
-}
-
-// translateServicesToNumericIDs translates service UUIDs to numeric IDs.
-func translateServicesToNumericIDs(services []client.CreateStatusPageService, uuidToID map[string]int) []client.CreateStatusPageService {
-	if len(services) == 0 {
-		return services
-	}
-
-	translated := make([]client.CreateStatusPageService, len(services))
-	for i, svc := range services {
-		translated[i] = translateServiceToNumericID(svc, uuidToID)
-	}
-
-	return translated
-}
-
-// translateServiceToNumericID translates a single service's UUID to numeric ID.
-func translateServiceToNumericID(svc client.CreateStatusPageService, uuidToID map[string]int) client.CreateStatusPageService {
-	result := client.CreateStatusPageService{
-		NameShown:         svc.NameShown,
-		Name:              svc.Name,
-		ShowUptime:        svc.ShowUptime,
-		ShowResponseTimes: svc.ShowResponseTimes,
-		IsGroup:           svc.IsGroup,
-	}
-
-	// Top-level services use MonitorUUID
-	if svc.MonitorUUID != nil {
-		if numID, ok := uuidToID[*svc.MonitorUUID]; ok {
-			idStr := strconv.Itoa(numID)
-			result.MonitorUUID = &idStr
-		} else {
-			result.MonitorUUID = svc.MonitorUUID
-		}
-	}
-
-	// Nested services use UUID
-	if svc.UUID != nil {
-		if numID, ok := uuidToID[*svc.UUID]; ok {
-			idStr := strconv.Itoa(numID)
-			result.UUID = &idStr
-		} else {
-			result.UUID = svc.UUID
-		}
-	}
-
-	// Recurse into nested services for groups
-	if len(svc.Services) > 0 {
-		result.Services = translateServicesToNumericIDs(svc.Services, uuidToID)
-	}
-
-	return result
+	return idToUUID
 }
 
 // translateStatusPageToUUIDs walks the StatusPage response and replaces numeric
@@ -162,4 +90,49 @@ func serviceIDToNumericString(id interface{}) string {
 		}
 	}
 	return ""
+}
+
+// warnUnresolvedNumericUUIDs checks for services that still have numeric UUIDs
+// after translation (i.e., the API returned a numeric ID that couldn't be mapped
+// to a mon_xxx UUID). This indicates legacy drift from older provider versions
+// that translated UUIDs to numeric IDs on write. The next terraform apply will
+// fix these by sending the correct mon_xxx UUIDs from the config.
+func warnUnresolvedNumericUUIDs(sp *client.StatusPage, diags *diag.Diagnostics) {
+	if sp == nil {
+		return
+	}
+
+	var drifted []string
+	for _, section := range sp.Sections {
+		collectDriftedUUIDs(section.Services, &drifted)
+	}
+
+	if len(drifted) > 0 {
+		diags.AddWarning(
+			"Status page services have numeric UUIDs (legacy drift detected)",
+			fmt.Sprintf(
+				"Found %d service(s) with numeric UUIDs instead of mon_xxx format: %s. "+
+					"This was caused by an older provider version that translated UUIDs to numeric IDs. "+
+					"Run 'terraform apply' to fix — the provider will send the correct UUIDs from your config.",
+				len(drifted), strings.Join(drifted, ", ")),
+		)
+	}
+}
+
+// collectDriftedUUIDs recursively collects service UUIDs that are still numeric strings.
+func collectDriftedUUIDs(services []client.StatusPageService, drifted *[]string) {
+	for _, svc := range services {
+		if svc.UUID != "" && isNumericString(svc.UUID) {
+			*drifted = append(*drifted, svc.UUID)
+		}
+		if len(svc.Services) > 0 {
+			collectDriftedUUIDs(svc.Services, drifted)
+		}
+	}
+}
+
+// isNumericString returns true if s contains only digits.
+func isNumericString(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
 }

--- a/internal/provider/statuspage_id_translation_test.go
+++ b/internal/provider/statuspage_id_translation_test.go
@@ -4,106 +4,50 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
 )
 
-func TestTranslateSectionsToNumericIDs_TopLevelService(t *testing.T) {
-	uuid := "mon_abc123"
-	uuidToID := map[string]int{"mon_abc123": 115746}
-
-	sections := []client.CreateStatusPageSection{
-		{
-			Name: "API",
-			Services: []client.CreateStatusPageService{
-				{MonitorUUID: &uuid},
-			},
-		},
-	}
-
-	result := translateSectionsToNumericIDs(sections, uuidToID)
-
-	if result[0].Services[0].MonitorUUID == nil {
-		t.Fatal("expected MonitorUUID to be set")
-	}
-	if *result[0].Services[0].MonitorUUID != "115746" {
-		t.Errorf("expected '115746', got %q", *result[0].Services[0].MonitorUUID)
-	}
-
-	// Verify original was not mutated
-	if *sections[0].Services[0].MonitorUUID != "mon_abc123" {
-		t.Error("original section was mutated")
-	}
+// mockMonitorAPI implements client.MonitorAPI for testing buildMonitorIDToUUIDMap.
+type mockMonitorAPI struct {
+	listMonitorsFunc func(ctx context.Context) ([]client.Monitor, error)
 }
 
-func TestTranslateSectionsToNumericIDs_NestedService(t *testing.T) {
-	uuid := "mon_def456"
-	isGroup := true
-	uuidToID := map[string]int{"mon_def456": 115747}
-
-	sections := []client.CreateStatusPageSection{
-		{
-			Name: "Group",
-			Services: []client.CreateStatusPageService{
-				{
-					IsGroup: &isGroup,
-					Services: []client.CreateStatusPageService{
-						{UUID: &uuid},
-					},
-				},
-			},
-		},
+func (m *mockMonitorAPI) ListMonitors(ctx context.Context) ([]client.Monitor, error) {
+	if m.listMonitorsFunc != nil {
+		return m.listMonitorsFunc(ctx)
 	}
-
-	result := translateSectionsToNumericIDs(sections, uuidToID)
-
-	nested := result[0].Services[0].Services[0]
-	if nested.UUID == nil {
-		t.Fatal("expected UUID to be set on nested service")
-	}
-	if *nested.UUID != "115747" {
-		t.Errorf("expected '115747', got %q", *nested.UUID)
-	}
+	return nil, nil
 }
 
-func TestTranslateSectionsToNumericIDs_UnknownUUID(t *testing.T) {
-	unknownUUID := "mon_unknown"
-	uuidToID := map[string]int{"mon_abc123": 115746}
-
-	sections := []client.CreateStatusPageSection{
-		{
-			Name: "API",
-			Services: []client.CreateStatusPageService{
-				{MonitorUUID: &unknownUUID},
-			},
-		},
-	}
-
-	result := translateSectionsToNumericIDs(sections, uuidToID)
-
-	if *result[0].Services[0].MonitorUUID != "mon_unknown" {
-		t.Errorf("expected unknown UUID to pass through, got %q", *result[0].Services[0].MonitorUUID)
-	}
+func (m *mockMonitorAPI) GetMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
+	return nil, nil
 }
 
-func TestTranslateSectionsToNumericIDs_EmptyMap(t *testing.T) {
-	uuid := "mon_abc123"
-	sections := []client.CreateStatusPageSection{
-		{
-			Name: "API",
-			Services: []client.CreateStatusPageService{
-				{MonitorUUID: &uuid},
-			},
-		},
-	}
+func (m *mockMonitorAPI) CreateMonitor(ctx context.Context, req client.CreateMonitorRequest) (*client.Monitor, error) {
+	return nil, nil
+}
 
-	result := translateSectionsToNumericIDs(sections, map[string]int{})
+func (m *mockMonitorAPI) UpdateMonitor(ctx context.Context, uuid string, req client.UpdateMonitorRequest) (*client.Monitor, error) {
+	return nil, nil
+}
 
-	// Should return original sections unchanged
-	if *result[0].Services[0].MonitorUUID != "mon_abc123" {
-		t.Errorf("expected UUID unchanged, got %q", *result[0].Services[0].MonitorUUID)
-	}
+func (m *mockMonitorAPI) DeleteMonitor(ctx context.Context, uuid string) error {
+	return nil
+}
+
+func (m *mockMonitorAPI) PauseMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
+	return nil, nil
+}
+
+func (m *mockMonitorAPI) ResumeMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
+	return nil, nil
 }
 
 func TestTranslateStatusPageToUUIDs_NumericString(t *testing.T) {
@@ -191,34 +135,14 @@ func TestTranslateStatusPageToUUIDs_EmptyMap(t *testing.T) {
 	}
 }
 
-func TestTranslateRoundTrip(t *testing.T) {
-	uuid := "mon_abc123"
-	uuidToID := map[string]int{"mon_abc123": 115746}
+func TestTranslateStatusPageToUUIDs_AlreadyUUID(t *testing.T) {
 	idToUUID := map[string]string{"115746": "mon_abc123"}
 
-	// Forward: UUID -> numeric ID
-	sections := []client.CreateStatusPageSection{
-		{
-			Name: "API",
-			Services: []client.CreateStatusPageService{
-				{MonitorUUID: &uuid},
-			},
-		},
-	}
-
-	translated := translateSectionsToNumericIDs(sections, uuidToID)
-	numericID := *translated[0].Services[0].MonitorUUID
-
-	if numericID != "115746" {
-		t.Fatalf("forward translation failed: expected '115746', got %q", numericID)
-	}
-
-	// Reverse: numeric ID -> UUID
 	sp := &client.StatusPage{
 		Sections: []client.StatusPageSection{
 			{
 				Services: []client.StatusPageService{
-					{UUID: numericID, ID: numericID},
+					{UUID: "mon_xyz789"},
 				},
 			},
 		},
@@ -226,8 +150,9 @@ func TestTranslateRoundTrip(t *testing.T) {
 
 	translateStatusPageToUUIDs(sp, idToUUID)
 
-	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
-		t.Errorf("round-trip failed: expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
+	// Should remain unchanged — already a valid UUID
+	if sp.Sections[0].Services[0].UUID != "mon_xyz789" {
+		t.Errorf("expected 'mon_xyz789', got %q", sp.Sections[0].Services[0].UUID)
 	}
 }
 
@@ -249,6 +174,173 @@ func TestServiceIDToNumericString(t *testing.T) {
 			got := serviceIDToNumericString(tt.id)
 			if got != tt.want {
 				t.Errorf("serviceIDToNumericString(%v) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWarnUnresolvedNumericUUIDs_DetectsDrift(t *testing.T) {
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "117896"}, // drifted
+					{UUID: "mon_abc123"},
+					{UUID: "118001"}, // drifted
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	warnUnresolvedNumericUUIDs(sp, &diags)
+
+	if diags.WarningsCount() != 1 {
+		t.Fatalf("expected 1 warning, got %d", diags.WarningsCount())
+	}
+
+	detail := diags[0].Detail()
+	if !strings.Contains(detail, "117896") || !strings.Contains(detail, "118001") {
+		t.Errorf("expected warning to list both drifted UUIDs, got: %s", detail)
+	}
+	if !strings.Contains(detail, "2 service(s)") {
+		t.Errorf("expected count of 2, got: %s", detail)
+	}
+}
+
+func TestWarnUnresolvedNumericUUIDs_NoWarningWhenClean(t *testing.T) {
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "mon_abc123"},
+					{UUID: "mon_def456"},
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	warnUnresolvedNumericUUIDs(sp, &diags)
+
+	if diags.WarningsCount() > 0 {
+		t.Errorf("expected no warnings, got %d", diags.WarningsCount())
+	}
+}
+
+func TestWarnUnresolvedNumericUUIDs_NestedDrift(t *testing.T) {
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{
+						IsGroup: true,
+						UUID:    "",
+						Services: []client.StatusPageService{
+							{UUID: "117896"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	warnUnresolvedNumericUUIDs(sp, &diags)
+
+	if diags.WarningsCount() != 1 {
+		t.Errorf("expected 1 warning, got %d", diags.WarningsCount())
+	}
+}
+
+func TestWarnUnresolvedNumericUUIDs_NilStatusPage(t *testing.T) {
+	var diags diag.Diagnostics
+	warnUnresolvedNumericUUIDs(nil, &diags)
+
+	if diags.WarningsCount() > 0 {
+		t.Errorf("expected no warnings for nil status page, got %d", diags.WarningsCount())
+	}
+}
+
+func TestWarnUnresolvedNumericUUIDs_EmptyUUIDSkipped(t *testing.T) {
+	sp := &client.StatusPage{
+		Sections: []client.StatusPageSection{
+			{
+				Services: []client.StatusPageService{
+					{UUID: "", IsGroup: true}, // group header, no UUID
+					{UUID: "mon_abc123"},
+				},
+			},
+		},
+	}
+
+	var diags diag.Diagnostics
+	warnUnresolvedNumericUUIDs(sp, &diags)
+
+	if diags.WarningsCount() > 0 {
+		t.Errorf("expected no warnings, got %d", diags.WarningsCount())
+	}
+}
+
+func TestBuildMonitorIDToUUIDMap_Success(t *testing.T) {
+	mock := &mockMonitorAPI{
+		listMonitorsFunc: func(ctx context.Context) ([]client.Monitor, error) {
+			return []client.Monitor{
+				{UUID: "mon_abc123", ID: 115746},
+				{UUID: "mon_def456", ID: 115747},
+			}, nil
+		},
+	}
+
+	var diags diag.Diagnostics
+	result := buildMonitorIDToUUIDMap(context.Background(), mock, &diags)
+
+	if diags.HasError() || diags.WarningsCount() > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if result["115746"] != "mon_abc123" {
+		t.Errorf("expected mon_abc123 for 115746, got %q", result["115746"])
+	}
+	if result["115747"] != "mon_def456" {
+		t.Errorf("expected mon_def456 for 115747, got %q", result["115747"])
+	}
+}
+
+func TestBuildMonitorIDToUUIDMap_ErrorReturnsEmpty(t *testing.T) {
+	mock := &mockMonitorAPI{
+		listMonitorsFunc: func(ctx context.Context) ([]client.Monitor, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+
+	var diags diag.Diagnostics
+	result := buildMonitorIDToUUIDMap(context.Background(), mock, &diags)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map on error, got %d entries", len(result))
+	}
+	if diags.WarningsCount() != 1 {
+		t.Errorf("expected 1 warning, got %d", diags.WarningsCount())
+	}
+}
+
+func TestIsNumericString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"115746", true},
+		{"0", true},
+		{"mon_abc123", false},
+		{"", false},
+		{"12abc", false},
+		{"sp_xyz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isNumericString(tt.input); got != tt.want {
+				t.Errorf("isNumericString(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -389,12 +389,6 @@ func (r *StatusPageResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Translate UUIDs to numeric IDs for status page renderer compatibility
-	if len(createReq.Sections) > 0 {
-		uuidToID, _ := buildMonitorIDMaps(ctx, r.client, &resp.Diagnostics)
-		createReq.Sections = translateSectionsToNumericIDs(createReq.Sections, uuidToID)
-	}
-
 	// Create status page via API
 	statusPage, err := r.client.CreateStatusPage(ctx, *createReq)
 	if err != nil {
@@ -463,12 +457,6 @@ func (r *StatusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Translate UUIDs to numeric IDs for status page renderer compatibility
-	if len(updateReq.Sections) > 0 {
-		uuidToID, _ := buildMonitorIDMaps(ctx, r.client, &resp.Diagnostics)
-		updateReq.Sections = translateSectionsToNumericIDs(updateReq.Sections, uuidToID)
-	}
-
 	// Update status page via API
 	statusPage, err := r.client.UpdateStatusPage(ctx, state.ID.ValueString(), *updateReq)
 	if err != nil {
@@ -520,9 +508,14 @@ func (r *StatusPageResource) ImportState(ctx context.Context, req resource.Impor
 // It extracts configured languages from the model's settings to filter API response localized fields,
 // preventing drift from API auto-population of all supported languages.
 func (r *StatusPageResource) mapStatusPageToModel(ctx context.Context, sp *client.StatusPage, model *StatusPageResourceModel, diags *diag.Diagnostics) {
-	// Reverse-translate numeric IDs to UUIDs for TF state consistency
-	_, idToUUID := buildMonitorIDMaps(ctx, r.client, diags)
+	// Reverse-translate numeric IDs to UUIDs for TF state consistency.
+	// This handles legacy data where the provider previously sent numeric IDs
+	// to the API, which stored the service's own ID instead of the monitor ID.
+	idToUUID := buildMonitorIDToUUIDMap(ctx, r.client, diags)
 	translateStatusPageToUUIDs(sp, idToUUID)
+
+	// Warn if any services still have numeric UUIDs after translation
+	warnUnresolvedNumericUUIDs(sp, diags)
 
 	// Detect isProtected drift: the Hyperping admin UI can reset an internal
 	// isProtected flag to true via v1 writes, causing a "Sign In" wall even when


### PR DESCRIPTION
## Summary
- **Removes write-path UUID-to-numeric-ID translation** that caused all status page services to store the service's own numeric ID instead of the linked monitor UUID, resulting in orphaned entries with no live data
- **Adds read-time drift detection** that warns when services still have unresolved numeric UUIDs from legacy data
- Existing broken status pages (56 of 57) will **self-heal on next `terraform apply`**

## Root Cause
The provider translated `mon_xxx` UUIDs to v1 numeric IDs before sending to the API. The API then stored the service's own numeric ID in the `uuid` field (not the monitor's), and the reverse translation on read failed silently because that ID wasn't in the monitor map.

## Test plan
- [x] All 14 new unit tests pass (drift detection, read translation, edge cases)
- [x] `go build ./...` compiles
- [x] `go vet ./...` clean
- [x] `make lint` 0 issues
- [x] `go test -race ./internal/...` all pass
- [ ] CI green