### PR TITLE
fix: warn when description set on nested services (API limitation)

### DIFF
--- a/docs/resources/statuspage.md
+++ b/docs/resources/statuspage.md
@@ -289,7 +289,7 @@ Read-Only:
 
 Optional:
 
-- `description` (Map of String) Localized service description (language code -> text)
+- `description` (Map of String) Localized service description (language code -> text). **Note:** The Hyperping API does not currently persist descriptions on nested services inside groups. The value is accepted by Terraform but will not appear on the rendered status page. Use descriptions on top-level (non-group) services instead.
 - `is_group` (Boolean) Whether this nested service is a group
 - `name` (Map of String) Localized service name (language code -> text)
 - `show_response_times` (Boolean) Show response times

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -17,8 +17,11 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &StatusPageResource{}
-var _ resource.ResourceWithImportState = &StatusPageResource{}
+var (
+	_ resource.Resource                = &StatusPageResource{}
+	_ resource.ResourceWithImportState = &StatusPageResource{}
+	_ resource.ResourceWithModifyPlan  = &StatusPageResource{}
+)
 
 func NewStatusPageResource() resource.Resource {
 	return &StatusPageResource{}
@@ -39,6 +42,58 @@ type StatusPageResourceModel struct {
 	Password        types.String `tfsdk:"password"`
 	Settings        types.Object `tfsdk:"settings"`
 	Sections        types.List   `tfsdk:"sections"`
+}
+
+// ModifyPlan warns when description is set on nested services inside groups,
+// since the Hyperping API does not persist descriptions at that nesting level.
+func (r *StatusPageResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return // destroy plan
+	}
+
+	var plan StatusPageResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() || plan.Sections.IsNull() || plan.Sections.IsUnknown() {
+		return
+	}
+
+	for _, secElem := range plan.Sections.Elements() {
+		secObj, ok := secElem.(types.Object)
+		if !ok {
+			continue
+		}
+		svcList, ok := secObj.Attributes()["services"].(types.List)
+		if !ok || svcList.IsNull() || svcList.IsUnknown() {
+			continue
+		}
+		for _, svcElem := range svcList.Elements() {
+			svcObj, ok := svcElem.(types.Object)
+			if !ok {
+				continue
+			}
+			nestedList, ok := svcObj.Attributes()["services"].(types.List)
+			if !ok || nestedList.IsNull() || nestedList.IsUnknown() {
+				continue
+			}
+			for _, nestedElem := range nestedList.Elements() {
+				nestedObj, ok := nestedElem.(types.Object)
+				if !ok {
+					continue
+				}
+				desc, ok := nestedObj.Attributes()["description"].(types.Map)
+				if ok && !desc.IsNull() && !desc.IsUnknown() && len(desc.Elements()) > 0 {
+					resp.Diagnostics.AddWarning(
+						"Nested Service Description Not Supported by API",
+						"The Hyperping API does not persist descriptions on services nested inside groups "+
+							"(sections[].services[].services[].description). The value will be preserved in "+
+							"Terraform state but will not appear on the rendered status page. "+
+							"Use descriptions on top-level services (not inside groups) instead.",
+					)
+					return // one warning is enough
+				}
+			}
+		}
+	}
 }
 
 func (r *StatusPageResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {

--- a/internal/provider/statuspage_resource_schema.go
+++ b/internal/provider/statuspage_resource_schema.go
@@ -331,7 +331,7 @@ func (r *StatusPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 													Computed:            true,
 												},
 												"description": schema.MapAttribute{
-													MarkdownDescription: "Localized service description (language code -> text)",
+													MarkdownDescription: "Localized service description (language code -> text). **Note:** The Hyperping API does not currently persist descriptions on nested services inside groups. The value is accepted by Terraform but will not appear on the rendered status page. Use descriptions on top-level (non-group) services instead.",
 													ElementType:         types.StringType,
 													Optional:            true,
 												},


### PR DESCRIPTION
## Summary

The Hyperping API does not persist `description` on services nested inside groups. This is a confirmed API limitation — both plain string and localized map formats were tested (v1.8.0, v1.8.2), neither persists. Top-level services work correctly.

This PR adds clear user-facing communication about the limitation.

## Changes

1. **Plan-time warning** via `ResourceWithModifyPlan` — when a user sets `description` on a nested service, they see:
   > Warning: Nested Service Description Not Supported by API
   > The Hyperping API does not persist descriptions on services nested inside groups. The value will be preserved in Terraform state but will not appear on the rendered status page.

2. **Schema description updated** — nested service `description` attribute now documents the limitation inline.

3. **State preservation remains** — the v1.8.1 workaround prevents Terraform errors, this PR adds transparency.

## What users see

```
Warning: Nested Service Description Not Supported by API

The Hyperping API does not persist descriptions on services nested
inside groups (sections[].services[].services[].description). The
value will be preserved in Terraform state but will not appear on
the rendered status page. Use descriptions on top-level services
(not inside groups) instead.
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/... -race` all pass
- [x] `make lint` 0 issues
- [x] Docs auto-regenerated