### PR TITLE
fix(statuspage): make hosted_subdomain optional

### DIFF
--- a/docs/resources/statuspage.md
+++ b/docs/resources/statuspage.md
@@ -166,12 +166,12 @@ output "status_page_id" {
 
 ### Required
 
-- `hosted_subdomain` (String) Hyperping-hosted subdomain (e.g., 'status' for status.hyperping.app)
 - `name` (String) Display name for the status page
 - `settings` (Attributes) Status page appearance and behavior settings (see [below for nested schema](#nestedatt--settings))
 
 ### Optional
 
+- `hosted_subdomain` (String) Hyperping-hosted subdomain (e.g., 'status' for status.hyperping.app). Optional when a custom `hostname` is set.
 - `hostname` (String) Custom domain for the status page (optional). If not provided, uses hosted subdomain.
 - `password` (String, Sensitive) Password for password-protected status pages. Set this along with `settings.authentication.password_protection = true` to require visitors to enter a password.
 - `sections` (Attributes List) Status page sections containing monitors/services (see [below for nested schema](#nestedatt--sections))

--- a/internal/provider/statuspage_mapping.go
+++ b/internal/provider/statuspage_mapping.go
@@ -66,15 +66,17 @@ func MapStatusPageCommonFieldsWithFilter(sp *client.StatusPage, configuredLangs 
 		}
 	}
 
-	// Normalize subdomain by stripping .hyperping.app suffix
-	// This ensures state matches the user's configuration
-	normalizedSubdomain := normalizeSubdomain(sp.HostedSubdomain)
-
 	result := StatusPageCommonFields{
-		ID:              types.StringValue(sp.UUID),
-		Name:            types.StringValue(sp.Name),
-		HostedSubdomain: types.StringValue(normalizedSubdomain),
-		URL:             types.StringValue(sp.URL),
+		ID:   types.StringValue(sp.UUID),
+		Name: types.StringValue(sp.Name),
+		URL:  types.StringValue(sp.URL),
+	}
+
+	// Handle optional hosted subdomain — null when empty (custom hostname only)
+	if sp.HostedSubdomain != "" {
+		result.HostedSubdomain = types.StringValue(normalizeSubdomain(sp.HostedSubdomain))
+	} else {
+		result.HostedSubdomain = types.StringNull()
 	}
 
 	// Handle optional hostname

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -78,8 +78,10 @@ func (r *StatusPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Computed:            true,
 			},
 			"hosted_subdomain": schema.StringAttribute{
-				MarkdownDescription: "Hyperping-hosted subdomain (e.g., 'status' for status.hyperping.app)",
-				Required:            true,
+				MarkdownDescription: "Hyperping-hosted subdomain (e.g., 'status' for status.hyperping.app). " +
+					"Optional when a custom `hostname` is set.",
+				Optional: true,
+				Computed: true,
 			},
 			"url": schema.StringAttribute{
 				MarkdownDescription: "Public URL of the status page (computed)",
@@ -650,8 +652,7 @@ func (r *StatusPageResource) buildCreateRequest(ctx context.Context, plan *Statu
 		Name: plan.Name.ValueString(),
 	}
 
-	subdomain := plan.HostedSubdomain.ValueString()
-	req.Subdomain = &subdomain
+	req.Subdomain = tfStringToPtr(plan.HostedSubdomain)
 
 	req.Hostname = extractOptionalStringPtr(plan.Hostname)
 	req.Password = extractOptionalStringPtr(plan.Password)


### PR DESCRIPTION
The Hyperping API accepts subdomain as optional on both POST and PUT. When a custom hostname is set, the subdomain is not needed. Previously the provider required it unconditionally, preventing users from removing the *.hyperping.app subdomain after setting a custom domain.

Changes:
- Schema: hosted_subdomain changed from Required to Optional+Computed
- Create path: use tfStringToPtr (sends null when omitted)
- Read path: return null when API returns empty subdomain

## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
