### PR TITLE
fix(statuspage): remove read-path UUID reverse translation that masked drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`hyperping_statuspage`**: Removed read-path reverse translation that masked UUID drift.
+  The provider previously translated numeric IDs back to `mon_xxx` UUIDs during state refresh,
+  making `terraform plan` report "No changes" even when the API had broken numeric IDs.
+  State now stores raw API values, so plan correctly detects drift and triggers an apply to fix it.
+  Note: `show_uptime` and `show_response_times` may also drift on affected pages until the UUID
+  drift is fixed by apply (the boolean preservation keys on UUID, which won't match until fixed).
+- **`hyperping_statuspage`**: Data sources now also warn when services have numeric UUID drift.
+
 ## [1.4.4] - 2026-03-04
 
 ### Fixed

--- a/internal/client/models_statuspage.go
+++ b/internal/client/models_statuspage.go
@@ -73,9 +73,9 @@ type StatusPageSection struct {
 //   - an integer (e.g. 117122) when set via v1 admin UI or numeric ID workaround
 //   - absent entirely for group header entries (which have no top-level monitor)
 //
-// The provider sends mon_xxx UUIDs directly. Legacy data from older provider
-// versions (< 1.5.0) may still have numeric IDs, which are translated back to
-// UUIDs on read via buildMonitorIDToUUIDMap.
+// The provider sends mon_xxx UUIDs directly and stores raw API response values
+// in state. If the API returns numeric IDs (legacy drift), the plan engine
+// detects the diff against the config's mon_xxx UUIDs and triggers an apply.
 type StatusPageService struct {
 	ID                interface{}         `json:"id,omitempty"`
 	UUID              string              `json:"uuid,omitempty"`

--- a/internal/provider/statuspage_data_source.go
+++ b/internal/provider/statuspage_data_source.go
@@ -326,6 +326,7 @@ func (d *StatusPageDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 // mapStatusPageToModel maps API response to data source model.
 func (d *StatusPageDataSource) mapStatusPageToModel(sp *client.StatusPage, model *StatusPageDataSourceModel, resp *datasource.ReadResponse) {
+	warnUnresolvedNumericUUIDs(sp, &resp.Diagnostics)
 	commonFields := MapStatusPageCommonFields(sp, &resp.Diagnostics)
 	model.ID = commonFields.ID
 	model.Name = commonFields.Name

--- a/internal/provider/statuspage_id_translation.go
+++ b/internal/provider/statuspage_id_translation.go
@@ -4,7 +4,6 @@
 package provider
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,89 +13,11 @@ import (
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
 )
 
-// buildMonitorIDToUUIDMap fetches all monitors and builds a lookup map from
-// v1 numeric IDs (e.g. "115746") to UUID strings (e.g. "mon_abc123").
-// Used on the read path to translate numeric IDs in API responses back to UUIDs.
-// On error, adds a warning diagnostic and returns an empty map (graceful fallback).
-func buildMonitorIDToUUIDMap(ctx context.Context, apiClient client.MonitorAPI, diags *diag.Diagnostics) map[string]string {
-	idToUUID := make(map[string]string)
-
-	monitors, err := apiClient.ListMonitors(ctx)
-	if err != nil {
-		diags.AddWarning(
-			"Unable to fetch monitor list for ID translation",
-			fmt.Sprintf("Status page services may show numeric IDs instead of UUIDs: %s", err),
-		)
-		return idToUUID
-	}
-
-	for _, mon := range monitors {
-		if mon.UUID != "" && mon.ID != 0 {
-			idToUUID[strconv.Itoa(mon.ID)] = mon.UUID
-		}
-	}
-
-	return idToUUID
-}
-
-// translateStatusPageToUUIDs walks the StatusPage response and replaces numeric
-// ID strings with UUIDs in-place. This ensures Terraform always stores UUIDs
-// regardless of what the API returned.
-func translateStatusPageToUUIDs(sp *client.StatusPage, idToUUID map[string]string) {
-	if sp == nil || len(idToUUID) == 0 {
-		return
-	}
-
-	for i := range sp.Sections {
-		translateSectionServicesToUUIDs(sp.Sections[i].Services, idToUUID)
-	}
-}
-
-// translateSectionServicesToUUIDs translates services within a section from numeric IDs to UUIDs.
-func translateSectionServicesToUUIDs(services []client.StatusPageService, idToUUID map[string]string) {
-	for i := range services {
-		svc := &services[i]
-
-		// Check if UUID field is a numeric string that needs translation
-		if svc.UUID != "" {
-			if uuid, ok := idToUUID[svc.UUID]; ok {
-				svc.UUID = uuid
-			}
-		}
-
-		// Check if ID field is a numeric value that needs translation
-		idStr := serviceIDToNumericString(svc.ID)
-		if idStr != "" {
-			if uuid, ok := idToUUID[idStr]; ok {
-				svc.UUID = uuid
-			}
-		}
-
-		// Recurse into nested services
-		if len(svc.Services) > 0 {
-			translateSectionServicesToUUIDs(svc.Services, idToUUID)
-		}
-	}
-}
-
-// serviceIDToNumericString extracts a numeric string from the flexible ID field.
-func serviceIDToNumericString(id interface{}) string {
-	switch v := id.(type) {
-	case float64:
-		return fmt.Sprintf("%.0f", v)
-	case string:
-		if _, err := strconv.Atoi(v); err == nil {
-			return v
-		}
-	}
-	return ""
-}
-
-// warnUnresolvedNumericUUIDs checks for services that still have numeric UUIDs
-// after translation (i.e., the API returned a numeric ID that couldn't be mapped
-// to a mon_xxx UUID). This indicates legacy drift from older provider versions
-// that translated UUIDs to numeric IDs on write. The next terraform apply will
-// fix these by sending the correct mon_xxx UUIDs from the config.
+// warnUnresolvedNumericUUIDs checks for services that have numeric UUIDs
+// instead of mon_xxx format. This indicates the API stored a numeric ID
+// (legacy drift from older provider versions or API behavior). Since we
+// store raw API values in state, the plan engine will detect these as diffs
+// against the config's mon_xxx UUIDs and trigger an apply to fix them.
 func warnUnresolvedNumericUUIDs(sp *client.StatusPage, diags *diag.Diagnostics) {
 	if sp == nil {
 		return
@@ -109,17 +30,17 @@ func warnUnresolvedNumericUUIDs(sp *client.StatusPage, diags *diag.Diagnostics) 
 
 	if len(drifted) > 0 {
 		diags.AddWarning(
-			"Status page services have numeric UUIDs (legacy drift detected)",
+			"Status page services have numeric UUIDs (drift detected)",
 			fmt.Sprintf(
 				"Found %d service(s) with numeric UUIDs instead of mon_xxx format: %s. "+
-					"This was caused by an older provider version that translated UUIDs to numeric IDs. "+
+					"The API returned numeric IDs instead of monitor UUIDs. "+
 					"Run 'terraform apply' to fix — the provider will send the correct UUIDs from your config.",
 				len(drifted), strings.Join(drifted, ", ")),
 		)
 	}
 }
 
-// collectDriftedUUIDs recursively collects service UUIDs that are still numeric strings.
+// collectDriftedUUIDs recursively collects service UUIDs that are numeric strings.
 func collectDriftedUUIDs(services []client.StatusPageService, drifted *[]string) {
 	for _, svc := range services {
 		if svc.UUID != "" && isNumericString(svc.UUID) {

--- a/internal/provider/statuspage_id_translation_test.go
+++ b/internal/provider/statuspage_id_translation_test.go
@@ -4,8 +4,6 @@
 package provider
 
 import (
-	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -14,179 +12,14 @@ import (
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
 )
 
-// mockMonitorAPI implements client.MonitorAPI for testing buildMonitorIDToUUIDMap.
-type mockMonitorAPI struct {
-	listMonitorsFunc func(ctx context.Context) ([]client.Monitor, error)
-}
-
-func (m *mockMonitorAPI) ListMonitors(ctx context.Context) ([]client.Monitor, error) {
-	if m.listMonitorsFunc != nil {
-		return m.listMonitorsFunc(ctx)
-	}
-	return nil, nil
-}
-
-func (m *mockMonitorAPI) GetMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
-	return nil, nil
-}
-
-func (m *mockMonitorAPI) CreateMonitor(ctx context.Context, req client.CreateMonitorRequest) (*client.Monitor, error) {
-	return nil, nil
-}
-
-func (m *mockMonitorAPI) UpdateMonitor(ctx context.Context, uuid string, req client.UpdateMonitorRequest) (*client.Monitor, error) {
-	return nil, nil
-}
-
-func (m *mockMonitorAPI) DeleteMonitor(ctx context.Context, uuid string) error {
-	return nil
-}
-
-func (m *mockMonitorAPI) PauseMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
-	return nil, nil
-}
-
-func (m *mockMonitorAPI) ResumeMonitor(ctx context.Context, uuid string) (*client.Monitor, error) {
-	return nil, nil
-}
-
-func TestTranslateStatusPageToUUIDs_NumericString(t *testing.T) {
-	idToUUID := map[string]string{"115746": "mon_abc123"}
-
-	sp := &client.StatusPage{
-		Sections: []client.StatusPageSection{
-			{
-				Services: []client.StatusPageService{
-					{UUID: "115746", ID: float64(115746)},
-				},
-			},
-		},
-	}
-
-	translateStatusPageToUUIDs(sp, idToUUID)
-
-	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
-		t.Errorf("expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
-	}
-}
-
-func TestTranslateStatusPageToUUIDs_Float64ID(t *testing.T) {
-	idToUUID := map[string]string{"115746": "mon_abc123"}
-
-	sp := &client.StatusPage{
-		Sections: []client.StatusPageSection{
-			{
-				Services: []client.StatusPageService{
-					{UUID: "", ID: float64(115746)},
-				},
-			},
-		},
-	}
-
-	translateStatusPageToUUIDs(sp, idToUUID)
-
-	if sp.Sections[0].Services[0].UUID != "mon_abc123" {
-		t.Errorf("expected 'mon_abc123', got %q", sp.Sections[0].Services[0].UUID)
-	}
-}
-
-func TestTranslateStatusPageToUUIDs_NestedServices(t *testing.T) {
-	idToUUID := map[string]string{"115747": "mon_def456"}
-
-	sp := &client.StatusPage{
-		Sections: []client.StatusPageSection{
-			{
-				Services: []client.StatusPageService{
-					{
-						IsGroup: true,
-						Services: []client.StatusPageService{
-							{UUID: "115747", ID: float64(115747)},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	translateStatusPageToUUIDs(sp, idToUUID)
-
-	nested := sp.Sections[0].Services[0].Services[0]
-	if nested.UUID != "mon_def456" {
-		t.Errorf("expected 'mon_def456', got %q", nested.UUID)
-	}
-}
-
-func TestTranslateStatusPageToUUIDs_EmptyMap(t *testing.T) {
-	sp := &client.StatusPage{
-		Sections: []client.StatusPageSection{
-			{
-				Services: []client.StatusPageService{
-					{UUID: "115746", ID: float64(115746)},
-				},
-			},
-		},
-	}
-
-	translateStatusPageToUUIDs(sp, map[string]string{})
-
-	// Should remain unchanged
-	if sp.Sections[0].Services[0].UUID != "115746" {
-		t.Errorf("expected '115746' unchanged, got %q", sp.Sections[0].Services[0].UUID)
-	}
-}
-
-func TestTranslateStatusPageToUUIDs_AlreadyUUID(t *testing.T) {
-	idToUUID := map[string]string{"115746": "mon_abc123"}
-
-	sp := &client.StatusPage{
-		Sections: []client.StatusPageSection{
-			{
-				Services: []client.StatusPageService{
-					{UUID: "mon_xyz789"},
-				},
-			},
-		},
-	}
-
-	translateStatusPageToUUIDs(sp, idToUUID)
-
-	// Should remain unchanged — already a valid UUID
-	if sp.Sections[0].Services[0].UUID != "mon_xyz789" {
-		t.Errorf("expected 'mon_xyz789', got %q", sp.Sections[0].Services[0].UUID)
-	}
-}
-
-func TestServiceIDToNumericString(t *testing.T) {
-	tests := []struct {
-		name string
-		id   interface{}
-		want string
-	}{
-		{"float64", float64(115746), "115746"},
-		{"numeric string", "115746", "115746"},
-		{"uuid string", "mon_abc123", ""},
-		{"nil", nil, ""},
-		{"empty string", "", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := serviceIDToNumericString(tt.id)
-			if got != tt.want {
-				t.Errorf("serviceIDToNumericString(%v) = %q, want %q", tt.id, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestWarnUnresolvedNumericUUIDs_DetectsDrift(t *testing.T) {
 	sp := &client.StatusPage{
 		Sections: []client.StatusPageSection{
 			{
 				Services: []client.StatusPageService{
-					{UUID: "117896"}, // drifted
-					{UUID: "mon_abc123"},
-					{UUID: "118001"}, // drifted
+					{UUID: "117896"},     // drifted
+					{UUID: "mon_abc123"}, // correct
+					{UUID: "118001"},     // drifted
 				},
 			},
 		},
@@ -279,48 +112,6 @@ func TestWarnUnresolvedNumericUUIDs_EmptyUUIDSkipped(t *testing.T) {
 
 	if diags.WarningsCount() > 0 {
 		t.Errorf("expected no warnings, got %d", diags.WarningsCount())
-	}
-}
-
-func TestBuildMonitorIDToUUIDMap_Success(t *testing.T) {
-	mock := &mockMonitorAPI{
-		listMonitorsFunc: func(ctx context.Context) ([]client.Monitor, error) {
-			return []client.Monitor{
-				{UUID: "mon_abc123", ID: 115746},
-				{UUID: "mon_def456", ID: 115747},
-			}, nil
-		},
-	}
-
-	var diags diag.Diagnostics
-	result := buildMonitorIDToUUIDMap(context.Background(), mock, &diags)
-
-	if diags.HasError() || diags.WarningsCount() > 0 {
-		t.Fatalf("unexpected diagnostics: %v", diags)
-	}
-	if result["115746"] != "mon_abc123" {
-		t.Errorf("expected mon_abc123 for 115746, got %q", result["115746"])
-	}
-	if result["115747"] != "mon_def456" {
-		t.Errorf("expected mon_def456 for 115747, got %q", result["115747"])
-	}
-}
-
-func TestBuildMonitorIDToUUIDMap_ErrorReturnsEmpty(t *testing.T) {
-	mock := &mockMonitorAPI{
-		listMonitorsFunc: func(ctx context.Context) ([]client.Monitor, error) {
-			return nil, fmt.Errorf("connection refused")
-		},
-	}
-
-	var diags diag.Diagnostics
-	result := buildMonitorIDToUUIDMap(context.Background(), mock, &diags)
-
-	if len(result) != 0 {
-		t.Errorf("expected empty map on error, got %d entries", len(result))
-	}
-	if diags.WarningsCount() != 1 {
-		t.Errorf("expected 1 warning, got %d", diags.WarningsCount())
 	}
 }
 

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -507,14 +507,10 @@ func (r *StatusPageResource) ImportState(ctx context.Context, req resource.Impor
 // mapStatusPageToModel maps API response to Terraform model.
 // It extracts configured languages from the model's settings to filter API response localized fields,
 // preventing drift from API auto-population of all supported languages.
-func (r *StatusPageResource) mapStatusPageToModel(ctx context.Context, sp *client.StatusPage, model *StatusPageResourceModel, diags *diag.Diagnostics) {
-	// Reverse-translate numeric IDs to UUIDs for TF state consistency.
-	// This handles legacy data where the provider previously sent numeric IDs
-	// to the API, which stored the service's own ID instead of the monitor ID.
-	idToUUID := buildMonitorIDToUUIDMap(ctx, r.client, diags)
-	translateStatusPageToUUIDs(sp, idToUUID)
-
-	// Warn if any services still have numeric UUIDs after translation
+func (r *StatusPageResource) mapStatusPageToModel(_ context.Context, sp *client.StatusPage, model *StatusPageResourceModel, diags *diag.Diagnostics) {
+	// Warn if any services have numeric UUIDs (legacy drift from older provider versions).
+	// We intentionally do NOT translate numeric IDs back to UUIDs here — storing the raw
+	// API values lets the plan engine detect drift and trigger an apply that fixes the data.
 	warnUnresolvedNumericUUIDs(sp, diags)
 
 	// Detect isProtected drift: the Hyperping admin UI can reset an internal

--- a/internal/provider/statuspages_data_source.go
+++ b/internal/provider/statuspages_data_source.go
@@ -341,6 +341,7 @@ func (d *StatusPagesDataSource) Read(ctx context.Context, req datasource.ReadReq
 	// Map status pages to list
 	statusPages := make([]StatusPageCommonFields, len(filteredStatusPages))
 	for i, sp := range filteredStatusPages {
+		warnUnresolvedNumericUUIDs(&sp, &resp.Diagnostics)
 		statusPages[i] = MapStatusPageCommonFields(&sp, &resp.Diagnostics)
 	}
 


### PR DESCRIPTION
## Summary

- Removed the read-path reverse translation (`translateStatusPageToUUIDs`) that converted numeric IDs back to `mon_xxx` UUIDs during state refresh
- State now stores raw API values, so `terraform plan` correctly detects UUID drift on the 56 affected status pages and triggers an apply to fix them
- Added numeric UUID drift warnings to both `hyperping_statuspage` and `hyperping_statuspages` data sources
- Removed all dead translation code (~280 lines deleted)

## Context

v1.4.4 fixed the **write path** (stopped sending numeric IDs to the API). But the **read path** still had `buildMonitorIDToUUIDMap` + `translateStatusPageToUUIDs` which silently converted numeric IDs back to `mon_xxx` in state — masking the drift. `terraform plan` showed "No changes" even though status pages were visually broken.

### Self-healing lifecycle

1. First `plan` after upgrade → detects numeric UUIDs → shows drift + warning → triggers apply
2. `apply` → sends `mon_xxx` from config → API stores `mon_xxx` (passthrough)
3. Next `plan` → API returns `mon_xxx` → matches config → no changes

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make lint` — 0 issues
- [x] `go test ./internal/... -race -timeout=5m` — all pass