### PR TITLE
fix(scraper): prevent false positive API change issues

### DIFF
--- a/tools/cmd/scraper/diff/diff.go
+++ b/tools/cmd/scraper/diff/diff.go
@@ -18,8 +18,10 @@ import (
 
 // Result contains the outcome of comparing two OpenAPI specs.
 type Result struct {
-	// HasChanges is true when any diff was detected.
+	// HasChanges is true when any diff was detected (including metadata-only).
 	HasChanges bool
+	// HasPathChanges is true when endpoint-level changes exist (added/deleted/modified paths).
+	HasPathChanges bool
 	// Breaking is true when at least one breaking change is detected.
 	Breaking bool
 	// Summary is a human-readable markdown description of the changes.
@@ -54,10 +56,14 @@ func Compare(basePath, currPath string) (*Result, error) {
 
 	changes := checker.CheckBackwardCompatibility(checker.NewConfig(checker.GetAllChecks()), d, sources)
 
+	hasPathChanges := d.PathsDiff != nil &&
+		(len(d.PathsDiff.Added) > 0 || len(d.PathsDiff.Deleted) > 0 || len(d.PathsDiff.Modified) > 0)
+
 	return &Result{
-		HasChanges: true,
-		Breaking:   changes.HasLevelOrHigher(checker.ERR),
-		Summary:    FormatMarkdown(d),
+		HasChanges:     true,
+		HasPathChanges: hasPathChanges,
+		Breaking:       changes.HasLevelOrHigher(checker.ERR),
+		Summary:        FormatMarkdown(d),
 	}, nil
 }
 

--- a/tools/cmd/scraper/diff/diff_test.go
+++ b/tools/cmd/scraper/diff/diff_test.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -442,4 +443,118 @@ func TestFormatMarkdown_MultiplePathsSorted(t *testing.T) {
 	if !(idx1 < idx2 && idx2 < idx3) {
 		t.Errorf("expected paths in alphabetical order, got indices: healthchecks=%d, monitors=%d, monitors/{uuid}=%d", idx1, idx2, idx3)
 	}
+}
+
+// TestCompare_MetadataOnlyChange verifies that HasPathChanges is false when
+// diffs are metadata-only (e.g. info/description changed, no path changes).
+// This was the root cause of false positive "API Change Detected" issues.
+func TestCompare_MetadataOnlyChange(t *testing.T) {
+	base := t.TempDir() + "/base.yaml"
+	curr := t.TempDir() + "/curr.yaml"
+
+	baseSpec := `openapi: "3.0.0"
+info:
+  title: "Test API"
+  version: "1.0.0"
+  description: "Original description"
+paths:
+  /monitors:
+    get:
+      summary: "List monitors"
+      responses:
+        "200":
+          description: "OK"
+`
+	// Only the info description changed — no path changes.
+	currSpec := `openapi: "3.0.0"
+info:
+  title: "Test API"
+  version: "1.0.1"
+  description: "Updated description"
+paths:
+  /monitors:
+    get:
+      summary: "List monitors"
+      responses:
+        "200":
+          description: "OK"
+`
+	if err := writeFile(base, baseSpec); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile(curr, currSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Compare(base, curr)
+	if err != nil {
+		t.Fatalf("Compare failed: %v", err)
+	}
+
+	if !result.HasChanges {
+		t.Error("expected HasChanges=true for metadata diff")
+	}
+	if result.HasPathChanges {
+		t.Error("expected HasPathChanges=false for metadata-only diff")
+	}
+}
+
+// TestCompare_PathLevelChange verifies HasPathChanges is true when endpoints change.
+func TestCompare_PathLevelChange(t *testing.T) {
+	base := t.TempDir() + "/base.yaml"
+	curr := t.TempDir() + "/curr.yaml"
+
+	baseSpec := `openapi: "3.0.0"
+info:
+  title: "Test API"
+  version: "1.0.0"
+paths:
+  /monitors:
+    get:
+      summary: "List monitors"
+      responses:
+        "200":
+          description: "OK"
+`
+	// Added a new endpoint.
+	currSpec := `openapi: "3.0.0"
+info:
+  title: "Test API"
+  version: "1.0.0"
+paths:
+  /monitors:
+    get:
+      summary: "List monitors"
+      responses:
+        "200":
+          description: "OK"
+  /healthchecks:
+    get:
+      summary: "List healthchecks"
+      responses:
+        "200":
+          description: "OK"
+`
+	if err := writeFile(base, baseSpec); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile(curr, currSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Compare(base, curr)
+	if err != nil {
+		t.Fatalf("Compare failed: %v", err)
+	}
+
+	if !result.HasChanges {
+		t.Error("expected HasChanges=true")
+	}
+	if !result.HasPathChanges {
+		t.Error("expected HasPathChanges=true for added endpoint")
+	}
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0600)
 }

--- a/tools/cmd/scraper/main.go
+++ b/tools/cmd/scraper/main.go
@@ -185,7 +185,11 @@ func runScrape(ctx context.Context) int {
 		} else if result.HasChanges {
 			log.Println("\n📝 API changes detected:")
 			fmt.Println(result.Summary)
-			notifyAPIChange(result)
+			if result.HasPathChanges {
+				notifyAPIChange(result)
+			} else {
+				log.Println("   ⏭️  Metadata-only changes — skipping GitHub issue creation")
+			}
 		} else {
 			log.Println("\n✅ No API changes detected")
 		}


### PR DESCRIPTION
## Summary

- Add `HasPathChanges` field to `diff.Result` to distinguish real endpoint changes from metadata-only diffs (info version/description)
- Only create GitHub issues when actual path-level changes exist (added/deleted/modified endpoints)
- Metadata-only changes are logged but no issue is created
- Add tests for both metadata-only and path-level change scenarios

**Root cause**: oasdiff `d.Empty()` returns `false` for metadata changes even when no endpoints changed, causing the scraper to create issues with "No path-level changes" body.

Closes #69, Closes #71

## Test plan
- [x] All existing diff tests pass (19/19)
- [x] New `TestCompare_MetadataOnlyChange` verifies `HasPathChanges=false` for info-only diff
- [x] New `TestCompare_PathLevelChange` verifies `HasPathChanges=true` for added endpoint
- [x] `go vet`, `golangci-lint`, `govulncheck` all clean