### PR TITLE
fix(ci): use read-only cache restore for API sync check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,16 +262,17 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Restore scraper snapshots
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Restore scraper snapshots (read-only)
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
             tools/cmd/scraper/.scraper_cache.json
             tools/cmd/scraper/snapshots/
             tools/cmd/scraper/docs_scraped/
-          key: scraper-data-${{ hashFiles('tools/cmd/scraper/snapshots/**') }}
+          key: scraper-data-sync-${{ github.sha }}
           restore-keys: |
             scraper-data-
+            scraper-snapshots-
 
       - name: Build scraper
         working-directory: tools/cmd/scraper


### PR DESCRIPTION
## Summary

- Switch sync-check snapshot cache from `actions/cache` to `actions/cache/restore` (read-only)
- Use a unique key (`scraper-data-sync-${{ github.sha }}`) to force prefix-matching against the latest scraper workflow cache
- Add `scraper-snapshots-` as fallback restore-key for api-drift.yml caches
- Deleted stale `scraper-data-` cache entry (created Feb 5) that was blocking prefix fallback

**Root cause**: `hashFiles('tools/cmd/scraper/snapshots/**')` returns empty string since snapshots aren't in the repo, making the key exactly `scraper-data-`. This exactly matched a stale Feb 5 cache entry with no valid snapshots, bypassing the prefix fallback that would have found the latest scraper output. Additionally, `actions/cache` would re-save this stale entry, perpetuating the problem.

## Test plan
- [x] CI should now restore snapshots from latest scraper run and run the actual sync check
- [x] Warning annotation should no longer appear