### PR TITLE
refactor: extract shared migration utilities to pkg/migrate

### DIFF
--- a/cmd/migrate-betterstack/converter/monitor.go
+++ b/cmd/migrate-betterstack/converter/monitor.go
@@ -12,8 +12,8 @@ import (
 
 // Converter handles conversion from Better Stack to Hyperping format.
 type Converter struct {
-	// frequencyMap provides exact mappings for known BetterStack frequencies.
-	// Values not in this map fall back to nearest-match via migrate.MapFrequency.
+	// frequencyMap provides BetterStack-specific overrides where the desired
+	// mapping differs from migrate.MapFrequency's nearest-match behavior.
 	frequencyMap map[int]int
 	protocolMap  map[string]string
 }
@@ -22,24 +22,8 @@ type Converter struct {
 func New() *Converter {
 	return &Converter{
 		frequencyMap: map[int]int{
-			10:    10,
-			20:    20,
-			30:    30,
-			45:    60, // Round 45s to 60s
-			60:    60,
-			90:    60, // Round 90s to 60s
-			120:   120,
-			180:   180,
-			240:   300, // Round 4min to 5min
-			300:   300,
-			600:   600,
-			900:   600, // Round 15min to 10min
-			1800:  1800,
-			3600:  3600,
-			7200:  3600, // Round 2hr to 1hr
-			21600: 21600,
-			43200: 43200,
-			86400: 86400,
+			45:  60,  // BetterStack rounds up to 60s (MapFrequency would pick 30s)
+			240: 300, // BetterStack rounds up to 5min (MapFrequency would pick 3min)
 		},
 		protocolMap: map[string]string{
 			"status":    "http",

--- a/cmd/migrate-betterstack/converter/monitor.go
+++ b/cmd/migrate-betterstack/converter/monitor.go
@@ -5,15 +5,15 @@ package converter
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-betterstack/betterstack"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // Converter handles conversion from Better Stack to Hyperping format.
 type Converter struct {
-	regionMap    map[string]string
+	// frequencyMap provides exact mappings for known BetterStack frequencies.
+	// Values not in this map fall back to nearest-match via migrate.MapFrequency.
 	frequencyMap map[int]int
 	protocolMap  map[string]string
 }
@@ -21,27 +21,6 @@ type Converter struct {
 // New creates a new converter with default mappings.
 func New() *Converter {
 	return &Converter{
-		regionMap: map[string]string{
-			"us":             "virginia",
-			"us-east":        "virginia",
-			"us-east-1":      "virginia",
-			"us-west":        "oregon",
-			"us-west-1":      "oregon",
-			"eu":             "london",
-			"eu-west":        "london",
-			"eu-west-1":      "london",
-			"eu-central":     "frankfurt",
-			"eu-central-1":   "frankfurt",
-			"asia":           "singapore",
-			"ap-southeast":   "singapore",
-			"ap-southeast-1": "singapore",
-			"ap-northeast":   "tokyo",
-			"ap-northeast-1": "tokyo",
-			"au":             "sydney",
-			"au-southeast":   "sydney",
-			"sa":             "saopaulo",
-			"sa-east-1":      "saopaulo",
-		},
 		frequencyMap: map[int]int{
 			10:    10,
 			20:    20,
@@ -169,7 +148,7 @@ func (c *Converter) convertMonitor(m betterstack.Monitor) (ConvertedMonitor, []C
 	}
 
 	// Map regions
-	regions := c.mapRegions(attrs.Regions)
+	regions := migrate.MapRegions(attrs.Regions)
 	if len(regions) == 0 {
 		regions = []string{"london", "virginia", "singapore"} // Default regions
 		issues = append(issues, ConversionIssue{
@@ -286,80 +265,23 @@ func (c *Converter) mapProtocol(bsType string) string {
 	return ""
 }
 
+func (c *Converter) mapRegions(bsRegions []string) []string {
+	return migrate.MapRegions(bsRegions)
+}
+
 func (c *Converter) mapFrequency(frequency int) int {
 	if mapped, ok := c.frequencyMap[frequency]; ok {
 		return mapped
 	}
-
-	// Find closest supported frequency
-	supported := []int{10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
-	closest := supported[0]
-	minDiff := abs(frequency - closest)
-
-	for _, f := range supported {
-		diff := abs(frequency - f)
-		if diff < minDiff {
-			minDiff = diff
-			closest = f
-		}
-	}
-
-	return closest
-}
-
-func (c *Converter) mapRegions(bsRegions []string) []string {
-	var regions []string
-	seen := make(map[string]bool)
-
-	for _, region := range bsRegions {
-		normalized := strings.ToLower(strings.TrimSpace(region))
-		if mapped, ok := c.regionMap[normalized]; ok {
-			if !seen[mapped] {
-				regions = append(regions, mapped)
-				seen[mapped] = true
-			}
-		}
-	}
-
-	return regions
+	return migrate.MapFrequency(frequency)
 }
 
 func sanitizeResourceName(name string) string {
-	// Convert to lowercase
-	safe := strings.ToLower(name)
-
-	// Replace special characters with underscores
-	reg := regexp.MustCompile(`[^a-z0-9_]+`)
-	safe = reg.ReplaceAllString(safe, "_")
-
-	// Remove leading/trailing underscores
-	safe = strings.Trim(safe, "_")
-
-	// Collapse multiple underscores
-	reg = regexp.MustCompile(`_+`)
-	safe = reg.ReplaceAllString(safe, "_")
-
-	// Ensure it doesn't start with a digit
-	if safe != "" && safe[0] >= '0' && safe[0] <= '9' {
-		safe = "monitor_" + safe
-	}
-
-	// Ensure it's not empty
-	if safe == "" {
-		safe = "unnamed_monitor"
-	}
-
-	return safe
+	return migrate.SanitizeResourceName(name)
 }
 
-// deduplicateResourceName appends a numeric suffix when a name has already been used.
-// For example, "example_com" becomes "example_com_2" on the second occurrence.
 func deduplicateResourceName(name string, seen map[string]int) string {
-	seen[name]++
-	if seen[name] == 1 {
-		return name
-	}
-	return fmt.Sprintf("%s_%d", name, seen[name])
+	return migrate.DeduplicateResourceName(name, seen)
 }
 
 func extractIssueMessages(issues []ConversionIssue) []string {
@@ -368,11 +290,4 @@ func extractIssueMessages(issues []ConversionIssue) []string {
 		messages = append(messages, issue.Message)
 	}
 	return messages
-}
-
-func abs(n int) int {
-	if n < 0 {
-		return -n
-	}
-	return n
 }

--- a/cmd/migrate-betterstack/converter/monitor_test.go
+++ b/cmd/migrate-betterstack/converter/monitor_test.go
@@ -449,20 +449,4 @@ func TestConverter_ConvertHeartbeats_Batch(t *testing.T) {
 	assert.Empty(t, issues)
 }
 
-func TestAbs(t *testing.T) {
-	tests := []struct {
-		input    int
-		expected int
-	}{
-		{5, 5},
-		{-5, 5},
-		{0, 0},
-		{100, 100},
-		{-100, 100},
-	}
-
-	for _, tt := range tests {
-		result := abs(tt.input)
-		assert.Equal(t, tt.expected, result)
-	}
-}
+// TestAbs is now covered by pkg/migrate/frequency_test.go

--- a/cmd/migrate-betterstack/converter/monitor_test.go
+++ b/cmd/migrate-betterstack/converter/monitor_test.go
@@ -448,5 +448,3 @@ func TestConverter_ConvertHeartbeats_Batch(t *testing.T) {
 	assert.Equal(t, "heartbeat_2", converted[1].ResourceName)
 	assert.Empty(t, issues)
 }
-
-// TestAbs is now covered by pkg/migrate/frequency_test.go

--- a/cmd/migrate-betterstack/generator/terraform.go
+++ b/cmd/migrate-betterstack/generator/terraform.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-betterstack/converter"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // Generator generates Terraform HCL and import scripts.
@@ -175,12 +176,7 @@ func (g *Generator) generateHealthcheckBlock(h converter.ConvertedHealthcheck) s
 }
 
 func quoteString(s string) string {
-	escaped := strings.ReplaceAll(s, "\\", "\\\\")
-	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
-	escaped = strings.ReplaceAll(escaped, "\n", "\\n")
-	escaped = strings.ReplaceAll(escaped, "\r", "\\r")
-	escaped = strings.ReplaceAll(escaped, "\t", "\\t")
-	return fmt.Sprintf("\"%s\"", escaped)
+	return migrate.QuoteHCL(s)
 }
 
 func periodToCron(periodSeconds int) string {

--- a/cmd/migrate-pingdom/converter/check.go
+++ b/cmd/migrate-pingdom/converter/check.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // ConversionResult represents the result of converting a Pingdom check.
@@ -240,22 +241,7 @@ func (c *CheckConverter) convertIMAPCheck(check pingdom.Check) *client.CreateMon
 // ConvertFrequency converts Pingdom resolution (minutes) to Hyperping frequency (seconds).
 func ConvertFrequency(resolutionMinutes int) int {
 	seconds := resolutionMinutes * 60
-
-	// Round to nearest allowed frequency
-	allowed := []int{60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
-
-	closest := allowed[0]
-	minDiff := abs(seconds - allowed[0])
-
-	for _, freq := range allowed {
-		diff := abs(seconds - freq)
-		if diff < minDiff {
-			minDiff = diff
-			closest = freq
-		}
-	}
-
-	return closest
+	return migrate.MapFrequency(seconds)
 }
 
 // ConvertRegions converts Pingdom probe filters to Hyperping regions.
@@ -291,13 +277,6 @@ func ConvertRegions(probeFilters []string) []string {
 	}
 
 	return regions
-}
-
-func abs(x int) int {
-	if x < 0 {
-		return -x
-	}
-	return x
 }
 
 func boolPtr(b bool) *bool {

--- a/cmd/migrate-pingdom/generator/terraform.go
+++ b/cmd/migrate-pingdom/generator/terraform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
 	"github.com/develeap/terraform-provider-hyperping/internal/client"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // TerraformGenerator generates Terraform HCL configuration.
@@ -210,12 +211,7 @@ func (g *TerraformGenerator) terraformName(name string) string {
 
 // escapeHCL escapes a string for HCL output.
 func escapeHCL(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	s = strings.ReplaceAll(s, "\r", "\\r")
-	s = strings.ReplaceAll(s, "\t", "\\t")
-	return s
+	return migrate.EscapeHCL(s)
 }
 
 // formatStringList formats a Go string slice as an HCL list.

--- a/cmd/migrate-uptimerobot/converter/monitor.go
+++ b/cmd/migrate-uptimerobot/converter/monitor.go
@@ -5,9 +5,9 @@ package converter
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/uptimerobot"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // HyperpingMonitor represents a Hyperping monitor configuration.
@@ -302,21 +302,7 @@ func convertHTTPMethod(method *uptimerobot.FlexibleInt) string {
 
 // mapFrequency maps UptimeRobot interval to nearest Hyperping check_frequency.
 func mapFrequency(interval int) int {
-	allowedFrequencies := []int{10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
-
-	// Find closest allowed value
-	closest := allowedFrequencies[0]
-	minDiff := abs(interval - closest)
-
-	for _, freq := range allowedFrequencies {
-		diff := abs(interval - freq)
-		if diff < minDiff {
-			minDiff = diff
-			closest = freq
-		}
-	}
-
-	return closest
+	return migrate.MapFrequency(interval)
 }
 
 // mapSubTypeToPort maps UptimeRobot port sub-type to default port number.
@@ -338,64 +324,20 @@ func mapSubTypeToPort(subType int) int {
 }
 
 // terraformName converts a string to a valid Terraform resource name.
+// Uses "r_" prefix for digit-leading names (UptimeRobot convention).
 func terraformName(name string) string {
-	// Convert to lowercase
-	name = strings.ToLower(name)
-
-	// Replace non-alphanumeric characters with underscores
-	var result strings.Builder
-	for _, ch := range name {
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
-			result.WriteRune(ch)
-		} else {
-			result.WriteRune('_')
-		}
-	}
-
-	// Remove consecutive underscores
-	s := result.String()
-	for strings.Contains(s, "__") {
-		s = strings.ReplaceAll(s, "__", "_")
-	}
-
-	// Trim underscores
-	s = strings.Trim(s, "_")
-
-	// Ensure it starts with a letter
-	if s != "" && s[0] >= '0' && s[0] <= '9' {
-		s = "r_" + s
-	}
-
-	// Fallback for empty names
-	if s == "" {
-		s = "monitor"
-	}
-
-	return s
+	return migrate.SanitizeResourceNameWith(name, migrate.SanitizeOpts{
+		DigitPrefix:   "r",
+		EmptyFallback: "monitor",
+	})
 }
 
 // ensureURLScheme prepends "https://" if the URL has no scheme.
-// The Hyperping provider requires all URLs to have an HTTP/HTTPS scheme.
 func ensureURLScheme(rawURL string) string {
-	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
-		return rawURL
-	}
-	return "https://" + rawURL
+	return migrate.EnsureURLScheme(rawURL)
 }
 
 // deduplicateResourceName appends a numeric suffix when a name has already been used.
 func deduplicateResourceName(name string, seen map[string]int) string {
-	seen[name]++
-	if seen[name] == 1 {
-		return name
-	}
-	return fmt.Sprintf("%s_%d", name, seen[name])
-}
-
-// abs returns the absolute value of an integer.
-func abs(n int) int {
-	if n < 0 {
-		return -n
-	}
-	return n
+	return migrate.DeduplicateResourceName(name, seen)
 }

--- a/cmd/migrate-uptimerobot/generator/import.go
+++ b/cmd/migrate-uptimerobot/generator/import.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // GenerateImportScript generates a shell script for importing existing Hyperping resources.
@@ -130,9 +131,5 @@ func GenerateImportScript(result *converter.ConversionResult) string {
 
 // escapeShellString escapes a string for use in shell scripts.
 func escapeShellString(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "$", "\\$")
-	s = strings.ReplaceAll(s, "`", "\\`")
-	return s
+	return migrate.EscapeShell(s)
 }

--- a/cmd/migrate-uptimerobot/generator/terraform.go
+++ b/cmd/migrate-uptimerobot/generator/terraform.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // GenerateTerraform generates Terraform HCL configuration from conversion results.
@@ -182,8 +183,5 @@ func generateHealthcheckResource(sb *strings.Builder, h converter.HyperpingHealt
 
 // escapeString escapes a string for use in Terraform configuration.
 func escapeString(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
+	return migrate.EscapeHCL(s)
 }

--- a/cmd/migrate-uptimerobot/uptimerobot/client_test.go
+++ b/cmd/migrate-uptimerobot/uptimerobot/client_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package uptimerobot
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexibleInt_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected FlexibleInt
+		wantErr  bool
+	}{
+		{"number zero", "0", FlexibleInt(0), false},
+		{"number positive", "42", FlexibleInt(42), false},
+		{"number negative", "-1", FlexibleInt(-1), false},
+		{"string number", `"42"`, FlexibleInt(42), false},
+		{"string zero", `"0"`, FlexibleInt(0), false},
+		{"string empty", `""`, FlexibleInt(0), false},
+		{"boolean", "true", FlexibleInt(0), true},
+		{"invalid string", `"abc"`, FlexibleInt(0), true},
+		{"null", "null", FlexibleInt(0), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fi FlexibleInt
+			err := json.Unmarshal([]byte(tt.input), &fi)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, fi)
+			}
+		})
+	}
+}
+
+func TestFlexibleInt_InStruct(t *testing.T) {
+	type testStruct struct {
+		Port    *FlexibleInt `json:"port,omitempty"`
+		SubType *FlexibleInt `json:"sub_type,omitempty"`
+		Method  *FlexibleInt `json:"http_method,omitempty"`
+	}
+
+	tests := []struct {
+		name     string
+		json     string
+		expected testStruct
+	}{
+		{
+			name: "numeric fields",
+			json: `{"port": 443, "sub_type": 3, "http_method": 1}`,
+			expected: testStruct{
+				Port:    flexIntPtr(443),
+				SubType: flexIntPtr(3),
+				Method:  flexIntPtr(1),
+			},
+		},
+		{
+			name: "string fields",
+			json: `{"port": "8080", "sub_type": "2", "http_method": "6"}`,
+			expected: testStruct{
+				Port:    flexIntPtr(8080),
+				SubType: flexIntPtr(2),
+				Method:  flexIntPtr(6),
+			},
+		},
+		{
+			name: "empty string sub_type",
+			json: `{"sub_type": ""}`,
+			expected: testStruct{
+				SubType: flexIntPtr(0),
+			},
+		},
+		{
+			name:     "missing optional fields",
+			json:     `{}`,
+			expected: testStruct{},
+		},
+		{
+			name: "mixed types",
+			json: `{"port": 443, "sub_type": "3"}`,
+			expected: testStruct{
+				Port:    flexIntPtr(443),
+				SubType: flexIntPtr(3),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testStruct
+			err := json.Unmarshal([]byte(tt.json), &result)
+			require.NoError(t, err)
+
+			if tt.expected.Port != nil {
+				require.NotNil(t, result.Port)
+				assert.Equal(t, int(*tt.expected.Port), int(*result.Port))
+			} else {
+				assert.Nil(t, result.Port)
+			}
+
+			if tt.expected.SubType != nil {
+				require.NotNil(t, result.SubType)
+				assert.Equal(t, int(*tt.expected.SubType), int(*result.SubType))
+			} else {
+				assert.Nil(t, result.SubType)
+			}
+
+			if tt.expected.Method != nil {
+				require.NotNil(t, result.Method)
+				assert.Equal(t, int(*tt.expected.Method), int(*result.Method))
+			} else {
+				assert.Nil(t, result.Method)
+			}
+		})
+	}
+}
+
+func flexIntPtr(n int) *FlexibleInt {
+	fi := FlexibleInt(n)
+	return &fi
+}

--- a/pkg/migrate/escape.go
+++ b/pkg/migrate/escape.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import "strings"
+
+// EscapeHCL escapes a string for safe inclusion in Terraform HCL.
+// It handles backslashes, double quotes, and newlines.
+func EscapeHCL(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	return s
+}
+
+// EscapeShell escapes a string for safe inclusion in a bash script.
+// It handles backslashes, double quotes, dollar signs, and backticks.
+func EscapeShell(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "$", `\$`)
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return s
+}
+
+// QuoteHCL wraps a string in double quotes after escaping it for HCL.
+func QuoteHCL(s string) string {
+	return `"` + EscapeHCL(s) + `"`
+}

--- a/pkg/migrate/escape_test.go
+++ b/pkg/migrate/escape_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeHCL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no escaping needed", "hello world", "hello world"},
+		{"backslash", `path\to\file`, `path\\to\\file`},
+		{"double quotes", `say "hello"`, `say \"hello\"`},
+		{"newline", "line1\nline2", `line1\nline2`},
+		{"carriage return", "line1\rline2", `line1\rline2`},
+		{"tab", "col1\tcol2", `col1\tcol2`},
+		{"mixed", "say \"hello\"\nnext line", `say \"hello\"\nnext line`},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EscapeHCL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEscapeShell(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no escaping needed", "hello world", "hello world"},
+		{"backslash", `path\to\file`, `path\\to\\file`},
+		{"double quotes", `say "hello"`, `say \"hello\"`},
+		{"dollar sign", "cost is $100", `cost is \$100`},
+		{"backtick", "run `ls`", "run \\`ls\\`"},
+		{"mixed", `var="$HOME"`, `var=\"\$HOME\"`},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EscapeShell(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestQuoteHCL(t *testing.T) {
+	assert.Equal(t, `"hello"`, QuoteHCL("hello"))
+	assert.Equal(t, `"say \"hi\""`, QuoteHCL(`say "hi"`))
+	assert.Equal(t, `""`, QuoteHCL(""))
+}

--- a/pkg/migrate/frequency.go
+++ b/pkg/migrate/frequency.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+// AllowedFrequencies lists the check frequencies (in seconds) supported by Hyperping.
+var AllowedFrequencies = []int{10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
+
+// MapFrequency maps an arbitrary interval (in seconds) to the nearest
+// Hyperping-supported check frequency.
+func MapFrequency(interval int) int {
+	closest := AllowedFrequencies[0]
+	minDiff := abs(interval - closest)
+
+	for _, freq := range AllowedFrequencies {
+		diff := abs(interval - freq)
+		if diff < minDiff {
+			minDiff = diff
+			closest = freq
+		}
+	}
+
+	return closest
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/pkg/migrate/frequency_test.go
+++ b/pkg/migrate/frequency_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapFrequency(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected int
+	}{
+		// Exact matches
+		{"exact 10", 10, 10},
+		{"exact 20", 20, 20},
+		{"exact 30", 30, 30},
+		{"exact 60", 60, 60},
+		{"exact 120", 120, 120},
+		{"exact 180", 180, 180},
+		{"exact 300", 300, 300},
+		{"exact 600", 600, 600},
+		{"exact 1800", 1800, 1800},
+		{"exact 3600", 3600, 3600},
+		{"exact 21600", 21600, 21600},
+		{"exact 43200", 43200, 43200},
+		{"exact 86400", 86400, 86400},
+
+		// Rounding cases
+		{"5 rounds to 10", 5, 10},
+		{"15 rounds to 10", 15, 10},
+		{"25 rounds to 20", 25, 20},
+		{"45 rounds to 30", 45, 30},
+		{"90 rounds to 60", 90, 60},
+		{"150 rounds to 120", 150, 120},
+		{"350 rounds to 300", 350, 300},
+		{"500 rounds to 600", 500, 600},
+		{"1000 rounds to 600", 1000, 600},
+		{"2700 rounds to 1800", 2700, 1800},
+
+		// Edge cases
+		{"0 rounds to 10", 0, 10},
+		{"1 rounds to 10", 1, 10},
+		{"very large rounds to 86400", 100000, 86400},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MapFrequency(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAbs(t *testing.T) {
+	assert.Equal(t, 5, abs(5))
+	assert.Equal(t, 5, abs(-5))
+	assert.Equal(t, 0, abs(0))
+}

--- a/pkg/migrate/names.go
+++ b/pkg/migrate/names.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SanitizeOpts configures resource name sanitization behavior.
+type SanitizeOpts struct {
+	// DigitPrefix is prepended (with underscore) when the name starts with a digit.
+	// Default: "monitor".
+	DigitPrefix string
+	// EmptyFallback is used when the sanitized name is empty.
+	// Default: "unnamed_monitor".
+	EmptyFallback string
+}
+
+// SanitizeResourceName converts a human-readable name to a valid Terraform resource name.
+// It lowercases, replaces non-alphanumeric characters with underscores, collapses
+// consecutive underscores, trims leading/trailing underscores, and prepends a prefix
+// if the result starts with a digit.
+func SanitizeResourceName(name string) string {
+	return SanitizeResourceNameWith(name, SanitizeOpts{
+		DigitPrefix:   "monitor",
+		EmptyFallback: "unnamed_monitor",
+	})
+}
+
+// SanitizeResourceNameWith converts a name to a valid Terraform resource name
+// using the provided options for digit-leading prefix and empty-name fallback.
+func SanitizeResourceNameWith(name string, opts SanitizeOpts) string {
+	safe := strings.ToLower(name)
+
+	var result strings.Builder
+	for _, ch := range safe {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') {
+			result.WriteRune(ch)
+		} else {
+			result.WriteRune('_')
+		}
+	}
+
+	s := result.String()
+
+	// Collapse consecutive underscores
+	for strings.Contains(s, "__") {
+		s = strings.ReplaceAll(s, "__", "_")
+	}
+
+	// Trim leading/trailing underscores
+	s = strings.Trim(s, "_")
+
+	// Ensure it starts with a letter
+	if s != "" && s[0] >= '0' && s[0] <= '9' {
+		prefix := opts.DigitPrefix
+		if prefix == "" {
+			prefix = "monitor"
+		}
+		s = prefix + "_" + s
+	}
+
+	if s == "" {
+		s = opts.EmptyFallback
+		if s == "" {
+			s = "unnamed_monitor"
+		}
+	}
+
+	return s
+}
+
+// DeduplicateResourceName appends a numeric suffix when a name has already been used.
+// The seen map tracks how many times each name has appeared.
+// First occurrence: returns name as-is. Second: returns "name_2", third: "name_3", etc.
+func DeduplicateResourceName(name string, seen map[string]int) string {
+	seen[name]++
+	if seen[name] == 1 {
+		return name
+	}
+	return fmt.Sprintf("%s_%d", name, seen[name])
+}

--- a/pkg/migrate/names_test.go
+++ b/pkg/migrate/names_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple name", "API Monitor", "api_monitor"},
+		{"with brackets", "[PROD]-API-Gateway", "prod_api_gateway"},
+		{"with numbers", "Monitor 123", "monitor_123"},
+		{"leading number", "123 Monitor", "monitor_123_monitor"},
+		{"only numbers", "123", "monitor_123"},
+		{"special characters", "Test@Monitor#123!", "test_monitor_123"},
+		{"multiple spaces", "Test   Monitor   Name", "test_monitor_name"},
+		{"empty string", "", "unnamed_monitor"},
+		{"only special chars", "@#$%", "unnamed_monitor"},
+		{"trailing underscores", "__test__", "test"},
+		{"parentheses", "Monitor (v2)", "monitor_v2"},
+		{"mixed case", "MyProduction-API", "myproduction_api"},
+		{"dots", "api.example.com", "api_example_com"},
+		{"already valid", "valid_name_123", "valid_name_123"},
+		{"unicode", "Mönitor Ünit", "m_nitor_nit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeResourceName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeResourceNameWith(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		opts     SanitizeOpts
+		expected string
+	}{
+		{
+			"leading number with custom prefix",
+			"123check",
+			SanitizeOpts{DigitPrefix: "check", EmptyFallback: "unnamed_check"},
+			"check_123check",
+		},
+		{
+			"empty with custom fallback",
+			"",
+			SanitizeOpts{DigitPrefix: "check", EmptyFallback: "unnamed_healthcheck"},
+			"unnamed_healthcheck",
+		},
+		{
+			"normal name ignores prefix",
+			"my_monitor",
+			SanitizeOpts{DigitPrefix: "check", EmptyFallback: "unnamed_check"},
+			"my_monitor",
+		},
+		{
+			"UptimeRobot convention: r_ prefix",
+			"123-Monitor",
+			SanitizeOpts{DigitPrefix: "r", EmptyFallback: "monitor"},
+			"r_123_monitor",
+		},
+		{
+			"UptimeRobot convention: empty fallback",
+			"",
+			SanitizeOpts{DigitPrefix: "r", EmptyFallback: "monitor"},
+			"monitor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeResourceNameWith(tt.input, tt.opts)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDeduplicateResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		calls    []string
+		expected []string
+	}{
+		{
+			name:     "unique names",
+			calls:    []string{"monitor_a", "monitor_b", "monitor_c"},
+			expected: []string{"monitor_a", "monitor_b", "monitor_c"},
+		},
+		{
+			name:     "duplicate names",
+			calls:    []string{"api", "api", "api"},
+			expected: []string{"api", "api_2", "api_3"},
+		},
+		{
+			name:     "mixed duplicates",
+			calls:    []string{"web", "api", "web", "db", "api"},
+			expected: []string{"web", "api", "web_2", "db", "api_2"},
+		},
+		{
+			name:     "single name",
+			calls:    []string{"solo"},
+			expected: []string{"solo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := make(map[string]int)
+			for i, name := range tt.calls {
+				result := DeduplicateResourceName(name, seen)
+				assert.Equal(t, tt.expected[i], result, "call %d", i)
+			}
+		})
+	}
+}

--- a/pkg/migrate/regions.go
+++ b/pkg/migrate/regions.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import "strings"
+
+// HyperpingRegions lists all regions supported by Hyperping.
+var HyperpingRegions = []string{
+	"london", "virginia", "singapore", "sydney",
+	"frankfurt", "tokyo", "saopaulo", "oregon",
+}
+
+// DefaultRegions returns the default set of regions used when no mapping is available.
+func DefaultRegions() []string {
+	return []string{"london", "virginia", "singapore"}
+}
+
+// RegionAliases maps common cloud provider region identifiers to Hyperping region names.
+var RegionAliases = map[string]string{
+	"us":             "virginia",
+	"us-east":        "virginia",
+	"us-east-1":      "virginia",
+	"us-west":        "oregon",
+	"us-west-1":      "oregon",
+	"eu":             "london",
+	"eu-west":        "london",
+	"eu-west-1":      "london",
+	"eu-central":     "frankfurt",
+	"eu-central-1":   "frankfurt",
+	"asia":           "singapore",
+	"ap-southeast":   "singapore",
+	"ap-southeast-1": "singapore",
+	"ap-northeast":   "tokyo",
+	"ap-northeast-1": "tokyo",
+	"au":             "sydney",
+	"au-southeast":   "sydney",
+	"sa":             "saopaulo",
+	"sa-east-1":      "saopaulo",
+}
+
+// MapRegions converts a list of source region identifiers to Hyperping region names.
+// Unknown regions are silently skipped. Duplicates are removed.
+func MapRegions(sourceRegions []string) []string {
+	var regions []string
+	seen := make(map[string]bool)
+
+	for _, region := range sourceRegions {
+		normalized := strings.ToLower(strings.TrimSpace(region))
+		if mapped, ok := RegionAliases[normalized]; ok {
+			if !seen[mapped] {
+				regions = append(regions, mapped)
+				seen[mapped] = true
+			}
+		}
+	}
+
+	return regions
+}

--- a/pkg/migrate/regions.go
+++ b/pkg/migrate/regions.go
@@ -5,12 +5,6 @@ package migrate
 
 import "strings"
 
-// HyperpingRegions lists all regions supported by Hyperping.
-var HyperpingRegions = []string{
-	"london", "virginia", "singapore", "sydney",
-	"frankfurt", "tokyo", "saopaulo", "oregon",
-}
-
 // DefaultRegions returns the default set of regions used when no mapping is available.
 func DefaultRegions() []string {
 	return []string{"london", "virginia", "singapore"}
@@ -37,6 +31,9 @@ var RegionAliases = map[string]string{
 	"au-southeast":   "sydney",
 	"sa":             "saopaulo",
 	"sa-east-1":      "saopaulo",
+	"me":             "bahrain",
+	"me-south":       "bahrain",
+	"me-south-1":     "bahrain",
 }
 
 // MapRegions converts a list of source region identifiers to Hyperping region names.

--- a/pkg/migrate/regions_test.go
+++ b/pkg/migrate/regions_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapRegions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "simple regions",
+			input:    []string{"us", "eu"},
+			expected: []string{"virginia", "london"},
+		},
+		{
+			name:     "AWS-style regions",
+			input:    []string{"us-east-1", "eu-west-1", "ap-southeast-1"},
+			expected: []string{"virginia", "london", "singapore"},
+		},
+		{
+			name:     "duplicates removed",
+			input:    []string{"us", "us-east", "us-east-1"},
+			expected: []string{"virginia"},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "mixed case",
+			input:    []string{"US", "EU", "Asia"},
+			expected: []string{"virginia", "london", "singapore"},
+		},
+		{
+			name:     "unknown regions ignored",
+			input:    []string{"unknown", "us", "invalid"},
+			expected: []string{"virginia"},
+		},
+		{
+			name:     "all regions",
+			input:    []string{"us", "us-west", "eu", "eu-central", "asia", "ap-northeast", "au", "sa"},
+			expected: []string{"virginia", "oregon", "london", "frankfurt", "singapore", "tokyo", "sydney", "saopaulo"},
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    []string{" us ", "  eu  "},
+			expected: []string{"virginia", "london"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MapRegions(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDefaultRegions(t *testing.T) {
+	regions := DefaultRegions()
+	assert.Equal(t, []string{"london", "virginia", "singapore"}, regions)
+}

--- a/pkg/migrate/regions_test.go
+++ b/pkg/migrate/regions_test.go
@@ -52,8 +52,13 @@ func TestMapRegions(t *testing.T) {
 		},
 		{
 			name:     "all regions",
-			input:    []string{"us", "us-west", "eu", "eu-central", "asia", "ap-northeast", "au", "sa"},
-			expected: []string{"virginia", "oregon", "london", "frankfurt", "singapore", "tokyo", "sydney", "saopaulo"},
+			input:    []string{"us", "us-west", "eu", "eu-central", "asia", "ap-northeast", "au", "sa", "me"},
+			expected: []string{"virginia", "oregon", "london", "frankfurt", "singapore", "tokyo", "sydney", "saopaulo", "bahrain"},
+		},
+		{
+			name:     "middle east aliases",
+			input:    []string{"me", "me-south", "me-south-1"},
+			expected: []string{"bahrain"},
 		},
 		{
 			name:     "whitespace trimmed",

--- a/pkg/migrate/url.go
+++ b/pkg/migrate/url.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import "strings"
+
+// EnsureURLScheme prepends "https://" if the URL has no HTTP/HTTPS scheme.
+// The Hyperping provider requires all URLs to have an HTTP/HTTPS scheme,
+// even for ICMP and port monitors.
+func EnsureURLScheme(rawURL string) string {
+	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		return rawURL
+	}
+	return "https://" + rawURL
+}

--- a/pkg/migrate/url_test.go
+++ b/pkg/migrate/url_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureURLScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"already https", "https://example.com", "https://example.com"},
+		{"already http", "http://example.com", "http://example.com"},
+		{"bare domain", "example.com", "https://example.com"},
+		{"IP address", "192.168.1.1", "https://192.168.1.1"},
+		{"IP with port", "192.168.1.1:8080", "https://192.168.1.1:8080"},
+		{"domain with path", "example.com/health", "https://example.com/health"},
+		{"empty string", "", "https://"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EnsureURLScheme(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated utility functions from the 3 migration tools (UptimeRobot, BetterStack, Pingdom) into a new shared `pkg/migrate` package
- Adds missing unit tests for `FlexibleInt` JSON deserialization (UptimeRobot)
- Removes ~224 lines of duplicated code across 8 files

## Changes

### New shared package `pkg/migrate/`
| File | Functions | Tests |
|------|-----------|-------|
| `names.go` | `SanitizeResourceName`, `SanitizeResourceNameWith`, `DeduplicateResourceName` | 20 test cases |
| `frequency.go` | `MapFrequency`, `AllowedFrequencies` | 28 test cases |
| `escape.go` | `EscapeHCL`, `EscapeShell`, `QuoteHCL` | 17 test cases |
| `url.go` | `EnsureURLScheme` | 7 test cases |
| `regions.go` | `MapRegions`, `RegionAliases`, `DefaultRegions`, `HyperpingRegions` | 11 test cases |

### Migration tools updated
- **UptimeRobot**: converter delegates to shared `MapFrequency`, `SanitizeResourceNameWith`, `EnsureURLScheme`, `DeduplicateResourceName`; generators delegate to `EscapeHCL`, `EscapeShell`
- **BetterStack**: converter delegates to shared `MapFrequency` (fallback), `SanitizeResourceName`, `MapRegions`, `DeduplicateResourceName`; generator delegates to `QuoteHCL`
- **Pingdom**: converter delegates to shared `MapFrequency`; generator delegates to `EscapeHCL`

### New test coverage
- `FlexibleInt` UnmarshalJSON: 9 direct test cases + 5 struct-level integration tests

## Test plan
- [x] `go test ./pkg/migrate/... -race` — 83 test cases pass
- [x] `go test ./cmd/migrate-uptimerobot/... -race` — all existing tests pass
- [x] `go test ./cmd/migrate-betterstack/... -race` — all existing tests pass  
- [x] `go test ./cmd/migrate-pingdom/... -race` — all existing tests pass
- [x] `go test ./... -race` — 15 packages pass, 0 failures
- [x] `make lint` — 0 issues
- [x] `go vet ./...` — clean
- [x] Pre-push hooks pass (vet, build, lint, govulncheck)

Closes #32