### PR TITLE
feat: add DNS protocol support for monitors

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -57,6 +57,8 @@ resource "hyperping_incident" "outage" {
 
 - `alerts_wait` (Number) Minutes to wait before sending alerts after an outage is detected. One of: `-1` (disabled), `0`, `1`, `2`, `3`, `5`, `10`, `30`, `60`.
 - `check_frequency` (Number) Check frequency in seconds.
+- `dns_expected_answer` (String) Expected DNS answer to validate against.
+- `dns_nameserver` (String) Nameserver used for DNS queries.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
 - `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
@@ -66,7 +68,7 @@ resource "hyperping_incident" "outage" {
 - `paused` (Boolean) Whether the monitor is paused.
 - `port` (Number) Port number for port protocol monitors.
 - `project_uuid` (String) UUID of the project this monitor belongs to.
-- `protocol` (String) The protocol used for monitoring (http, icmp, tcp, udp).
+- `protocol` (String) The protocol used for monitoring (http, port, icmp, dns).
 - `regions` (List of String) List of regions the monitor checks from.
 - `request_body` (String) Request body for POST/PUT/PATCH requests.
 - `request_headers` (Attributes List) Custom HTTP headers sent with requests. (see [below for nested schema](#nestedatt--request_headers))

--- a/docs/data-sources/monitors.md
+++ b/docs/data-sources/monitors.md
@@ -85,6 +85,8 @@ Read-Only:
 
 - `alerts_wait` (Number) Minutes to wait before sending alerts after an outage is detected. One of: `-1` (disabled), `0`, `1`, `2`, `3`, `5`, `10`, `30`, `60`.
 - `check_frequency` (Number) Check frequency in seconds.
+- `dns_expected_answer` (String) Expected DNS answer to validate against.
+- `dns_nameserver` (String) Nameserver used for DNS queries.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
 - `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
@@ -95,7 +97,7 @@ Read-Only:
 - `paused` (Boolean) Whether the monitor is paused.
 - `port` (Number) Port number for port protocol monitors.
 - `project_uuid` (String) UUID of the project this monitor belongs to.
-- `protocol` (String) The protocol used for monitoring (http, icmp, tcp, udp).
+- `protocol` (String) The protocol used for monitoring (http, port, icmp, dns).
 - `regions` (List of String) List of regions the monitor checks from.
 - `request_body` (String) Request body for POST/PUT/PATCH requests.
 - `request_headers` (Attributes List) Custom HTTP headers sent with the request. (see [below for nested schema](#nestedatt--monitors--request_headers))

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -63,12 +63,15 @@ resource "hyperping_monitor" "maintenance" {
 ### Required
 
 - `name` (String) The display name of the monitor. Must be 1-255 characters.
-- `url` (String) The URL to monitor. Must include protocol scheme (e.g., `https://api.example.com/health`).
+- `url` (String) The URL to monitor. For HTTP/ICMP/port protocols, must include scheme (e.g., `https://api.example.com/health`). For DNS protocol, use a bare domain (e.g., `example.com`).
 
 ### Optional
 
 - `alerts_wait` (Number) Minutes to wait before sending alerts after an outage is detected. Must be one of: `-1` (disabled), `0`, `1`, `2`, `3`, `5`, `10`, `30`, `60`.
 - `check_frequency` (Number) Check frequency in seconds. Valid values: `10`, `20`, `30`, `60`, `120`, `180`, `300`, `600`, `1800`, `3600`, `21600`, `43200`, `86400`. Defaults to `60`.
+- `dns_expected_answer` (String) Expected DNS answer to validate against. Only valid when protocol is `dns`. Monitor fails if the resolved value does not contain this string.
+- `dns_nameserver` (String) Nameserver to query against (e.g., `8.8.8.8`). Only valid when protocol is `dns`. Leave empty to use default resolvers.
+- `dns_record_type` (String) DNS record type to check. Only valid when protocol is `dns`. Valid values: `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SOA`, `SRV`, `CAA`, `PTR`. Defaults to `A` (set by the API if omitted).
 - `escalation_policy` (String) UUID of the escalation policy to link to this monitor.
 - `expected_status_code` (String) Expected HTTP status code pattern. Use a specific code like `200`, a wildcard like `2xx` (200-299), or a range like `1xx-3xx` (100-399). Defaults to `2xx`.
 - `follow_redirects` (Boolean) Whether to follow HTTP redirects. Only applies to `http` protocol monitors. Defaults to `true`.
@@ -76,7 +79,7 @@ resource "hyperping_monitor" "maintenance" {
 - `paused` (Boolean) Whether the monitor is paused. Defaults to `false`.
 - `port` (Number) TCP port number (1-65535). Required when protocol is `port`. Examples: `443` (HTTPS), `5432` (PostgreSQL), `6379` (Redis).
 - `project_uuid` (String) UUID of the Hyperping project this monitor belongs to.
-- `protocol` (String) The protocol type. Valid values: `http`, `port`, `icmp`. Defaults to `http`.
+- `protocol` (String) The protocol type. Valid values: `http`, `port`, `icmp`, `dns`. Defaults to `http`.
 - `regions` (List of String) List of monitoring regions. Use the `hyperping_monitoring_locations` data source to discover available locations. Valid values: `london`, `frankfurt`, `singapore`, `sydney`, `tokyo`, `virginia`, `saopaulo`, `bahrain`.
 - `request_body` (String) HTTP request body. Only valid when protocol is `http` and http_method is `POST`, `PUT`, or `PATCH`.
 - `request_headers` (Attributes List) Custom HTTP headers to send with the request. Only valid when protocol is `http`. (see [below for nested schema](#nestedatt--request_headers))
@@ -84,7 +87,6 @@ resource "hyperping_monitor" "maintenance" {
 
 ### Read-Only
 
-- `dns_record_type` (String) DNS record type for DNS-protocol monitors (read-only, set by the API).
 - `id` (String) The unique identifier (UUID) of the monitor.
 - `ssl_expiration` (Number) Days until the SSL certificate expires.
 - `status` (String) Current monitor status. Either `up` or `down`.

--- a/internal/client/dns_integration_test.go
+++ b/internal/client/dns_integration_test.go
@@ -1,0 +1,497 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build integration
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Comprehensive integration tests for dns_record_type PUT workaround removal
+// and DNS monitor support.
+//
+// Run all:
+//   export $(grep HYPERPING_API_KEY .env | head -1)
+//   go test ./internal/client/ -tags integration -run TestAPI_ -v
+//
+// These tests create real monitors against the Hyperping API and clean up after
+// themselves. Each test is independent and safe to run in parallel.
+// =============================================================================
+
+func mustAPIKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("HYPERPING_API_KEY")
+	if key == "" {
+		t.Skip("HYPERPING_API_KEY not set")
+	}
+	return key
+}
+
+func mustCreateMonitor(t *testing.T, c *Client, ctx context.Context, req CreateMonitorRequest) *Monitor {
+	t.Helper()
+	m, err := c.CreateMonitor(ctx, req)
+	if err != nil {
+		t.Fatalf("Failed to create monitor: %v", err)
+	}
+	t.Logf("Created %s monitor %q (uuid: %s)", m.Protocol, m.Name, m.UUID)
+	return m
+}
+
+func cleanupMonitor(t *testing.T, c *Client, uuid string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := c.DeleteMonitor(ctx, uuid); err != nil {
+		t.Logf("Warning: failed to delete monitor %s: %v", uuid, err)
+	} else {
+		t.Logf("Cleaned up monitor %s", uuid)
+	}
+}
+
+func safeDeref(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}
+
+func strp(s string) *string { return &s }
+
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano()%1_000_000)
+}
+
+// ─── Workaround removal tests ───────────────────────────────────────────────
+
+// TestAPI_PUT_HTTPMonitor_WithoutDNSRecordType verifies PUT on an HTTP monitor
+// succeeds when dns_record_type is absent from the request body.
+// This was the original bug: API returned 422 for missing dns_record_type.
+func TestAPI_PUT_HTTPMonitor_WithoutDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("put-no-drt"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		Name: strp(m.Name + "-updated"),
+	})
+	if err != nil {
+		t.Fatalf("PUT without dns_record_type FAILED: %v", err)
+	}
+	t.Logf("PASS: PUT without dns_record_type succeeded (name: %s)", updated.Name)
+}
+
+// TestAPI_PUT_HTTPMonitor_WithNullDNSRecordType sends dns_record_type: null explicitly.
+// This was another variant of the bug (v1.3.7 regression).
+func TestAPI_PUT_HTTPMonitor_WithNullDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("put-null-drt"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	// Build raw JSON with explicit null to bypass Go's omitempty
+	body := map[string]interface{}{
+		"name":            m.Name + "-null-test",
+		"dns_record_type": nil,
+	}
+	var result Monitor
+	err := c.doRequest(ctx, "PUT", fmt.Sprintf("/v1/monitors/%s", m.UUID), body, &result)
+	if err != nil {
+		t.Fatalf("PUT with dns_record_type:null FAILED: %v", err)
+	}
+	t.Logf("PASS: PUT with dns_record_type:null succeeded (name: %s)", result.Name)
+}
+
+// TestAPI_PUT_HTTPMonitor_WithEmptyStringDNSRecordType sends dns_record_type: "".
+// This was the third rejection variant.
+func TestAPI_PUT_HTTPMonitor_WithEmptyStringDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("put-empty-drt"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	body := map[string]interface{}{
+		"name":            m.Name + "-empty-test",
+		"dns_record_type": "",
+	}
+	var result Monitor
+	err := c.doRequest(ctx, "PUT", fmt.Sprintf("/v1/monitors/%s", m.UUID), body, &result)
+	if err != nil {
+		t.Logf("PUT with dns_record_type:\"\" FAILED: %v", err)
+		t.Logf("INFO: API still rejects empty string for dns_record_type. This is fine — " +
+			"the provider never sends an empty string (uses omitempty).")
+	} else {
+		t.Logf("PASS: PUT with dns_record_type:\"\" succeeded (name: %s)", result.Name)
+	}
+}
+
+// TestAPI_PUT_ICMPMonitor_WithoutDNSRecordType verifies the bug is fixed for ICMP too.
+func TestAPI_PUT_ICMPMonitor_WithoutDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("icmp-no-drt"), URL: "1.1.1.1", Protocol: "icmp",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		Name: strp(m.Name + "-updated"),
+	})
+	if err != nil {
+		t.Fatalf("PUT on ICMP monitor without dns_record_type FAILED: %v", err)
+	}
+	t.Logf("PASS: ICMP monitor PUT without dns_record_type succeeded (name: %s)", updated.Name)
+}
+
+// TestAPI_PUT_PortMonitor_WithoutDNSRecordType verifies the bug is fixed for port too.
+func TestAPI_PUT_PortMonitor_WithoutDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	port := 443
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("port-no-drt"), URL: "httpstat.us", Protocol: "port", Port: &port,
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	newPort := 8443
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		Port: &newPort,
+	})
+	if err != nil {
+		t.Fatalf("PUT on port monitor without dns_record_type FAILED: %v", err)
+	}
+	t.Logf("PASS: Port monitor PUT without dns_record_type succeeded (port: %v)", updated.Port)
+}
+
+// TestAPI_PUT_MultipleFieldsUpdate_NoDNSRecordType does a realistic multi-field
+// update (name + url + check_frequency) without dns_record_type.
+func TestAPI_PUT_MultipleFieldsUpdate_NoDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("multi-update"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	freq := 120
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		Name:           strp(m.Name + "-multi"),
+		URL:            strp("https://httpstat.us/201"),
+		CheckFrequency: &freq,
+	})
+	if err != nil {
+		t.Fatalf("Multi-field PUT without dns_record_type FAILED: %v", err)
+	}
+	if updated.CheckFrequency != 120 {
+		t.Errorf("Expected check_frequency 120, got %d", updated.CheckFrequency)
+	}
+	t.Logf("PASS: Multi-field update succeeded (name: %s, freq: %d)", updated.Name, updated.CheckFrequency)
+}
+
+// TestAPI_PUT_RawHTTP_OmittedField uses raw HTTP to send a PUT with absolutely
+// no dns_record_type in the JSON — not null, not empty, just absent.
+func TestAPI_PUT_RawHTTP_OmittedField(t *testing.T) {
+	apiKey := mustAPIKey(t)
+	c := NewClient(apiKey)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("raw-http"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	// Build raw JSON manually — guaranteed no dns_record_type key
+	rawJSON := fmt.Sprintf(`{"name":"%s-raw"}`, m.Name)
+	url := fmt.Sprintf("https://api.hyperping.io/v1/monitors/%s", m.UUID)
+
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewBufferString(rawJSON))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Raw HTTP PUT failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == 422 {
+		t.Fatalf("API returned 422 — bug has REGRESSED. Body: %s", string(body))
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("Unexpected status %d. Body: %s", resp.StatusCode, string(body))
+	}
+
+	var result Monitor
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	t.Logf("PASS: Raw HTTP PUT (no dns_record_type) returned 200 (name: %s)", result.Name)
+}
+
+// ─── DNS monitor CRUD tests ─────────────────────────────────────────────────
+
+// TestAPI_DNS_FullCRUD tests create, read, update, and delete of a DNS monitor.
+func TestAPI_DNS_FullCRUD(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// CREATE
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name:              uniqueName("dns-crud"),
+		URL:               "example.com",
+		Protocol:          "dns",
+		DNSRecordType:     strp("CNAME"),
+		DNSNameserver:     strp("8.8.8.8"),
+		DNSExpectedAnswer: strp("www.example.com"),
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	// Verify create response
+	if m.Protocol != "dns" {
+		t.Errorf("Create: expected protocol 'dns', got %q", m.Protocol)
+	}
+	if safeDeref(m.DNSRecordType) != "CNAME" {
+		t.Errorf("Create: expected dns_record_type 'CNAME', got %q", safeDeref(m.DNSRecordType))
+	}
+	if safeDeref(m.DNSNameserver) != "8.8.8.8" {
+		t.Errorf("Create: expected dns_nameserver '8.8.8.8', got %q", safeDeref(m.DNSNameserver))
+	}
+	if safeDeref(m.DNSExpectedAnswer) != "www.example.com" {
+		t.Errorf("Create: expected dns_expected_answer 'www.example.com', got %q", safeDeref(m.DNSExpectedAnswer))
+	}
+
+	// READ
+	got, err := c.GetMonitor(ctx, m.UUID)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if safeDeref(got.DNSRecordType) != "CNAME" {
+		t.Errorf("Read: expected dns_record_type 'CNAME', got %q", safeDeref(got.DNSRecordType))
+	}
+	if safeDeref(got.DNSNameserver) != "8.8.8.8" {
+		t.Errorf("Read: expected dns_nameserver '8.8.8.8', got %q", safeDeref(got.DNSNameserver))
+	}
+	if safeDeref(got.DNSExpectedAnswer) != "www.example.com" {
+		t.Errorf("Read: expected dns_expected_answer 'www.example.com', got %q", safeDeref(got.DNSExpectedAnswer))
+	}
+	t.Logf("READ verified: all DNS fields match")
+
+	// UPDATE
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		DNSRecordType:     strp("MX"),
+		DNSNameserver:     strp("1.1.1.1"),
+		DNSExpectedAnswer: strp("mail.example.com"),
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if safeDeref(updated.DNSRecordType) != "MX" {
+		t.Errorf("Update: expected dns_record_type 'MX', got %q", safeDeref(updated.DNSRecordType))
+	}
+	if safeDeref(updated.DNSNameserver) != "1.1.1.1" {
+		t.Errorf("Update: expected dns_nameserver '1.1.1.1', got %q", safeDeref(updated.DNSNameserver))
+	}
+	if safeDeref(updated.DNSExpectedAnswer) != "mail.example.com" {
+		t.Errorf("Update: expected dns_expected_answer 'mail.example.com', got %q", safeDeref(updated.DNSExpectedAnswer))
+	}
+	t.Logf("UPDATE verified: all DNS fields updated correctly")
+
+	// READ again to confirm persistence
+	got2, err := c.GetMonitor(ctx, m.UUID)
+	if err != nil {
+		t.Fatalf("Read after update failed: %v", err)
+	}
+	if safeDeref(got2.DNSRecordType) != "MX" {
+		t.Errorf("Read after update: expected 'MX', got %q", safeDeref(got2.DNSRecordType))
+	}
+	t.Logf("READ after UPDATE verified: changes persisted")
+}
+
+// TestAPI_DNS_AllRecordTypes creates a DNS monitor and cycles through all record types.
+func TestAPI_DNS_AllRecordTypes(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("dns-all-rt"), URL: "example.com", Protocol: "dns",
+		DNSRecordType: strp("A"),
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	recordTypes := []string{"A", "AAAA", "CNAME", "MX", "NS", "TXT", "SOA", "SRV", "CAA", "PTR"}
+	for _, rt := range recordTypes {
+		updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+			DNSRecordType: strp(rt),
+		})
+		if err != nil {
+			t.Errorf("Failed to set dns_record_type=%q: %v", rt, err)
+			continue
+		}
+		if safeDeref(updated.DNSRecordType) != rt {
+			t.Errorf("Expected dns_record_type %q, got %q", rt, safeDeref(updated.DNSRecordType))
+		} else {
+			t.Logf("PASS: dns_record_type=%q accepted and persisted", rt)
+		}
+	}
+}
+
+// TestAPI_DNS_DefaultRecordType verifies API defaults dns_record_type to "A" when omitted.
+func TestAPI_DNS_DefaultRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("dns-default-rt"), URL: "example.com", Protocol: "dns",
+		// No DNSRecordType — should default to "A"
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	got, err := c.GetMonitor(ctx, m.UUID)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	rt := safeDeref(got.DNSRecordType)
+	t.Logf("dns_record_type when omitted from create: %q", rt)
+	if rt != "A" {
+		t.Errorf("Expected default dns_record_type 'A', got %q", rt)
+	}
+}
+
+// TestAPI_DNS_HTTPMonitorHasNullDNSFields verifies HTTP monitors return null DNS fields.
+func TestAPI_DNS_HTTPMonitorHasNullDNSFields(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("http-null-dns"), URL: "https://httpstat.us/200", Protocol: "http",
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	got, err := c.GetMonitor(ctx, m.UUID)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if got.DNSRecordType != nil {
+		t.Errorf("HTTP monitor should have nil dns_record_type, got %q", *got.DNSRecordType)
+	}
+	if got.DNSNameserver != nil {
+		t.Errorf("HTTP monitor should have nil dns_nameserver, got %q", *got.DNSNameserver)
+	}
+	if got.DNSExpectedAnswer != nil {
+		t.Errorf("HTTP monitor should have nil dns_expected_answer, got %q", *got.DNSExpectedAnswer)
+	}
+	t.Logf("PASS: HTTP monitor has null DNS fields as expected")
+}
+
+// TestAPI_DNS_ListIncludesDNSFields verifies DNS fields appear in list responses.
+func TestAPI_DNS_ListIncludesDNSFields(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("dns-list"), URL: "example.com", Protocol: "dns",
+		DNSRecordType: strp("TXT"), DNSNameserver: strp("8.8.4.4"),
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	monitors, err := c.ListMonitors(ctx)
+	if err != nil {
+		t.Fatalf("ListMonitors failed: %v", err)
+	}
+
+	var found *Monitor
+	for i := range monitors {
+		if monitors[i].UUID == m.UUID {
+			found = &monitors[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("DNS monitor %s not found in list response", m.UUID)
+	}
+
+	if safeDeref(found.DNSRecordType) != "TXT" {
+		t.Errorf("List: expected dns_record_type 'TXT', got %q", safeDeref(found.DNSRecordType))
+	}
+	if safeDeref(found.DNSNameserver) != "8.8.4.4" {
+		t.Errorf("List: expected dns_nameserver '8.8.4.4', got %q", safeDeref(found.DNSNameserver))
+	}
+	t.Logf("PASS: DNS fields present in list response")
+}
+
+// TestAPI_PUT_DNSMonitor_WithoutDNSRecordType verifies that updating a DNS monitor
+// without resending dns_record_type preserves the existing value.
+func TestAPI_PUT_DNSMonitor_WithoutDNSRecordType(t *testing.T) {
+	c := NewClient(mustAPIKey(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	m := mustCreateMonitor(t, c, ctx, CreateMonitorRequest{
+		Name: uniqueName("dns-preserve-rt"), URL: "example.com", Protocol: "dns",
+		DNSRecordType: strp("CNAME"),
+	})
+	defer cleanupMonitor(t, c, m.UUID)
+
+	// Update name only — dns_record_type not in payload
+	updated, err := c.UpdateMonitor(ctx, m.UUID, UpdateMonitorRequest{
+		Name: strp(m.Name + "-nameonly"),
+	})
+	if err != nil {
+		t.Fatalf("PUT on DNS monitor without dns_record_type failed: %v", err)
+	}
+
+	// Read back to check
+	got, err := c.GetMonitor(ctx, updated.UUID)
+	if err != nil {
+		t.Fatalf("Read after update failed: %v", err)
+	}
+
+	rt := safeDeref(got.DNSRecordType)
+	t.Logf("dns_record_type after updating name only: %q", rt)
+	if rt != "CNAME" {
+		t.Errorf("Expected dns_record_type preserved as 'CNAME', got %q", rt)
+	}
+	t.Logf("PASS: dns_record_type preserved when not included in PUT")
+}

--- a/internal/client/models_common.go
+++ b/internal/client/models_common.go
@@ -145,7 +145,10 @@ var (
 	AllowedTimeouts = []int{5, 10, 15, 20}
 
 	// AllowedProtocols contains valid monitor protocols.
-	AllowedProtocols = []string{"http", "port", "icmp"}
+	AllowedProtocols = []string{"http", "port", "icmp", "dns"}
+
+	// AllowedDNSRecordTypes contains valid DNS record types for DNS-protocol monitors.
+	AllowedDNSRecordTypes = []string{"A", "AAAA", "CNAME", "MX", "NS", "TXT", "SOA", "SRV", "CAA", "PTR"}
 
 	// AllowedMethods contains valid HTTP methods for monitors.
 	AllowedMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}

--- a/internal/client/models_monitor.go
+++ b/internal/client/models_monitor.go
@@ -45,9 +45,11 @@ type Monitor struct {
 	Port               *int            `json:"port,omitempty"`
 	AlertsWait         int             `json:"alerts_wait,omitempty"`
 	EscalationPolicy   *string         `json:"escalation_policy,omitempty"`
-	DNSRecordType      *string         `json:"dns_record_type,omitempty"` // Required for DNS-protocol monitors
-	Status             string          `json:"status,omitempty"`          // up, down (read-only)
-	SSLExpiration      *int            `json:"ssl_expiration,omitempty"`  // Days until SSL cert expiration (read-only)
+	DNSRecordType      *string         `json:"dns_record_type,omitempty"`
+	DNSNameserver      *string         `json:"dns_nameserver,omitempty"`
+	DNSExpectedAnswer  *string         `json:"dns_expected_answer,omitempty"`
+	Status             string          `json:"status,omitempty"`
+	SSLExpiration      *int            `json:"ssl_expiration,omitempty"`
 }
 
 // monitorAlias is used to prevent infinite recursion in Monitor.UnmarshalJSON.
@@ -120,6 +122,9 @@ type CreateMonitorRequest struct {
 	Port               *int            `json:"port,omitempty"`
 	AlertsWait         *int            `json:"alerts_wait,omitempty"`
 	EscalationPolicy   *string         `json:"escalation_policy,omitempty"`
+	DNSRecordType      *string         `json:"dns_record_type,omitempty"`
+	DNSNameserver      *string         `json:"dns_nameserver,omitempty"`
+	DNSExpectedAnswer  *string         `json:"dns_expected_answer,omitempty"`
 }
 
 // Validate checks input lengths on CreateMonitorRequest fields.
@@ -153,4 +158,6 @@ type UpdateMonitorRequest struct {
 	AlertsWait         *int             `json:"alerts_wait,omitempty"`
 	EscalationPolicy   *string          `json:"escalation_policy,omitempty"`
 	DNSRecordType      *string          `json:"dns_record_type,omitempty"`
+	DNSNameserver      *string          `json:"dns_nameserver,omitempty"`
+	DNSExpectedAnswer  *string          `json:"dns_expected_answer,omitempty"`
 }

--- a/internal/client/monitors.go
+++ b/internal/client/monitors.go
@@ -94,26 +94,10 @@ func (c *Client) CreateMonitor(ctx context.Context, req CreateMonitorRequest) (*
 	return &monitor, nil
 }
 
-// dnsRecordTypeWorkaround is a valid enum value sent in every PUT to work
-// around a Hyperping API bug. The PUT /v1/monitors/{uuid} endpoint requires
-// dns_record_type to be a valid enum value in every request, even for non-DNS
-// monitors. Omitted, null, and "" values are all rejected with 422. Sending a
-// valid value like "A" passes validation without affecting monitor behavior —
-// the API ignores dns_record_type for non-DNS protocols and returns null in
-// the response.
-const dnsRecordTypeWorkaround = "A"
-
 // UpdateMonitor updates an existing monitor.
 func (c *Client) UpdateMonitor(ctx context.Context, id string, req UpdateMonitorRequest) (*Monitor, error) {
 	if err := ValidateResourceID(id); err != nil {
 		return nil, fmt.Errorf("UpdateMonitor: %w", err)
-	}
-
-	// Always include a valid dns_record_type to work around the Hyperping
-	// API PUT validation bug. See dnsRecordTypeWorkaround doc for details.
-	if req.DNSRecordType == nil {
-		workaround := dnsRecordTypeWorkaround
-		req.DNSRecordType = &workaround
 	}
 
 	var monitor Monitor

--- a/internal/client/monitors_test.go
+++ b/internal/client/monitors_test.go
@@ -1229,21 +1229,16 @@ func TestUpdateMonitorRequest_JSONMarshaling_OmitsNilFields(t *testing.T) {
 		t.Error("check_frequency should not be present when nil")
 	}
 
-	// dns_record_type should be omitted when nil (omitempty). The workaround
-	// that injects "A" is applied in UpdateMonitor(), not at the struct level.
+	// dns_record_type should be omitted when nil (omitempty).
 	if _, exists := decoded["dns_record_type"]; exists {
 		t.Error("dns_record_type should not be present when nil (omitempty)")
 	}
 }
 
-// TestUpdateMonitor_DNSRecordType_WorkaroundApplied captures the real PUT request
-// body at the HTTP layer and confirms UpdateMonitor injects dns_record_type:"A".
-//
-// The Hyperping API PUT endpoint requires dns_record_type to be a valid enum
-// value in every request, even for non-DNS monitors. Omitted, null, and ""
-// values are all rejected with 422. Sending "A" passes validation without
-// affecting monitor behavior (the API ignores it for non-DNS protocols).
-func TestUpdateMonitor_DNSRecordType_WorkaroundApplied(t *testing.T) {
+// TestUpdateMonitor_DNSRecordType_NotInjected verifies that UpdateMonitor does NOT
+// inject dns_record_type into the PUT body for non-DNS monitors. The Hyperping API
+// previously required this workaround (v1.3.7-v1.5.0) but the bug has been fixed.
+func TestUpdateMonitor_DNSRecordType_NotInjected(t *testing.T) {
 	t.Parallel()
 
 	var capturedBody string
@@ -1274,24 +1269,14 @@ func TestUpdateMonitor_DNSRecordType_WorkaroundApplied(t *testing.T) {
 		t.Fatalf("UpdateMonitor failed: %v", err)
 	}
 
-	t.Logf("=== PUT body captured from HTTP server ===")
-	t.Logf("CURRENT (v1.3.8): %s", capturedBody)
-	t.Logf("v1.3.7 (broken):  {\"name\":\"Updated\",\"dns_record_type\":null} → API rejects null → 422")
-	t.Logf("v1.3.6 (broken):  {\"name\":\"Updated\"} — field absent, API validates stored \"\" → 422")
-	t.Logf("==========================================")
-
 	var decoded map[string]interface{}
 	if err := json.Unmarshal([]byte(capturedBody), &decoded); err != nil {
 		t.Fatalf("failed to parse captured body: %v", err)
 	}
 
-	// dns_record_type must be "A" — the workaround value injected by UpdateMonitor
-	val, exists := decoded["dns_record_type"]
-	if !exists {
-		t.Error("dns_record_type must be present in PUT body (workaround for API validation bug)")
-	}
-	if val != "A" {
-		t.Errorf("dns_record_type must be \"A\" (workaround), got %v", val)
+	// dns_record_type must NOT be present when not explicitly set (workaround removed)
+	if _, exists := decoded["dns_record_type"]; exists {
+		t.Error("dns_record_type must NOT be present in PUT body — the API workaround has been removed")
 	}
 
 	// Sanity: intentionally-set fields still present
@@ -1299,10 +1284,11 @@ func TestUpdateMonitor_DNSRecordType_WorkaroundApplied(t *testing.T) {
 		t.Errorf("name field missing or wrong: %v", decoded["name"])
 	}
 
-	// Sanity: omitempty fields still absent when nil (except dns_record_type which is injected)
+	// Sanity: omitempty fields still absent when nil
 	for _, absent := range []string{"url", "protocol", "http_method", "check_frequency",
 		"regions", "request_headers", "follow_redirects", "paused", "port",
-		"alerts_wait", "escalation_policy", "required_keyword"} {
+		"alerts_wait", "escalation_policy", "required_keyword",
+		"dns_record_type", "dns_nameserver", "dns_expected_answer"} {
 		if _, exists := decoded[absent]; exists {
 			t.Errorf("field %q should be absent (omitempty, nil), but was present", absent)
 		}
@@ -1380,5 +1366,200 @@ func TestMonitor_NumericID_Deserialization(t *testing.T) {
 	}
 	if monitors[1].UUID != "mon_def456" {
 		t.Errorf("expected UUID 'mon_def456', got %q", monitors[1].UUID)
+	}
+}
+
+// TestMonitor_DNSFields_Deserialization verifies DNS fields are correctly parsed
+// from a JSON API response.
+func TestMonitor_DNSFields_Deserialization(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"uuid": "mon_dns1",
+			"name": "DNS Monitor",
+			"url": "example.com",
+			"protocol": "dns",
+			"check_frequency": 60,
+			"dns_record_type": "CNAME",
+			"dns_nameserver": "8.8.8.8",
+			"dns_expected_answer": "www.example.com",
+			"status": "up"
+		}`))
+	}))
+	defer server.Close()
+
+	c := NewClient("test_key", WithBaseURL(server.URL), WithMaxRetries(0))
+	monitor, err := c.GetMonitor(context.Background(), "mon_dns1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if monitor.Protocol != "dns" {
+		t.Errorf("expected protocol 'dns', got %q", monitor.Protocol)
+	}
+	if monitor.DNSRecordType == nil || *monitor.DNSRecordType != "CNAME" {
+		t.Errorf("expected dns_record_type 'CNAME', got %v", monitor.DNSRecordType)
+	}
+	if monitor.DNSNameserver == nil || *monitor.DNSNameserver != "8.8.8.8" {
+		t.Errorf("expected dns_nameserver '8.8.8.8', got %v", monitor.DNSNameserver)
+	}
+	if monitor.DNSExpectedAnswer == nil || *monitor.DNSExpectedAnswer != "www.example.com" {
+		t.Errorf("expected dns_expected_answer 'www.example.com', got %v", monitor.DNSExpectedAnswer)
+	}
+}
+
+// TestMonitor_DNSFields_NilWhenAbsent verifies DNS fields are nil when the API
+// response omits them (e.g. for HTTP monitors).
+func TestMonitor_DNSFields_NilWhenAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"uuid": "mon_http1",
+			"name": "HTTP Monitor",
+			"url": "https://example.com",
+			"protocol": "http",
+			"check_frequency": 60,
+			"status": "up"
+		}`))
+	}))
+	defer server.Close()
+
+	c := NewClient("test_key", WithBaseURL(server.URL), WithMaxRetries(0))
+	monitor, err := c.GetMonitor(context.Background(), "mon_http1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if monitor.DNSRecordType != nil {
+		t.Errorf("expected dns_record_type nil for HTTP monitor, got %q", *monitor.DNSRecordType)
+	}
+	if monitor.DNSNameserver != nil {
+		t.Errorf("expected dns_nameserver nil for HTTP monitor, got %q", *monitor.DNSNameserver)
+	}
+	if monitor.DNSExpectedAnswer != nil {
+		t.Errorf("expected dns_expected_answer nil for HTTP monitor, got %q", *monitor.DNSExpectedAnswer)
+	}
+}
+
+// TestCreateMonitorRequest_DNSFields_JSONMarshaling verifies DNS fields are correctly
+// included in the JSON body when creating a DNS monitor.
+func TestCreateMonitorRequest_DNSFields_JSONMarshaling(t *testing.T) {
+	drt := "MX"
+	ns := "1.1.1.1"
+	ea := "mail.example.com"
+
+	req := CreateMonitorRequest{
+		Name:              "DNS Test",
+		URL:               "example.com",
+		Protocol:          "dns",
+		DNSRecordType:     &drt,
+		DNSNameserver:     &ns,
+		DNSExpectedAnswer: &ea,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if decoded["protocol"] != "dns" {
+		t.Errorf("protocol = %v, expected 'dns'", decoded["protocol"])
+	}
+	if decoded["dns_record_type"] != "MX" {
+		t.Errorf("dns_record_type = %v, expected 'MX'", decoded["dns_record_type"])
+	}
+	if decoded["dns_nameserver"] != "1.1.1.1" {
+		t.Errorf("dns_nameserver = %v, expected '1.1.1.1'", decoded["dns_nameserver"])
+	}
+	if decoded["dns_expected_answer"] != "mail.example.com" {
+		t.Errorf("dns_expected_answer = %v, expected 'mail.example.com'", decoded["dns_expected_answer"])
+	}
+}
+
+// TestUpdateMonitorRequest_DNSFields_JSONMarshaling verifies DNS fields in update requests.
+func TestUpdateMonitorRequest_DNSFields_JSONMarshaling(t *testing.T) {
+	drt := "AAAA"
+	ns := "8.8.4.4"
+	ea := "::1"
+
+	req := UpdateMonitorRequest{
+		DNSRecordType:     &drt,
+		DNSNameserver:     &ns,
+		DNSExpectedAnswer: &ea,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if decoded["dns_record_type"] != "AAAA" {
+		t.Errorf("dns_record_type = %v, expected 'AAAA'", decoded["dns_record_type"])
+	}
+	if decoded["dns_nameserver"] != "8.8.4.4" {
+		t.Errorf("dns_nameserver = %v, expected '8.8.4.4'", decoded["dns_nameserver"])
+	}
+	if decoded["dns_expected_answer"] != "::1" {
+		t.Errorf("dns_expected_answer = %v, expected '::1'", decoded["dns_expected_answer"])
+	}
+
+	// Other fields must be absent (omitempty)
+	if _, exists := decoded["name"]; exists {
+		t.Error("name should not be present when nil")
+	}
+}
+
+// TestUpdateMonitor_DNSFields_SentInPUTBody captures the actual PUT body and verifies
+// DNS fields are passed through to the API when explicitly set.
+func TestUpdateMonitor_DNSFields_SentInPUTBody(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		capturedBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(Monitor{UUID: "mon_dns", Protocol: "dns"})
+	}))
+	defer server.Close()
+
+	c := NewClient("test_key", WithBaseURL(server.URL), WithMaxRetries(0))
+
+	drt := "TXT"
+	ns := "ns1.example.com"
+	ea := "v=spf1 include:example.com"
+	_, err := c.UpdateMonitor(context.Background(), "mon_dns", UpdateMonitorRequest{
+		DNSRecordType:     &drt,
+		DNSNameserver:     &ns,
+		DNSExpectedAnswer: &ea,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMonitor failed: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal([]byte(capturedBody), &decoded); err != nil {
+		t.Fatalf("failed to parse captured body: %v", err)
+	}
+
+	if decoded["dns_record_type"] != "TXT" {
+		t.Errorf("dns_record_type = %v, expected 'TXT'", decoded["dns_record_type"])
+	}
+	if decoded["dns_nameserver"] != "ns1.example.com" {
+		t.Errorf("dns_nameserver = %v, expected 'ns1.example.com'", decoded["dns_nameserver"])
+	}
+	if decoded["dns_expected_answer"] != "v=spf1 include:example.com" {
+		t.Errorf("dns_expected_answer = %v, expected SPF record", decoded["dns_expected_answer"])
 	}
 }

--- a/internal/provider/error_diagnostics.go
+++ b/internal/provider/error_diagnostics.go
@@ -37,6 +37,7 @@ func buildMonitorReference() string {
 	fmt.Fprintf(&b, "  check_frequency:      %s\n", formatIntSlice(client.AllowedFrequencies))
 	b.WriteString("  expected_status_code: Specific code (200), wildcard (2xx), or range (1xx-3xx)\n")
 	fmt.Fprintf(&b, "  regions:              %s\n", strings.Join(client.AllowedRegions, ", "))
+	fmt.Fprintf(&b, "  dns_record_type:      %s\n", strings.Join(client.AllowedDNSRecordTypes, ", "))
 	fmt.Fprintf(&b, "  alerts_wait:          %s\n", formatAlertsWaitValues())
 	return b.String()
 }

--- a/internal/provider/mapping.go
+++ b/internal/provider/mapping.go
@@ -60,11 +60,21 @@ func MapMonitorCommonFields(monitor *client.Monitor, diags *diag.Diagnostics) Mo
 		result.EscalationPolicy = types.StringNull()
 	}
 
-	// Handle dns_record_type (DNS-protocol monitors only)
+	// Handle DNS-protocol fields
 	if monitor.DNSRecordType != nil && *monitor.DNSRecordType != "" {
 		result.DNSRecordType = types.StringValue(*monitor.DNSRecordType)
 	} else {
 		result.DNSRecordType = types.StringNull()
+	}
+	if monitor.DNSNameserver != nil && *monitor.DNSNameserver != "" {
+		result.DNSNameserver = types.StringValue(*monitor.DNSNameserver)
+	} else {
+		result.DNSNameserver = types.StringNull()
+	}
+	if monitor.DNSExpectedAnswer != nil && *monitor.DNSExpectedAnswer != "" {
+		result.DNSExpectedAnswer = types.StringValue(*monitor.DNSExpectedAnswer)
+	} else {
+		result.DNSExpectedAnswer = types.StringNull()
 	}
 
 	// Handle required_keyword
@@ -112,6 +122,8 @@ type MonitorCommonFields struct {
 	AlertsWait         types.Int64
 	EscalationPolicy   types.String
 	DNSRecordType      types.String
+	DNSNameserver      types.String
+	DNSExpectedAnswer  types.String
 	RequiredKeyword    types.String
 	Status             types.String
 	SSLExpiration      types.Int64

--- a/internal/provider/monitor_data_source.go
+++ b/internal/provider/monitor_data_source.go
@@ -49,6 +49,8 @@ type MonitorDataSourceModel struct {
 	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
 	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
 	DNSRecordType      types.String `tfsdk:"dns_record_type"`
+	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
 	RequiredKeyword    types.String `tfsdk:"required_keyword"`
 	Status             types.String `tfsdk:"status"`
 	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
@@ -79,7 +81,7 @@ func (d *MonitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Computed:            true,
 			},
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "The protocol used for monitoring (http, icmp, tcp, udp).",
+				MarkdownDescription: "The protocol used for monitoring (http, port, icmp, dns).",
 				Computed:            true,
 			},
 			"http_method": schema.StringAttribute{
@@ -142,6 +144,14 @@ func (d *MonitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			},
 			"dns_record_type": schema.StringAttribute{
 				MarkdownDescription: "DNS record type for DNS-protocol monitors.",
+				Computed:            true,
+			},
+			"dns_nameserver": schema.StringAttribute{
+				MarkdownDescription: "Nameserver used for DNS queries.",
+				Computed:            true,
+			},
+			"dns_expected_answer": schema.StringAttribute{
+				MarkdownDescription: "Expected DNS answer to validate against.",
 				Computed:            true,
 			},
 			"required_keyword": schema.StringAttribute{
@@ -230,6 +240,8 @@ func (d *MonitorDataSource) mapMonitorToDataSourceModel(monitor *client.Monitor,
 	model.AlertsWait = fields.AlertsWait
 	model.EscalationPolicy = fields.EscalationPolicy
 	model.DNSRecordType = fields.DNSRecordType
+	model.DNSNameserver = fields.DNSNameserver
+	model.DNSExpectedAnswer = fields.DNSExpectedAnswer
 	model.RequiredKeyword = fields.RequiredKeyword
 	model.Status = fields.Status
 	model.SSLExpiration = fields.SSLExpiration

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -61,6 +61,8 @@ type MonitorResourceModel struct {
 	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
 	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
 	DNSRecordType      types.String `tfsdk:"dns_record_type"`
+	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
 	RequiredKeyword    types.String `tfsdk:"required_keyword"`
 	Status             types.String `tfsdk:"status"`
 	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
@@ -93,14 +95,12 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"url": schema.StringAttribute{
-				MarkdownDescription: "The URL to monitor. Must include protocol scheme (e.g., `https://api.example.com/health`).",
-				Required:            true,
-				Validators: []validator.String{
-					URLFormat(),
-				},
+				MarkdownDescription: "The URL to monitor. For HTTP/ICMP/port protocols, must include scheme " +
+					"(e.g., `https://api.example.com/health`). For DNS protocol, use a bare domain (e.g., `example.com`).",
+				Required: true,
 			},
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "The protocol type. Valid values: `http`, `port`, `icmp`. Defaults to `http`.",
+				MarkdownDescription: "The protocol type. Valid values: `http`, `port`, `icmp`, `dns`. Defaults to `http`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("http"),
@@ -208,8 +208,24 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"dns_record_type": schema.StringAttribute{
-				MarkdownDescription: "DNS record type for DNS-protocol monitors (read-only, set by the API).",
-				Computed:            true,
+				MarkdownDescription: "DNS record type to check. Only valid when protocol is `dns`. " +
+					"Valid values: `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SOA`, `SRV`, `CAA`, `PTR`. " +
+					"Defaults to `A` (set by the API if omitted).",
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(client.AllowedDNSRecordTypes...),
+				},
+			},
+			"dns_nameserver": schema.StringAttribute{
+				MarkdownDescription: "Nameserver to query against (e.g., `8.8.8.8`). " +
+					"Only valid when protocol is `dns`. Leave empty to use default resolvers.",
+				Optional: true,
+			},
+			"dns_expected_answer": schema.StringAttribute{
+				MarkdownDescription: "Expected DNS answer to validate against. " +
+					"Only valid when protocol is `dns`. Monitor fails if the resolved value does not contain this string.",
+				Optional: true,
 			},
 			"required_keyword": schema.StringAttribute{
 				MarkdownDescription: "A keyword that must appear in the HTTP response body for the check to pass. Only valid when protocol is `http`.",
@@ -550,11 +566,21 @@ func (r *MonitorResource) mapMonitorToModel(monitor *client.Monitor, model *Moni
 		model.EscalationPolicy = types.StringNull()
 	}
 
-	// Handle dns_record_type (DNS-protocol monitors only)
+	// Handle DNS-protocol fields
 	if monitor.DNSRecordType != nil && *monitor.DNSRecordType != "" {
 		model.DNSRecordType = types.StringValue(*monitor.DNSRecordType)
 	} else {
 		model.DNSRecordType = types.StringNull()
+	}
+	if monitor.DNSNameserver != nil && *monitor.DNSNameserver != "" {
+		model.DNSNameserver = types.StringValue(*monitor.DNSNameserver)
+	} else {
+		model.DNSNameserver = types.StringNull()
+	}
+	if monitor.DNSExpectedAnswer != nil && *monitor.DNSExpectedAnswer != "" {
+		model.DNSExpectedAnswer = types.StringValue(*monitor.DNSExpectedAnswer)
+	} else {
+		model.DNSExpectedAnswer = types.StringNull()
 	}
 
 	// Handle required_keyword
@@ -625,6 +651,11 @@ func (r *MonitorResource) buildCreateRequest(ctx context.Context, plan *MonitorR
 
 	// Handle optional required_keyword
 	createReq.RequiredKeyword = tfStringToPtr(plan.RequiredKeyword)
+
+	// Handle optional DNS fields
+	createReq.DNSRecordType = tfStringToPtr(plan.DNSRecordType)
+	createReq.DNSNameserver = tfStringToPtr(plan.DNSNameserver)
+	createReq.DNSExpectedAnswer = tfStringToPtr(plan.DNSExpectedAnswer)
 
 	// Handle optional project_uuid
 	createReq.ProjectUUID = plan.ProjectUUID.ValueString()
@@ -776,6 +807,27 @@ func applyMonitoringFieldChanges(ctx context.Context, plan *MonitorResourceModel
 	// Handle port
 	if !plan.Port.Equal(state.Port) {
 		updateReq.Port = tfIntToPtr(plan.Port)
+	}
+
+	// Handle DNS fields
+	if !plan.DNSRecordType.Equal(state.DNSRecordType) {
+		updateReq.DNSRecordType = tfStringToPtr(plan.DNSRecordType)
+	}
+	if !plan.DNSNameserver.Equal(state.DNSNameserver) {
+		if plan.DNSNameserver.IsNull() {
+			empty := ""
+			updateReq.DNSNameserver = &empty
+		} else {
+			updateReq.DNSNameserver = tfStringToPtr(plan.DNSNameserver)
+		}
+	}
+	if !plan.DNSExpectedAnswer.Equal(state.DNSExpectedAnswer) {
+		if plan.DNSExpectedAnswer.IsNull() {
+			empty := ""
+			updateReq.DNSExpectedAnswer = &empty
+		} else {
+			updateReq.DNSExpectedAnswer = tfStringToPtr(plan.DNSExpectedAnswer)
+		}
 	}
 }
 

--- a/internal/provider/monitor_resource_dns_test.go
+++ b/internal/provider/monitor_resource_dns_test.go
@@ -1,0 +1,534 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccMonitorResource_dnsBasic tests basic DNS monitor creation with defaults.
+func TestAccMonitorResource_dnsBasic(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccMonitorResourceConfigDNSBasic(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "name", "dns-basic"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "url", "example.com"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+					// dns_record_type should be computed to "A" (API default)
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "A"),
+					tfresource.TestCheckResourceAttrSet("hyperping_monitor.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "hyperping_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsFull tests DNS monitor creation with all DNS fields.
+func TestAccMonitorResource_dnsFull(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccMonitorResourceConfigDNSFull(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "name", "dns-full"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "url", "example.com"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "CNAME"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "8.8.8.8"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "www.example.com"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "check_frequency", "300"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "hyperping_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsUpdate tests updating DNS monitor fields.
+func TestAccMonitorResource_dnsUpdate(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Create with full DNS config
+			{
+				Config: testAccMonitorResourceConfigDNSFull(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "CNAME"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "8.8.8.8"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "www.example.com"),
+				),
+			},
+			// Update all DNS fields
+			{
+				Config: testAccMonitorResourceConfigDNSUpdate(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "name", "dns-updated"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "MX"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "1.1.1.1"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "mail.example.com"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "check_frequency", "600"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsFieldsOnHTTP tests that DNS fields are rejected on HTTP protocol.
+func TestAccMonitorResource_dnsFieldsOnHTTP(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name            = "http-with-dns-fields"
+  url             = "https://example.com"
+  protocol        = "http"
+  dns_record_type = "A"
+}
+`,
+				ExpectError: regexp.MustCompile(`dns_record_type is only valid for DNS monitors`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsFieldsOnICMP tests that DNS fields are rejected on ICMP protocol.
+func TestAccMonitorResource_dnsFieldsOnICMP(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name           = "icmp-with-dns-fields"
+  url            = "https://example.com"
+  protocol       = "icmp"
+  dns_nameserver = "8.8.8.8"
+}
+`,
+				ExpectError: regexp.MustCompile(`dns_nameserver is only valid for DNS monitors`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsFieldsOnPort tests that DNS fields are rejected on port protocol.
+func TestAccMonitorResource_dnsFieldsOnPort(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name                = "port-with-dns-fields"
+  url                 = "https://example.com"
+  protocol            = "port"
+  port                = 5432
+  dns_expected_answer = "127.0.0.1"
+}
+`,
+				ExpectError: regexp.MustCompile(`dns_expected_answer is only valid for DNS monitors`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsWithHTTPFields tests that HTTP fields are rejected on DNS protocol.
+func TestAccMonitorResource_dnsWithHTTPFields(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name        = "dns-with-http-fields"
+  url         = "example.com"
+  protocol    = "dns"
+  http_method = "POST"
+}
+`,
+				ExpectError: regexp.MustCompile(`http_method is only valid for HTTP monitors`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsWithPort tests that port is rejected on DNS protocol.
+func TestAccMonitorResource_dnsWithPort(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name     = "dns-with-port"
+  url      = "example.com"
+  protocol = "dns"
+  port     = 53
+}
+`,
+				ExpectError: regexp.MustCompile(`port is not valid when protocol is "dns"`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsRecordTypeNotLeakedToHTTP verifies that updating
+// an HTTP monitor does not cause dns_record_type to appear in its state.
+func TestAccMonitorResource_dnsRecordTypeNotLeakedToHTTP(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Create a basic HTTP monitor
+			{
+				Config: testAccMonitorResourceConfigBasic(server.URL, "no-leak-test"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "http"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_record_type"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_nameserver"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_expected_answer"),
+				),
+			},
+			// Update the HTTP monitor — DNS fields must remain absent
+			{
+				Config: testAccMonitorResourceConfigUpdateAll(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "name", "updated-all-fields"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_record_type"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_nameserver"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_expected_answer"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsToHTTPSwitch tests protocol switch from DNS to HTTP.
+// DNS fields should be cleared when switching to HTTP.
+func TestAccMonitorResource_dnsToHTTPSwitch(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Start with a full DNS monitor
+			{
+				Config: testAccMonitorResourceConfigDNSFull(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "CNAME"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "8.8.8.8"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "www.example.com"),
+				),
+			},
+			// Switch to HTTP — remove DNS fields, add HTTP URL
+			{
+				Config: testAccMonitorResourceConfigSwitchDNSToHTTP(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "http"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "url", "https://example.com"),
+					// DNS fields must not appear in state
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_record_type"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_nameserver"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_expected_answer"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_httpToDNSSwitch tests protocol switch from HTTP to DNS.
+func TestAccMonitorResource_httpToDNSSwitch(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Start with an HTTP monitor
+			{
+				Config: testAccMonitorResourceConfigBasic(server.URL, "switch-to-dns"),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "http"),
+				),
+			},
+			// Switch to DNS
+			{
+				Config: testAccMonitorResourceConfigDNSFull(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "CNAME"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "8.8.8.8"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "www.example.com"),
+				),
+			},
+			// Import and verify DNS fields persist
+			{
+				ResourceName:      "hyperping_monitor.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsRemoveOptionalFields tests removing optional DNS fields.
+// dns_nameserver and dns_expected_answer can be removed while keeping dns_record_type.
+func TestAccMonitorResource_dnsRemoveOptionalFields(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			// Create with all DNS fields
+			{
+				Config: testAccMonitorResourceConfigDNSFull(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "CNAME"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_nameserver", "8.8.8.8"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_expected_answer", "www.example.com"),
+				),
+			},
+			// Remove nameserver and expected_answer, keep record_type
+			{
+				Config: testAccMonitorResourceConfigDNSRecordTypeOnly(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", "AAAA"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_nameserver"),
+					tfresource.TestCheckNoResourceAttr("hyperping_monitor.test", "dns_expected_answer"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsAllRecordTypes tests that each supported DNS record type is accepted.
+func TestAccMonitorResource_dnsAllRecordTypes(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	// Test a subset of record types to keep the test fast
+	recordTypes := []string{"A", "AAAA", "CNAME", "MX", "NS", "TXT"}
+
+	steps := make([]tfresource.TestStep, len(recordTypes))
+	for i, rt := range recordTypes {
+		rt := rt // capture loop variable
+		steps[i] = tfresource.TestStep{
+			Config: testAccMonitorResourceConfigDNSWithRecordType(server.URL, rt),
+			Check: tfresource.ComposeAggregateTestCheckFunc(
+				tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+				tfresource.TestCheckResourceAttr("hyperping_monitor.test", "dns_record_type", rt),
+			),
+		}
+	}
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    steps,
+	})
+}
+
+// TestAccMonitorResource_dnsInvalidRecordType tests that an invalid DNS record type is rejected.
+func TestAccMonitorResource_dnsInvalidRecordType(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccMonitorResourceConfigDNSWithRecordType(server.URL, "INVALID"),
+				ExpectError: regexp.MustCompile(
+					`value must be one of`,
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsURLAcceptsBaredomain verifies DNS monitors accept bare domains.
+func TestAccMonitorResource_dnsURLAcceptsBaredomain(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccMonitorResourceConfigDNSBasic(server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "url", "example.com"),
+					tfresource.TestCheckResourceAttr("hyperping_monitor.test", "protocol", "dns"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_httpURLRejectsBareDomain verifies HTTP monitors reject bare domains.
+func TestAccMonitorResource_httpURLRejectsBareDomain(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: testAccProviderConfig(server.URL) + `
+resource "hyperping_monitor" "test" {
+  name     = "http-bare-domain"
+  url      = "example.com"
+  protocol = "http"
+}
+`,
+				ExpectError: regexp.MustCompile(`Invalid URL Format`),
+			},
+		},
+	})
+}
+
+// TestAccMonitorResource_dnsAllFieldsCrossValidation tests that ALL DNS fields
+// are rejected on ALL non-DNS protocols (combinatorial coverage).
+func TestAccMonitorResource_dnsAllFieldsCrossValidation(t *testing.T) {
+	server := newMockHyperpingServer(t)
+	defer server.Close()
+
+	tests := []struct {
+		name     string
+		config   string
+		errMatch string
+	}{
+		{
+			name: "http_with_dns_nameserver",
+			config: `
+resource "hyperping_monitor" "test" {
+  name           = "cross-val-test"
+  url            = "https://example.com"
+  protocol       = "http"
+  dns_nameserver = "8.8.8.8"
+}`,
+			errMatch: `dns_nameserver is only valid for DNS monitors`,
+		},
+		{
+			name: "http_with_dns_expected_answer",
+			config: `
+resource "hyperping_monitor" "test" {
+  name                = "cross-val-test"
+  url                 = "https://example.com"
+  protocol            = "http"
+  dns_expected_answer = "127.0.0.1"
+}`,
+			errMatch: `dns_expected_answer is only valid for DNS monitors`,
+		},
+		{
+			name: "icmp_with_dns_record_type",
+			config: `
+resource "hyperping_monitor" "test" {
+  name            = "cross-val-test"
+  url             = "https://example.com"
+  protocol        = "icmp"
+  dns_record_type = "A"
+}`,
+			errMatch: `dns_record_type is only valid for DNS monitors`,
+		},
+		{
+			name: "icmp_with_dns_expected_answer",
+			config: `
+resource "hyperping_monitor" "test" {
+  name                = "cross-val-test"
+  url                 = "https://example.com"
+  protocol            = "icmp"
+  dns_expected_answer = "10.0.0.1"
+}`,
+			errMatch: `dns_expected_answer is only valid for DNS monitors`,
+		},
+		{
+			name: "port_with_dns_record_type",
+			config: `
+resource "hyperping_monitor" "test" {
+  name            = "cross-val-test"
+  url             = "https://example.com"
+  protocol        = "port"
+  port            = 443
+  dns_record_type = "MX"
+}`,
+			errMatch: `dns_record_type is only valid for DNS monitors`,
+		},
+		{
+			name: "port_with_dns_nameserver",
+			config: `
+resource "hyperping_monitor" "test" {
+  name           = "cross-val-test"
+  url            = "https://example.com"
+  protocol       = "port"
+  port           = 443
+  dns_nameserver = "1.1.1.1"
+}`,
+			errMatch: `dns_nameserver is only valid for DNS monitors`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tfresource.Test(t, tfresource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []tfresource.TestStep{
+					{
+						Config:      testAccProviderConfig(server.URL) + tc.config,
+						ExpectError: regexp.MustCompile(tc.errMatch),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/provider/monitor_resource_test_helpers.go
+++ b/internal/provider/monitor_resource_test_helpers.go
@@ -446,8 +446,23 @@ func (m *mockHyperpingServer) createMonitor(w http.ResponseWriter, r *http.Reque
 		monitor["required_keyword"] = requiredKeyword
 	}
 
-	// dns_record_type is intentionally NOT stored — the real API ignores it
-	// for non-DNS monitors and returns null. See dnsRecordTypeWorkaround in monitors.go.
+	// Handle DNS fields — only store for DNS protocol monitors
+	protocol := getOrDefault(req, "protocol", "http")
+	if protocol == "dns" {
+		if drt, ok := req["dns_record_type"].(string); ok && drt != "" {
+			monitor["dns_record_type"] = drt
+		} else {
+			monitor["dns_record_type"] = "A" // API default
+		}
+		if ns, ok := req["dns_nameserver"].(string); ok {
+			monitor["dns_nameserver"] = ns
+		}
+		if ea, ok := req["dns_expected_answer"].(string); ok {
+			monitor["dns_expected_answer"] = ea
+		}
+	}
+	// For non-DNS monitors, dns_record_type is intentionally NOT stored —
+	// the real API ignores it and returns null.
 
 	m.monitors[id] = monitor
 
@@ -533,6 +548,11 @@ var monitorStringFields = map[string]bool{
 	"status":           true, "projectUuid": true,
 }
 
+// dnsStringFields are DNS-specific fields that should only be stored for DNS monitors.
+var dnsStringFields = map[string]bool{
+	"dns_record_type": true, "dns_nameserver": true, "dns_expected_answer": true,
+}
+
 // intFields are monitor fields that map from JSON numbers.
 var monitorIntFields = map[string]bool{
 	"check_frequency": true, "port": true, "alerts_wait": true, "ssl_expiration": true,
@@ -552,6 +572,12 @@ func applyMonitorField(monitor map[string]interface{}, key string, value interfa
 		applyIntField(monitor, key, value)
 	case monitorBoolFields[key]:
 		applyBoolField(monitor, key, value)
+	case dnsStringFields[key]:
+		// DNS fields are only stored for DNS monitors, matching real API behavior.
+		// The real API ignores dns_record_type on non-DNS monitors.
+		if protocol, ok := monitor["protocol"].(string); ok && protocol == "dns" {
+			applyStringField(monitor, key, value)
+		}
 	case key == "regions":
 		applyRegionsField(monitor, key, value)
 	case key == "request_headers":
@@ -591,8 +617,23 @@ func (m *mockHyperpingServer) updateMonitor(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Apply protocol first so DNS field logic in applyMonitorField sees the new protocol.
+	if proto, ok := req["protocol"]; ok {
+		applyMonitorField(monitor, "protocol", proto)
+	}
+
 	for key, value := range req {
+		if key == "protocol" {
+			continue // already applied above
+		}
 		applyMonitorField(monitor, key, value)
+	}
+
+	// When protocol changes away from DNS, clear DNS-specific fields (matches real API behavior).
+	if newProtocol, ok := req["protocol"].(string); ok && newProtocol != "dns" {
+		delete(monitor, "dns_record_type")
+		delete(monitor, "dns_nameserver")
+		delete(monitor, "dns_expected_answer")
 	}
 
 	m.monitors[id] = monitor
@@ -686,4 +727,77 @@ provider "hyperping" {
 // tfInt formats an integer value for use in HCL configuration strings.
 func tfInt(val int) string {
 	return fmt.Sprintf("%d", val)
+}
+
+// DNS monitor test configs
+
+func testAccMonitorResourceConfigDNSBasic(baseURL string) string {
+	return testAccProviderConfig(baseURL) + `
+resource "hyperping_monitor" "test" {
+  name     = "dns-basic"
+  url      = "example.com"
+  protocol = "dns"
+}
+`
+}
+
+func testAccMonitorResourceConfigDNSFull(baseURL string) string {
+	return testAccProviderConfig(baseURL) + `
+resource "hyperping_monitor" "test" {
+  name                = "dns-full"
+  url                 = "example.com"
+  protocol            = "dns"
+  dns_record_type     = "CNAME"
+  dns_nameserver      = "8.8.8.8"
+  dns_expected_answer = "www.example.com"
+  check_frequency     = 300
+  regions             = ["london", "virginia"]
+}
+`
+}
+
+func testAccMonitorResourceConfigDNSUpdate(baseURL string) string {
+	return testAccProviderConfig(baseURL) + `
+resource "hyperping_monitor" "test" {
+  name                = "dns-updated"
+  url                 = "example.com"
+  protocol            = "dns"
+  dns_record_type     = "MX"
+  dns_nameserver      = "1.1.1.1"
+  dns_expected_answer = "mail.example.com"
+  check_frequency     = 600
+}
+`
+}
+
+func testAccMonitorResourceConfigDNSRecordTypeOnly(baseURL string) string {
+	return testAccProviderConfig(baseURL) + `
+resource "hyperping_monitor" "test" {
+  name            = "dns-record-type-only"
+  url             = "example.com"
+  protocol        = "dns"
+  dns_record_type = "AAAA"
+}
+`
+}
+
+func testAccMonitorResourceConfigDNSWithRecordType(baseURL, recordType string) string {
+	return testAccProviderConfig(baseURL) + fmt.Sprintf(`
+resource "hyperping_monitor" "test" {
+  name            = "dns-record-type-test"
+  url             = "example.com"
+  protocol        = "dns"
+  dns_record_type = %q
+}
+`, recordType)
+}
+
+func testAccMonitorResourceConfigSwitchDNSToHTTP(baseURL string) string {
+	return testAccProviderConfig(baseURL) + `
+resource "hyperping_monitor" "test" {
+  name     = "dns-switched-to-http"
+  url      = "https://example.com"
+  protocol = "http"
+}
+`
 }

--- a/internal/provider/monitor_validate_config.go
+++ b/internal/provider/monitor_validate_config.go
@@ -6,6 +6,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -31,24 +33,54 @@ func (r *MonitorResource) ValidateConfig(ctx context.Context, req resource.Valid
 
 	switch protocolValue {
 	case "icmp":
+		validateURLIsHTTP(ctx, req, resp)
 		validateNonHTTPProtocol(ctx, req, resp, "icmp")
 		validatePortNotSet(ctx, req, resp, "icmp")
+		validateDNSFieldsNotSet(ctx, req, resp, "icmp")
 	case "port":
+		validateURLIsHTTP(ctx, req, resp)
 		validateNonHTTPProtocol(ctx, req, resp, "port")
 		validatePortRequired(ctx, req, resp)
+		validateDNSFieldsNotSet(ctx, req, resp, "port")
 	case "http":
+		validateURLIsHTTP(ctx, req, resp)
 		validateHTTPProtocol(ctx, req, resp)
+		validateDNSFieldsNotSet(ctx, req, resp, "http")
+	case "dns":
+		validateNonHTTPProtocol(ctx, req, resp, "dns")
+		validatePortNotSet(ctx, req, resp, "dns")
+	}
+}
+
+// validateURLIsHTTP checks that the url attribute is a valid HTTP or HTTPS URL.
+// This applies to http, port, and icmp protocols. DNS monitors use bare domains instead.
+func validateURLIsHTTP(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var urlVal types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("url"), &urlVal)...)
+	if resp.Diagnostics.HasError() || urlVal.IsNull() || urlVal.IsUnknown() {
+		return
+	}
+
+	value := urlVal.ValueString()
+	u, err := url.Parse(value)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("url"),
+			"Invalid URL Format",
+			fmt.Sprintf("The value %q must be a valid HTTP or HTTPS URL (e.g., \"https://example.com\"). "+
+				"For DNS monitors, bare domain names are accepted.", value),
+		)
 	}
 }
 
 // validateNonHTTPProtocol checks that HTTP-only fields are not set for non-HTTP protocols.
 func validateNonHTTPProtocol(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, protocol string) {
-	checkStringNotSet(ctx, req, resp, "http_method", protocol)
-	checkStringNotSet(ctx, req, resp, "expected_status_code", protocol)
+	checkStringNotSet(ctx, req, resp, "http_method", protocol, "http")
+	checkStringNotSet(ctx, req, resp, "expected_status_code", protocol, "http")
 	checkBoolNotSet(ctx, req, resp, "follow_redirects", protocol)
 	checkListNotSet(ctx, req, resp, "request_headers", protocol)
-	checkStringNotSet(ctx, req, resp, "request_body", protocol)
-	checkStringNotSet(ctx, req, resp, "required_keyword", protocol)
+	checkStringNotSet(ctx, req, resp, "request_body", protocol, "http")
+	checkStringNotSet(ctx, req, resp, "required_keyword", protocol, "http")
 }
 
 // validatePortRequired checks that port is set when protocol is "port".
@@ -100,8 +132,16 @@ func checkPortNotSet(ctx context.Context, req resource.ValidateConfigRequest, re
 	}
 }
 
+// validateDNSFieldsNotSet checks that DNS-only fields are not set for non-DNS protocols.
+func validateDNSFieldsNotSet(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, protocol string) {
+	checkStringNotSet(ctx, req, resp, "dns_record_type", protocol, "dns")
+	checkStringNotSet(ctx, req, resp, "dns_nameserver", protocol, "dns")
+	checkStringNotSet(ctx, req, resp, "dns_expected_answer", protocol, "dns")
+}
+
 // checkStringNotSet adds a diagnostic error if a string attribute is explicitly set.
-func checkStringNotSet(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, attrName, protocol string) {
+// ownerProtocol is the protocol that owns this field (e.g. "http", "dns").
+func checkStringNotSet(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse, attrName, protocol, ownerProtocol string) {
 	var val types.String
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root(attrName), &val)...)
 	if resp.Diagnostics.HasError() {
@@ -112,8 +152,8 @@ func checkStringNotSet(ctx context.Context, req resource.ValidateConfigRequest, 
 		resp.Diagnostics.AddAttributeError(
 			path.Root(attrName),
 			"Invalid Attribute Combination",
-			fmt.Sprintf("%s is only valid for HTTP monitors. When protocol is %q, remove %s or change protocol to \"http\".",
-				attrName, protocol, attrName),
+			fmt.Sprintf("%s is only valid for %s monitors. When protocol is %q, remove %s or change protocol to %q.",
+				attrName, strings.ToUpper(ownerProtocol), protocol, attrName, ownerProtocol),
 		)
 	}
 }

--- a/internal/provider/monitors_data_source.go
+++ b/internal/provider/monitors_data_source.go
@@ -58,6 +58,8 @@ type MonitorDataModel struct {
 	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
 	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
 	DNSRecordType      types.String `tfsdk:"dns_record_type"`
+	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
 	RequiredKeyword    types.String `tfsdk:"required_keyword"`
 	Status             types.String `tfsdk:"status"`
 	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
@@ -103,7 +105,7 @@ func (d *MonitorsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 							Computed:            true,
 						},
 						"protocol": schema.StringAttribute{
-							MarkdownDescription: "The protocol used for monitoring (http, icmp, tcp, udp).",
+							MarkdownDescription: "The protocol used for monitoring (http, port, icmp, dns).",
 							Computed:            true,
 						},
 						"http_method": schema.StringAttribute{
@@ -166,6 +168,14 @@ func (d *MonitorsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 						},
 						"dns_record_type": schema.StringAttribute{
 							MarkdownDescription: "DNS record type for DNS-protocol monitors.",
+							Computed:            true,
+						},
+						"dns_nameserver": schema.StringAttribute{
+							MarkdownDescription: "Nameserver used for DNS queries.",
+							Computed:            true,
+						},
+						"dns_expected_answer": schema.StringAttribute{
+							MarkdownDescription: "Expected DNS answer to validate against.",
 							Computed:            true,
 						},
 						"required_keyword": schema.StringAttribute{
@@ -362,6 +372,8 @@ func (d *MonitorsDataSource) mapMonitorToDataModel(monitor *client.Monitor, mode
 	model.AlertsWait = fields.AlertsWait
 	model.EscalationPolicy = fields.EscalationPolicy
 	model.DNSRecordType = fields.DNSRecordType
+	model.DNSNameserver = fields.DNSNameserver
+	model.DNSExpectedAnswer = fields.DNSExpectedAnswer
 	model.RequiredKeyword = fields.RequiredKeyword
 	model.Status = types.StringValue(monitor.Status)
 	model.SSLExpiration = func() types.Int64 {


### PR DESCRIPTION
## Summary

- Add DNS protocol support alongside existing HTTP, ICMP, and port monitors
- DNS monitors use bare domain names with `dns_record_type` (Optional+Computed, defaults to "A"), `dns_nameserver`, and `dns_expected_answer` fields
- Remove `dns_record_type` PUT workaround — API bug confirmed fixed via 13 integration tests against real Hyperping API
- Add protocol-aware URL validation and cross-field validation at plan time

## Changes

- **Client layer**: Add DNS fields to Monitor, CreateMonitorRequest, UpdateMonitorRequest; remove workaround from UpdateMonitor
- **Resource/data sources**: DNS fields in schema, create, update, mapping, and both data sources
- **Validation**: Protocol-aware URL validation (bare domains for DNS, HTTP(S) URLs for others); cross-field rejection of DNS fields on non-DNS protocols and vice versa; DRY up overlapping validate functions
- **Tests**: 16 acceptance tests, 8 client unit tests, 13 API integration tests (all 10 record types, CRUD, protocol switching, field persistence)

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` 0 issues
- [x] `make test` all pass (race detector enabled)
- [x] 16 DNS acceptance tests (TF_ACC=1) — CRUD, validation, protocol switches, record types, cross-field
- [x] 8 client unit tests — deserialization, marshaling, workaround removal, PUT body
- [x] 13 API integration tests against real Hyperping API — workaround removal confirmed, DNS feature verified
- [x] Pre-push hooks: vet, build, govulncheck, lint, test — all green