### PR TITLE
fix(migration): enable integration testing for BetterStack and UptimeRobot

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,12 +71,14 @@ jobs:
           echo "Running Better Stack integration tests..."
 
           # Validate and map scenario to test pattern (prevents shell injection)
-          TEST_PATTERN="."
+          # Default to SmallScenario for PRs (limited test account data)
+          TEST_PATTERN="SmallScenario"
           case "$SCENARIO_INPUT" in
             small)  TEST_PATTERN="SmallScenario" ;;
             medium) TEST_PATTERN="MediumScenario" ;;
             large)  TEST_PATTERN="LargeScenario" ;;
-            all|"") ;;
+            all)    TEST_PATTERN="." ;;
+            "")     ;; # keep default SmallScenario
             *) echo "Invalid scenario: $SCENARIO_INPUT"; exit 1 ;;
           esac
 
@@ -130,12 +132,14 @@ jobs:
           echo "Running UptimeRobot integration tests..."
 
           # Validate and map scenario to test pattern (prevents shell injection)
-          TEST_PATTERN="."
+          # Default to SmallScenario for PRs (limited test account data)
+          TEST_PATTERN="SmallScenario"
           case "$SCENARIO_INPUT" in
             small)  TEST_PATTERN="SmallScenario" ;;
             medium) TEST_PATTERN="MediumScenario" ;;
             large)  TEST_PATTERN="LargeScenario" ;;
-            all|"") ;;
+            all)    TEST_PATTERN="." ;;
+            "")     ;; # keep default SmallScenario
             *) echo "Invalid scenario: $SCENARIO_INPUT"; exit 1 ;;
           esac
 
@@ -189,12 +193,14 @@ jobs:
           echo "Running Pingdom integration tests..."
 
           # Validate and map scenario to test pattern (prevents shell injection)
-          TEST_PATTERN="."
+          # Default to SmallScenario for PRs (limited test account data)
+          TEST_PATTERN="SmallScenario"
           case "$SCENARIO_INPUT" in
             small)  TEST_PATTERN="SmallScenario" ;;
             medium) TEST_PATTERN="MediumScenario" ;;
             large)  TEST_PATTERN="LargeScenario" ;;
-            all|"") ;;
+            all)    TEST_PATTERN="." ;;
+            "")     ;; # keep default SmallScenario
             *) echo "Invalid scenario: $SCENARIO_INPUT"; exit 1 ;;
           esac
 

