### PR TITLE
fix: send nested service description as localized map

### DIFF
--- a/internal/client/models_statuspage.go
+++ b/internal/client/models_statuspage.go
@@ -163,7 +163,7 @@ type CreateStatusPageService struct {
 	Name              map[string]string         `json:"name,omitempty"`         // nested child display name (localized map)
 	ShowUptime        *bool                     `json:"show_uptime,omitempty"`
 	ShowResponseTimes *bool                     `json:"show_response_times,omitempty"`
-	Description       *string                   `json:"description,omitempty"`
+	Description       interface{}               `json:"description,omitempty"` // top-level: *string, nested: map[string]string
 	IsGroup           *bool                     `json:"is_group,omitempty"`
 	Services          []CreateStatusPageService `json:"services,omitempty"` // nested services
 }

--- a/internal/provider/statuspage_mapping.go
+++ b/internal/provider/statuspage_mapping.go
@@ -621,19 +621,11 @@ func mapTFToNestedServices(list types.List, diags *diag.Diagnostics) []client.Cr
 			svc.Name = mapTFToStringMap(nameMap, diags)
 		}
 
-		// Extract description (write as plain string from localized map)
+		// Extract description as localized map for nested services.
+		// The API expects nested service descriptions as maps (like "name"),
+		// unlike top-level services which use plain strings (like "name_shown").
 		if descMap, ok := attrs["description"].(types.Map); ok && !descMap.IsNull() {
-			descStrMap := mapTFToStringMap(descMap, diags)
-			if enDesc, ok := descStrMap["en"]; ok && enDesc != "" {
-				svc.Description = &enDesc
-			} else {
-				for _, v := range descStrMap {
-					if v != "" {
-						svc.Description = &v
-						break
-					}
-				}
-			}
+			svc.Description = mapTFToStringMap(descMap, diags)
 		}
 
 		// Extract show_uptime and show_response_times for nested services.

--- a/internal/provider/statuspage_mapping_coverage_test.go
+++ b/internal/provider/statuspage_mapping_coverage_test.go
@@ -1599,7 +1599,7 @@ func TestMapTFToService_Description(t *testing.T) {
 		if d.HasError() {
 			t.Fatalf("unexpected error: %v", d.Errors())
 		}
-		if result.Description == nil || *result.Description != "English desc" {
+		if descStr, ok := result.Description.(*string); !ok || descStr == nil || *descStr != "English desc" {
 			t.Errorf("expected 'English desc', got %v", result.Description)
 		}
 	})
@@ -1623,7 +1623,7 @@ func TestMapTFToService_Description(t *testing.T) {
 		if d.HasError() {
 			t.Fatalf("unexpected error: %v", d.Errors())
 		}
-		if result.Description == nil || *result.Description != "French desc" {
+		if descStr, ok := result.Description.(*string); !ok || descStr == nil || *descStr != "French desc" {
 			t.Errorf("expected 'French desc', got %v", result.Description)
 		}
 	})
@@ -1646,7 +1646,7 @@ func TestMapTFToService_Description(t *testing.T) {
 			t.Fatalf("unexpected error: %v", d.Errors())
 		}
 		if result.Description != nil {
-			t.Errorf("expected nil description, got %q", *result.Description)
+			t.Errorf("expected nil description, got %q", result.Description)
 		}
 	})
 }
@@ -1674,7 +1674,7 @@ func TestMapTFToNestedServices_Description(t *testing.T) {
 		if len(result) != 1 {
 			t.Fatalf("expected 1 service, got %d", len(result))
 		}
-		if result[0].Description == nil || *result[0].Description != "Nested desc" {
+		if descMap, ok := result[0].Description.(map[string]string); !ok || descMap["en"] != "Nested desc" {
 			t.Errorf("expected 'Nested desc', got %v", result[0].Description)
 		}
 	})
@@ -1697,7 +1697,7 @@ func TestMapTFToNestedServices_Description(t *testing.T) {
 			t.Fatalf("unexpected error: %v", d.Errors())
 		}
 		if result[0].Description != nil {
-			t.Errorf("expected nil description, got %q", *result[0].Description)
+			t.Errorf("expected nil description, got %q", result[0].Description)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes nested service descriptions being silently dropped by the API. This is **not an API bug** — it's a provider serialization bug.

## Root Cause

The Hyperping API uses different write formats at different nesting levels:

| Field | Top-level write | Nested write | Read (both) |
|-------|----------------|-------------|-------------|
| name | `name_shown` (string) | `name` (map) | `name` (map) |
| description | `description` (string) | `description` (**should be map**) | `description` (map) |

We were sending `"description": "text"` (plain string) for nested services, but the API expects `"description": {"en": "text"}` (localized map) — matching the `name` pattern.

## Fix

Changed `CreateStatusPageService.Description` from `*string` to `interface{}`:
- Top-level mapping sets `*string` → serializes as `"description": "text"`
- Nested mapping sets `map[string]string` → serializes as `"description": {"en": "text"}`

This means descriptions will now actually **persist and display** on status pages for nested services, not just be preserved in Terraform state.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/... -race` all pass
- [x] `make lint` 0 issues
- [x] JSON serialization verified: string ptr → `"text"`, map → `{"en": "text"}`
- [ ] User verification on live API with grouped nested services