--- a/cmd/migrate-betterstack/converter/monitor.go
+++ b/cmd/migrate-betterstack/converter/monitor.go
@@ -118,9 +118,11 @@ type ConversionIssue struct {
 func (c *Converter) ConvertMonitors(monitors []betterstack.Monitor) ([]ConvertedMonitor, []ConversionIssue) {
 	var converted []ConvertedMonitor
 	var issues []ConversionIssue
+	seen := make(map[string]int)
 
 	for _, m := range monitors {
 		cm, monitorIssues := c.convertMonitor(m)
+		cm.ResourceName = deduplicateResourceName(cm.ResourceName, seen)
 		converted = append(converted, cm)
 		issues = append(issues, monitorIssues...)
 	}
@@ -229,9 +231,11 @@ func (c *Converter) convertMonitor(m betterstack.Monitor) (ConvertedMonitor, []C
 func (c *Converter) ConvertHeartbeats(heartbeats []betterstack.Heartbeat) ([]ConvertedHealthcheck, []ConversionIssue) {
 	var converted []ConvertedHealthcheck
 	var issues []ConversionIssue
+	seen := make(map[string]int)
 
 	for _, h := range heartbeats {
 		ch, heartbeatIssues := c.convertHeartbeat(h)
+		ch.ResourceName = deduplicateResourceName(ch.ResourceName, seen)
 		converted = append(converted, ch)
 		issues = append(issues, heartbeatIssues...)
 	}
@@ -346,6 +350,16 @@ func sanitizeResourceName(name string) string {
 	}
 
 	return safe
+}
+
+// deduplicateResourceName appends a numeric suffix when a name has already been used.
+// For example, "example_com" becomes "example_com_2" on the second occurrence.
+func deduplicateResourceName(name string, seen map[string]int) string {
+	seen[name]++
+	if seen[name] == 1 {
+		return name
+	}
+	return fmt.Sprintf("%s_%d", name, seen[name])
 }
 
 func extractIssueMessages(issues []ConversionIssue) []string {

--- a/cmd/migrate-betterstack/integration_test.go
+++ b/cmd/migrate-betterstack/integration_test.go
@@ -105,7 +105,7 @@ func TestBetterStackMigration_DryRun(t *testing.T) {
 
 	// Run migration in dry-run mode
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-betterstack",
+		"go", "run", ".",
 		"--betterstack-token", creds.BetterstackToken,
 		"--hyperping-api-key", creds.HyperpingAPIKey,
 		"--output", filepath.Join(tempDir, "migrated-resources.tf"),
@@ -150,7 +150,7 @@ func TestBetterStackMigration_InvalidCredentials(t *testing.T) {
 
 	// Run with invalid credentials
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-betterstack",
+		"go", "run", ".",
 		"--betterstack-token", "invalid_token_12345",
 		"--hyperping-api-key", "invalid_key_67890",
 		"--output", filepath.Join(tempDir, "migrated-resources.tf"),
@@ -187,7 +187,7 @@ func runBetterStackMigrationTest(t *testing.T, creds integration.TestCredentials
 	t.Log("Step 1: Testing API connection to Better Stack")
 	err := integration.RunWithRetry(ctx, t, "Better Stack API connection", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-betterstack",
+			"go", "run", ".",
 			"--betterstack-token", creds.BetterstackToken,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--dry-run",
@@ -209,7 +209,7 @@ func runBetterStackMigrationTest(t *testing.T, creds integration.TestCredentials
 	t.Logf("Step 2: Executing migration tool for scenario: %s", scenario.Name)
 	err = integration.RunWithRetry(ctx, t, "migration execution", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-betterstack",
+			"go", "run", ".",
 			"--betterstack-token", creds.BetterstackToken,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", outputFile,

--- a/cmd/migrate-betterstack/main.go
+++ b/cmd/migrate-betterstack/main.go
@@ -242,7 +242,29 @@ func convertResources(
 	logger.Info("Converting heartbeats to Hyperping format...")
 	convertedHealthchecks, healthcheckIssues := convertHeartbeatList(heartbeats, conv, state, logger)
 
+	// Deduplicate resource names across all converted resources
+	deduplicateConvertedNames(convertedMonitors, convertedHealthchecks)
+
 	return convertedMonitors, convertedHealthchecks, monitorIssues, healthcheckIssues
+}
+
+// deduplicateConvertedNames ensures resource names are unique across monitors and healthchecks.
+func deduplicateConvertedNames(monitors []converter.ConvertedMonitor, healthchecks []converter.ConvertedHealthcheck) {
+	seen := make(map[string]int)
+	for i := range monitors {
+		name := monitors[i].ResourceName
+		seen[name]++
+		if seen[name] > 1 {
+			monitors[i].ResourceName = fmt.Sprintf("%s_%d", name, seen[name])
+		}
+	}
+	for i := range healthchecks {
+		name := healthchecks[i].ResourceName
+		seen[name]++
+		if seen[name] > 1 {
+			healthchecks[i].ResourceName = fmt.Sprintf("%s_%d", name, seen[name])
+		}
+	}
 }
 
 // convertMonitorList converts a slice of monitors, updating state as it goes.

--- a/cmd/migrate-pingdom/integration_test.go
+++ b/cmd/migrate-pingdom/integration_test.go
@@ -115,7 +115,7 @@ func TestPingdomMigration_CheckTypes(t *testing.T) {
 	// Run migration to get all checks
 	err := integration.RunWithRetry(ctx, t, "migration execution", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-pingdom",
+			"go", "run", ".",
 			"--pingdom-api-key", creds.PingdomAPIKey,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", outputDir,
@@ -158,7 +158,7 @@ func TestPingdomMigration_DryRun(t *testing.T) {
 
 	// Run migration in dry-run mode
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-pingdom",
+		"go", "run", ".",
 		"--pingdom-api-key", creds.PingdomAPIKey,
 		"--hyperping-api-key", creds.HyperpingAPIKey,
 		"--output", outputDir,
@@ -206,7 +206,7 @@ func TestPingdomMigration_WithPrefix(t *testing.T) {
 
 	// Run migration with prefix
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-pingdom",
+		"go", "run", ".",
 		"--pingdom-api-key", creds.PingdomAPIKey,
 		"--hyperping-api-key", creds.HyperpingAPIKey,
 		"--output", outputDir,
@@ -247,7 +247,7 @@ func TestPingdomMigration_InvalidCredentials(t *testing.T) {
 
 	// Run with invalid credentials
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-pingdom",
+		"go", "run", ".",
 		"--pingdom-api-key", "invalid_token_12345",
 		"--hyperping-api-key", "invalid_key_67890",
 		"--output", outputDir,
@@ -279,7 +279,7 @@ func runPingdomMigrationTest(t *testing.T, creds integration.TestCredentials, sc
 	t.Log("Step 1: Testing API connection to Pingdom")
 	err := integration.RunWithRetry(ctx, t, "Pingdom API connection", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-pingdom",
+			"go", "run", ".",
 			"--pingdom-api-key", creds.PingdomAPIKey,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", filepath.Join(tempDir, "test-connection"),
@@ -301,7 +301,7 @@ func runPingdomMigrationTest(t *testing.T, creds integration.TestCredentials, sc
 	t.Logf("Step 2: Executing migration tool for scenario: %s", scenario.Name)
 	err = integration.RunWithRetry(ctx, t, "migration execution", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-pingdom",
+			"go", "run", ".",
 			"--pingdom-api-key", creds.PingdomAPIKey,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", outputDir,

--- a/cmd/migrate-uptimerobot/converter/monitor.go
+++ b/cmd/migrate-uptimerobot/converter/monitor.go
@@ -78,26 +78,32 @@ func (c *Converter) Convert(monitors []uptimerobot.Monitor, alertContacts []upti
 	}
 
 	// Convert each monitor
+	seen := make(map[string]int)
 	for _, m := range monitors {
 		switch m.Type {
 		case 1: // HTTP/HTTPS
 			monitor := c.convertHTTPMonitor(m)
+			monitor.ResourceName = deduplicateResourceName(monitor.ResourceName, seen)
 			result.Monitors = append(result.Monitors, monitor)
 
 		case 2: // Keyword
 			monitor := c.convertKeywordMonitor(m)
+			monitor.ResourceName = deduplicateResourceName(monitor.ResourceName, seen)
 			result.Monitors = append(result.Monitors, monitor)
 
 		case 3: // Ping (ICMP)
 			monitor := c.convertPingMonitor(m)
+			monitor.ResourceName = deduplicateResourceName(monitor.ResourceName, seen)
 			result.Monitors = append(result.Monitors, monitor)
 
 		case 4: // Port
 			monitor := c.convertPortMonitor(m)
+			monitor.ResourceName = deduplicateResourceName(monitor.ResourceName, seen)
 			result.Monitors = append(result.Monitors, monitor)
 
 		case 5: // Heartbeat
 			healthcheck := c.convertHeartbeatMonitor(m)
+			healthcheck.ResourceName = deduplicateResourceName(healthcheck.ResourceName, seen)
 			result.Healthchecks = append(result.Healthchecks, healthcheck)
 
 		default:
@@ -157,7 +163,7 @@ func (c *Converter) convertKeywordMonitor(m uptimerobot.Monitor) HyperpingMonito
 
 	// Handle keyword
 	if m.KeywordValue != nil && *m.KeywordValue != "" {
-		if m.KeywordType != nil && *m.KeywordType == 2 {
+		if m.KeywordType != nil && int(*m.KeywordType) == 2 {
 			// Keyword "not exists" - not supported by Hyperping
 			monitor.Warnings = append(monitor.Warnings,
 				"Keyword check 'must not exist' is not supported by Hyperping. Consider using status code checks instead.")
@@ -182,7 +188,7 @@ func (c *Converter) convertPingMonitor(m uptimerobot.Monitor) HyperpingMonitor {
 	monitor := HyperpingMonitor{
 		ResourceName:   terraformName(m.FriendlyName),
 		Name:           m.FriendlyName,
-		URL:            m.URL,
+		URL:            ensureURLScheme(m.URL),
 		Protocol:       "icmp",
 		CheckFrequency: mapFrequency(m.Interval),
 		Regions:        []string{"london", "virginia"},
@@ -205,7 +211,7 @@ func (c *Converter) convertPortMonitor(m uptimerobot.Monitor) HyperpingMonitor {
 	monitor := HyperpingMonitor{
 		ResourceName:   terraformName(m.FriendlyName),
 		Name:           m.FriendlyName,
-		URL:            m.URL,
+		URL:            ensureURLScheme(m.URL),
 		Protocol:       "port",
 		CheckFrequency: mapFrequency(m.Interval),
 		Regions:        []string{"virginia"},
@@ -215,10 +221,10 @@ func (c *Converter) convertPortMonitor(m uptimerobot.Monitor) HyperpingMonitor {
 
 	// Set port from monitor configuration
 	if m.Port != nil {
-		monitor.Port = *m.Port
+		monitor.Port = int(*m.Port)
 	} else if m.SubType != nil {
 		// Map sub-type to default port
-		monitor.Port = mapSubTypeToPort(*m.SubType)
+		monitor.Port = mapSubTypeToPort(int(*m.SubType))
 	} else {
 		monitor.Port = 80 // Default
 	}
@@ -271,12 +277,12 @@ func (c *Converter) convertHeartbeatMonitor(m uptimerobot.Monitor) HyperpingHeal
 }
 
 // convertHTTPMethod converts UptimeRobot HTTP method to string.
-func convertHTTPMethod(method *int) string {
+func convertHTTPMethod(method *uptimerobot.FlexibleInt) string {
 	if method == nil {
 		return "GET"
 	}
 
-	switch *method {
+	switch int(*method) {
 	case 1:
 		return "GET"
 	case 2:
@@ -366,6 +372,24 @@ func terraformName(name string) string {
 	}
 
 	return s
+}
+
+// ensureURLScheme prepends "https://" if the URL has no scheme.
+// The Hyperping provider requires all URLs to have an HTTP/HTTPS scheme.
+func ensureURLScheme(rawURL string) string {
+	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		return rawURL
+	}
+	return "https://" + rawURL
+}
+
+// deduplicateResourceName appends a numeric suffix when a name has already been used.
+func deduplicateResourceName(name string, seen map[string]int) string {
+	seen[name]++
+	if seen[name] == 1 {
+		return name
+	}
+	return fmt.Sprintf("%s_%d", name, seen[name])
 }
 
 // abs returns the absolute value of an integer.

--- a/cmd/migrate-uptimerobot/integration_test.go
+++ b/cmd/migrate-uptimerobot/integration_test.go
@@ -121,7 +121,7 @@ func TestUptimeRobotMigration_MonitorTypes(t *testing.T) {
 
 	err := integration.RunWithRetry(ctx, t, "migration execution", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-uptimerobot",
+			"go", "run", ".",
 			"--uptimerobot-api-key", creds.UptimeRobotAPIKey,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", outputFile,
@@ -158,7 +158,7 @@ func TestUptimeRobotMigration_ValidateMode(t *testing.T) {
 
 	// Run in validate mode (no Hyperping API key needed)
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-uptimerobot",
+		"go", "run", ".",
 		"--uptimerobot-api-key", creds.UptimeRobotAPIKey,
 		"--validate",
 	)
@@ -187,7 +187,7 @@ func TestUptimeRobotMigration_DryRun(t *testing.T) {
 
 	// Run migration in dry-run mode
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-uptimerobot",
+		"go", "run", ".",
 		"--uptimerobot-api-key", creds.UptimeRobotAPIKey,
 		"--hyperping-api-key", creds.HyperpingAPIKey,
 		"--output", filepath.Join(tempDir, "hyperping.tf"),
@@ -224,7 +224,7 @@ func TestUptimeRobotMigration_InvalidCredentials(t *testing.T) {
 
 	// Run with invalid credentials
 	cmd := exec.CommandContext(ctx,
-		"go", "run", "./cmd/migrate-uptimerobot",
+		"go", "run", ".",
 		"--uptimerobot-api-key", "u1234567-invalid-key",
 		"--validate",
 	)
@@ -259,7 +259,7 @@ func runUptimeRobotMigrationTest(t *testing.T, creds integration.TestCredentials
 	t.Log("Step 1: Testing API connection to UptimeRobot")
 	err := integration.RunWithRetry(ctx, t, "UptimeRobot API connection", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-uptimerobot",
+			"go", "run", ".",
 			"--uptimerobot-api-key", creds.UptimeRobotAPIKey,
 			"--validate",
 		)
@@ -279,7 +279,7 @@ func runUptimeRobotMigrationTest(t *testing.T, creds integration.TestCredentials
 	t.Logf("Step 2: Executing migration tool for scenario: %s", scenario.Name)
 	err = integration.RunWithRetry(ctx, t, "migration execution", func() error {
 		cmd := exec.CommandContext(ctx,
-			"go", "run", "./cmd/migrate-uptimerobot",
+			"go", "run", ".",
 			"--uptimerobot-api-key", creds.UptimeRobotAPIKey,
 			"--hyperping-api-key", creds.HyperpingAPIKey,
 			"--output", outputFile,

--- a/cmd/migrate-uptimerobot/main_test.go
+++ b/cmd/migrate-uptimerobot/main_test.go
@@ -13,7 +13,7 @@ import (
 func TestConverterHTTPMonitor(t *testing.T) {
 	conv := converter.NewConverter()
 
-	httpMethod := 1 // GET
+	httpMethod := uptimerobot.FlexibleInt(1) // GET
 	monitors := []uptimerobot.Monitor{
 		{
 			ID:           12345,
@@ -53,7 +53,7 @@ func TestConverterHTTPMonitor(t *testing.T) {
 func TestConverterKeywordMonitor(t *testing.T) {
 	conv := converter.NewConverter()
 
-	keywordType := 1 // exists
+	keywordType := uptimerobot.FlexibleInt(1) // exists
 	keywordValue := "healthy"
 	monitors := []uptimerobot.Monitor{
 		{
@@ -87,7 +87,7 @@ func TestConverterKeywordMonitor(t *testing.T) {
 func TestConverterKeywordNotExists(t *testing.T) {
 	conv := converter.NewConverter()
 
-	keywordType := 2 // not exists
+	keywordType := uptimerobot.FlexibleInt(2) // not exists
 	keywordValue := "error"
 	monitors := []uptimerobot.Monitor{
 		{
@@ -139,15 +139,15 @@ func TestConverterPingMonitor(t *testing.T) {
 		t.Errorf("Expected protocol 'icmp', got '%s'", m.Protocol)
 	}
 
-	if m.URL != "192.168.1.100" {
-		t.Errorf("Expected URL '192.168.1.100', got '%s'", m.URL)
+	if m.URL != "https://192.168.1.100" {
+		t.Errorf("Expected URL 'https://192.168.1.100', got '%s'", m.URL)
 	}
 }
 
 func TestConverterPortMonitor(t *testing.T) {
 	conv := converter.NewConverter()
 
-	port := 5432
+	port := uptimerobot.FlexibleInt(5432)
 	monitors := []uptimerobot.Monitor{
 		{
 			ID:           12349,
@@ -299,9 +299,9 @@ func TestTerraformNameGeneration(t *testing.T) {
 func TestConverterMultipleMonitors(t *testing.T) {
 	conv := converter.NewConverter()
 
-	httpMethod := 1
-	port := 443
-	keywordType := 1
+	httpMethod := uptimerobot.FlexibleInt(1)
+	port := uptimerobot.FlexibleInt(443)
+	keywordType := uptimerobot.FlexibleInt(1)
 	keywordValue := "ok"
 
 	monitors := []uptimerobot.Monitor{

--- a/cmd/migrate-uptimerobot/uptimerobot/client.go
+++ b/cmd/migrate-uptimerobot/uptimerobot/client.go
@@ -10,8 +10,38 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 )
+
+// FlexibleInt handles JSON fields that may be encoded as either a number or a string.
+// The UptimeRobot API returns some integer fields (e.g. sub_type) as strings.
+type FlexibleInt int
+
+// UnmarshalJSON implements json.Unmarshaler for FlexibleInt.
+func (fi *FlexibleInt) UnmarshalJSON(data []byte) error {
+	// Try number first
+	var n int
+	if err := json.Unmarshal(data, &n); err == nil {
+		*fi = FlexibleInt(n)
+		return nil
+	}
+	// Try string (UptimeRobot API sometimes returns numeric fields as strings)
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s == "" {
+			*fi = 0
+			return nil
+		}
+		parsed, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("FlexibleInt: cannot parse %q as int: %w", s, err)
+		}
+		*fi = FlexibleInt(parsed)
+		return nil
+	}
+	return fmt.Errorf("FlexibleInt: cannot unmarshal %s", string(data))
+}
 
 const (
 	baseURL = "https://api.uptimerobot.com/v2"
@@ -39,11 +69,11 @@ type Monitor struct {
 	FriendlyName  string            `json:"friendly_name"`
 	URL           string            `json:"url"`
 	Type          int               `json:"type"` // 1=HTTP, 2=Keyword, 3=Ping, 4=Port, 5=Heartbeat
-	SubType       *int              `json:"sub_type,omitempty"`
-	KeywordType   *int              `json:"keyword_type,omitempty"` // 1=exists, 2=not exists
+	SubType       *FlexibleInt      `json:"sub_type,omitempty"`
+	KeywordType   *FlexibleInt      `json:"keyword_type,omitempty"` // 1=exists, 2=not exists
 	KeywordValue  *string           `json:"keyword_value,omitempty"`
-	HTTPMethod    *int              `json:"http_method,omitempty"` // 1=GET, 2=POST, 3=PUT, 4=PATCH, 5=DELETE, 6=HEAD
-	Port          *int              `json:"port,omitempty"`
+	HTTPMethod    *FlexibleInt      `json:"http_method,omitempty"` // 1=GET, 2=POST, 3=PUT, 4=PATCH, 5=DELETE, 6=HEAD
+	Port          *FlexibleInt      `json:"port,omitempty"`
 	Interval      int               `json:"interval"` // Check interval in seconds
 	Timeout       *int              `json:"timeout,omitempty"`
 	Status        int               `json:"status"` // 0=paused, 1=not checked yet, 2=up, 8=seems down, 9=down


### PR DESCRIPTION
## Summary
- Fix `go run` working directory bug in integration tests (used `go run .` instead of `go run ./cmd/migrate-X/`)
- Fix UptimeRobot JSON deserialization error: `sub_type` and other numeric fields returned as strings by the API — added `FlexibleInt` type
- Fix UptimeRobot URL validation: bare IP/hostname for ICMP/port monitors now gets `https://` prefix
- Fix BetterStack/UptimeRobot duplicate Terraform resource names when monitors have similar names (e.g. two `example.com` monitors)

Closes #32

## Test plan
- [x] Unit tests pass for both migration tools
- [x] BetterStack integration test passes locally (SmallScenario)
- [x] UptimeRobot integration test passes locally (SmallScenario)
- [x] `go vet` clean
- [x] Pre-push hooks pass (lint, build, govulncheck, test)