### PR TITLE
feat: add capetown region and outage severity/summary (closes #98, closes #99)

### DIFF
--- a/docs/data-sources/outage.md
+++ b/docs/data-sources/outage.md
@@ -49,8 +49,10 @@ output "incident_details" {
 - `monitor` (Attributes) The monitor associated with this outage. (see [below for nested schema](#nestedatt--monitor))
 - `monitor_uuid` (String) The UUID of the monitor associated with this outage.
 - `outage_type` (String) The type of outage (e.g. `manual` or `automatic`).
+- `severity` (String) Severity level of the outage.
 - `start_date` (String) The start date of the outage in ISO 8601 format.
 - `status_code` (Number) The HTTP status code that caused the outage.
+- `summary` (String) Summary description of the outage.
 
 <a id="nestedatt--acknowledged_by"></a>
 ### Nested Schema for `acknowledged_by`

--- a/docs/data-sources/outages.md
+++ b/docs/data-sources/outages.md
@@ -92,8 +92,10 @@ Read-Only:
 - `monitor` (Attributes) The monitor associated with this outage. (see [below for nested schema](#nestedatt--outages--monitor))
 - `monitor_uuid` (String) The UUID of the monitor associated with this outage.
 - `outage_type` (String) The type of outage (e.g. `manual` or `automatic`).
+- `severity` (String) Severity level of the outage.
 - `start_date` (String) The start date of the outage in ISO 8601 format.
 - `status_code` (Number) The HTTP status code that caused the outage.
+- `summary` (String) Summary description of the outage.
 
 <a id="nestedatt--outages--acknowledged_by"></a>
 ### Nested Schema for `outages.acknowledged_by`

--- a/docs/resources/outage.md
+++ b/docs/resources/outage.md
@@ -48,6 +48,8 @@ resource "hyperping_outage" "incident_tracking" {
 
 - `end_date` (String) The end date of the outage in ISO 8601 format. Null if ongoing.
 - `escalation_policy_uuid` (String) UUID of the escalation policy to link to this outage. If provided, the policy will be triggered according to its step timing.
+- `severity` (String) Severity level of the outage.
+- `summary` (String) Summary description of the outage.
 
 ### Read-Only
 

--- a/internal/client/CONTRACT_QUICK_REFERENCE.md
+++ b/internal/client/CONTRACT_QUICK_REFERENCE.md
@@ -162,7 +162,7 @@ RunContractTest(t, ContractTestConfig{
 ```go
 AllowedProtocols = []string{"http", "port", "icmp"}
 AllowedMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
-AllowedRegions = []string{"london", "frankfurt", "paris", "amsterdam", "singapore", "sydney", "tokyo", "seoul", "mumbai", "bangalore", "virginia", "california", "sanfrancisco", "nyc", "toronto", "saopaulo", "bahrain"}
+AllowedRegions = []string{"london", "frankfurt", "paris", "amsterdam", "singapore", "sydney", "tokyo", "seoul", "mumbai", "bangalore", "virginia", "california", "sanfrancisco", "nyc", "toronto", "saopaulo", "bahrain", "capetown"}
 AllowedFrequencies = []int{10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
 ```
 

--- a/internal/client/models_common.go
+++ b/internal/client/models_common.go
@@ -184,6 +184,8 @@ var (
 		"saopaulo",
 		// Middle East
 		"bahrain",
+		// Africa
+		"capetown",
 	}
 
 	// AllowedIncidentTypes contains valid incident type values.

--- a/internal/client/models_outage.go
+++ b/internal/client/models_outage.go
@@ -32,6 +32,8 @@ type Outage struct {
 	AcknowledgedBy     *AcknowledgedByUser        `json:"acknowledgedBy"`     // User who acknowledged
 	Monitor            MonitorReference           `json:"monitor"`            // Associated monitor
 	EscalationPolicy   *EscalationPolicyReference `json:"escalationPolicy"`   // Linked escalation policy
+	Severity           string                     `json:"severity,omitempty"`
+	Summary            string                     `json:"summary,omitempty"`
 }
 
 // AcknowledgedByUser represents the user who acknowledged an outage.
@@ -74,6 +76,8 @@ type CreateOutageRequest struct {
 	Description          string  `json:"description"`
 	OutageType           string  `json:"outageType"`                     // "manual" for manually created outages
 	EscalationPolicyUUID *string `json:"escalationPolicyUuid,omitempty"` // UUID of escalation policy to trigger
+	Severity             *string `json:"severity,omitempty"`
+	Summary              *string `json:"summary,omitempty"`
 }
 
 // Validate checks input lengths on CreateOutageRequest fields.

--- a/internal/client/models_test.go
+++ b/internal/client/models_test.go
@@ -521,6 +521,88 @@ func TestStatusPageService_Description_JSON(t *testing.T) {
 	})
 }
 
+// =============================================================================
+// Outage severity and summary fields
+// =============================================================================
+
+func TestOutage_SeverityAndSummary_Unmarshal(t *testing.T) {
+	t.Run("both fields present", func(t *testing.T) {
+		data := []byte(`{"uuid":"out_1","startDate":"2026-03-20T10:00:00Z","statusCode":500,"description":"down","outageType":"manual","isResolved":false,"detectedLocation":"us-east","confirmedLocations":"us-east","monitor":{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS"},"severity":"critical","summary":"Server outage"}`)
+		var outage Outage
+		if err := json.Unmarshal(data, &outage); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if outage.Severity != "critical" {
+			t.Errorf("expected severity 'critical', got %q", outage.Severity)
+		}
+		if outage.Summary != "Server outage" {
+			t.Errorf("expected summary 'Server outage', got %q", outage.Summary)
+		}
+	})
+
+	t.Run("fields absent", func(t *testing.T) {
+		data := []byte(`{"uuid":"out_1","startDate":"2026-03-20T10:00:00Z","statusCode":500,"description":"down","outageType":"manual","isResolved":false,"detectedLocation":"us-east","confirmedLocations":"us-east","monitor":{"uuid":"mon_1","name":"test","url":"https://example.com","protocol":"HTTPS"}}`)
+		var outage Outage
+		if err := json.Unmarshal(data, &outage); err != nil {
+			t.Fatalf("unmarshal error: %v", err)
+		}
+		if outage.Severity != "" {
+			t.Errorf("expected empty severity, got %q", outage.Severity)
+		}
+		if outage.Summary != "" {
+			t.Errorf("expected empty summary, got %q", outage.Summary)
+		}
+	})
+}
+
+func TestCreateOutageRequest_SeverityAndSummary_Marshal(t *testing.T) {
+	t.Run("nil omits fields", func(t *testing.T) {
+		req := CreateOutageRequest{
+			MonitorUUID: "mon_1",
+			StartDate:   "2026-03-20T10:00:00Z",
+			StatusCode:  500,
+			Description: "down",
+			OutageType:  "manual",
+		}
+		b, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal error: %v", err)
+		}
+		body := string(b)
+		if strings.Contains(body, "severity") {
+			t.Errorf("expected severity to be omitted when nil, got: %s", body)
+		}
+		if strings.Contains(body, "summary") {
+			t.Errorf("expected summary to be omitted when nil, got: %s", body)
+		}
+	})
+
+	t.Run("non-nil includes fields", func(t *testing.T) {
+		sev := "critical"
+		sum := "Server outage"
+		req := CreateOutageRequest{
+			MonitorUUID: "mon_1",
+			StartDate:   "2026-03-20T10:00:00Z",
+			StatusCode:  500,
+			Description: "down",
+			OutageType:  "manual",
+			Severity:    &sev,
+			Summary:     &sum,
+		}
+		b, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal error: %v", err)
+		}
+		body := string(b)
+		if !strings.Contains(body, `"severity":"critical"`) {
+			t.Errorf("expected severity in output, got: %s", body)
+		}
+		if !strings.Contains(body, `"summary":"Server outage"`) {
+			t.Errorf("expected summary in output, got: %s", body)
+		}
+	})
+}
+
 func TestCreateStatusPageService_Description_JSON(t *testing.T) {
 	t.Run("nil omits field", func(t *testing.T) {
 		svc := CreateStatusPageService{}

--- a/internal/provider/monitor_resource_validation_test.go
+++ b/internal/provider/monitor_resource_validation_test.go
@@ -122,7 +122,7 @@ func TestMonitorResource_Schema(t *testing.T) {
 
 func TestAllowedRegions(t *testing.T) {
 	// Verify client.AllowedRegions contains expected values
-	// From official API documentation (17 regions)
+	// From official API documentation (18 regions)
 	// See: https://hyperping.com/docs/api/monitors/create
 	expectedRegions := []string{
 		// Europe
@@ -135,6 +135,8 @@ func TestAllowedRegions(t *testing.T) {
 		"saopaulo",
 		// Middle East
 		"bahrain",
+		// Africa
+		"capetown",
 	}
 
 	if len(client.AllowedRegions) != len(expectedRegions) {

--- a/internal/provider/monitoring_locations_data_source.go
+++ b/internal/provider/monitoring_locations_data_source.go
@@ -75,6 +75,8 @@ var monitoringLocations = map[string]monitoringLocationMetadata{
 	"saopaulo": {Name: "Sao Paulo, BR", Continent: "South America", CloudRegion: "nyc1"},
 	// Middle East
 	"bahrain": {Name: "Bahrain, ME", Continent: "Middle East", CloudRegion: "blr1"},
+	// Africa
+	"capetown": {Name: "Cape Town, ZA", Continent: "Africa", CloudRegion: "cpt1"},
 }
 
 // Metadata returns the data source type name.

--- a/internal/provider/monitoring_locations_data_source_test.go
+++ b/internal/provider/monitoring_locations_data_source_test.go
@@ -120,8 +120,8 @@ func TestAccMonitoringLocationsDataSource_basic(t *testing.T) {
 				Config: testAccMonitoringLocationsDataSourceConfig(server.URL),
 				Check: tfresource.ComposeAggregateTestCheckFunc(
 					// T29: All 8 locations returned
-					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "locations.#", "17"),
-					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "ids.#", "17"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "locations.#", "18"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "ids.#", "18"),
 					// T30: Known IDs present
 					tfresource.TestCheckTypeSetElemAttr("data.hyperping_monitoring_locations.all", "ids.*", "london"),
 					tfresource.TestCheckTypeSetElemAttr("data.hyperping_monitoring_locations.all", "ids.*", "frankfurt"),

--- a/internal/provider/outage_data_source.go
+++ b/internal/provider/outage_data_source.go
@@ -43,6 +43,8 @@ type OutageDataSourceModel struct {
 	IsResolved       types.Bool   `tfsdk:"is_resolved"`
 	DurationMs       types.Int64  `tfsdk:"duration_ms"`
 	DetectedLocation types.String `tfsdk:"detected_location"`
+	Severity         types.String `tfsdk:"severity"`
+	Summary          types.String `tfsdk:"summary"`
 	Monitor          types.Object `tfsdk:"monitor"`
 	AcknowledgedBy   types.Object `tfsdk:"acknowledged_by"`
 }
@@ -96,6 +98,14 @@ func (d *OutageDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			},
 			"detected_location": schema.StringAttribute{
 				MarkdownDescription: "The location that detected the outage.",
+				Computed:            true,
+			},
+			"severity": schema.StringAttribute{
+				MarkdownDescription: "Severity level of the outage.",
+				Computed:            true,
+			},
+			"summary": schema.StringAttribute{
+				MarkdownDescription: "Summary description of the outage.",
 				Computed:            true,
 			},
 			"monitor": schema.SingleNestedAttribute{
@@ -200,6 +210,18 @@ func mapOutageToDataSourceModel(outage *client.Outage, model *OutageDataSourceMo
 	model.IsResolved = types.BoolValue(outage.IsResolved)
 	model.DurationMs = types.Int64Value(int64(outage.DurationMs))
 	model.DetectedLocation = types.StringValue(outage.DetectedLocation)
+
+	if outage.Severity != "" {
+		model.Severity = types.StringValue(outage.Severity)
+	} else {
+		model.Severity = types.StringNull()
+	}
+
+	if outage.Summary != "" {
+		model.Summary = types.StringValue(outage.Summary)
+	} else {
+		model.Summary = types.StringNull()
+	}
 
 	if outage.EndDate != nil {
 		model.EndDate = types.StringValue(*outage.EndDate)

--- a/internal/provider/outage_resource.go
+++ b/internal/provider/outage_resource.go
@@ -53,6 +53,8 @@ type OutageResourceModel struct {
 	IsResolved           types.Bool   `tfsdk:"is_resolved"`
 	DurationMs           types.Int64  `tfsdk:"duration_ms"`
 	DetectedLocation     types.String `tfsdk:"detected_location"`
+	Severity             types.String `tfsdk:"severity"`
+	Summary              types.String `tfsdk:"summary"`
 	Monitor              types.Object `tfsdk:"monitor"`
 	AcknowledgedBy       types.Object `tfsdk:"acknowledged_by"`
 }
@@ -118,6 +120,22 @@ func (r *OutageResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the outage (error message or reason).",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"severity": schema.StringAttribute{
+				MarkdownDescription: "Severity level of the outage.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"summary": schema.StringAttribute{
+				MarkdownDescription: "Summary description of the outage.",
+				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -235,6 +253,16 @@ func (r *OutageResource) Create(ctx context.Context, req resource.CreateRequest,
 	if !plan.EscalationPolicyUUID.IsNull() {
 		escPolicyUUID := plan.EscalationPolicyUUID.ValueString()
 		createReq.EscalationPolicyUUID = &escPolicyUUID
+	}
+
+	if !plan.Severity.IsNull() {
+		severity := plan.Severity.ValueString()
+		createReq.Severity = &severity
+	}
+
+	if !plan.Summary.IsNull() {
+		summary := plan.Summary.ValueString()
+		createReq.Summary = &summary
 	}
 
 	created, err := r.client.CreateOutage(ctx, createReq)
@@ -357,6 +385,18 @@ func (r *OutageResource) mapOutageToModel(outage *client.Outage, model *OutageRe
 	// If the API returns empty string (shouldn't happen), map it truthfully to maintain
 	// consistency with data sources.
 	model.OutageType = types.StringValue(outage.OutageType)
+
+	if outage.Severity != "" {
+		model.Severity = types.StringValue(outage.Severity)
+	} else {
+		model.Severity = types.StringNull()
+	}
+
+	if outage.Summary != "" {
+		model.Summary = types.StringValue(outage.Summary)
+	} else {
+		model.Summary = types.StringNull()
+	}
 
 	if outage.EndDate != nil {
 		model.EndDate = types.StringValue(*outage.EndDate)

--- a/internal/provider/outages_data_source.go
+++ b/internal/provider/outages_data_source.go
@@ -51,6 +51,8 @@ type OutageDataModel struct {
 	IsResolved       types.Bool   `tfsdk:"is_resolved"`
 	DurationMs       types.Int64  `tfsdk:"duration_ms"`
 	DetectedLocation types.String `tfsdk:"detected_location"`
+	Severity         types.String `tfsdk:"severity"`
+	Summary          types.String `tfsdk:"summary"`
 	Monitor          types.Object `tfsdk:"monitor"`
 	AcknowledgedBy   types.Object `tfsdk:"acknowledged_by"`
 }
@@ -119,6 +121,14 @@ func (d *OutagesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 						},
 						"detected_location": schema.StringAttribute{
 							MarkdownDescription: "The location that detected the outage.",
+							Computed:            true,
+						},
+						"severity": schema.StringAttribute{
+							MarkdownDescription: "Severity level of the outage.",
+							Computed:            true,
+						},
+						"summary": schema.StringAttribute{
+							MarkdownDescription: "Summary description of the outage.",
 							Computed:            true,
 						},
 						"monitor": schema.SingleNestedAttribute{
@@ -276,6 +286,18 @@ func (d *OutagesDataSource) mapOutageToDataModel(outage *client.Outage, model *O
 	model.IsResolved = types.BoolValue(outage.IsResolved)
 	model.DurationMs = types.Int64Value(int64(outage.DurationMs))
 	model.DetectedLocation = types.StringValue(outage.DetectedLocation)
+
+	if outage.Severity != "" {
+		model.Severity = types.StringValue(outage.Severity)
+	} else {
+		model.Severity = types.StringNull()
+	}
+
+	if outage.Summary != "" {
+		model.Summary = types.StringValue(outage.Summary)
+	} else {
+		model.Summary = types.StringNull()
+	}
 
 	if outage.EndDate != nil {
 		model.EndDate = types.StringValue(*outage.EndDate)


### PR DESCRIPTION
## Summary

Implements both open region-related issues:
- **#98**: Adds missing `capetown` monitor region
- **#99**: Adds new outage `severity` and `summary` fields from API change

## Changes

### Issue #98 — Missing `capetown` region
- Added `capetown` to `AllowedRegions` (17 -> 18 total)
- Added metadata: Cape Town, ZA / Africa / cpt1 to monitoring locations data source
- Updated region validation tests and acceptance test assertions

### Issue #99 — Outage severity and summary
- Added `Severity` and `Summary` to `Outage` read model and `CreateOutageRequest` write model
- Exposed in resource schema (Optional+Computed with RequiresReplace)
- Exposed in both data source schemas (single and list)
- Updated mapping functions with empty-string-to-null handling
- Added serialization/deserialization tests

## Tests

- [x] Unit tests for region validation (18 expected)
- [x] Unit tests for outage severity/summary marshaling
- [x] Monitoring locations data source metadata coverage
- [x] Edge cases: nil severity/summary omitted, empty string -> null
- [x] All existing tests pass (0 regressions)
- [x] `go build ./...` passes
- [x] `make lint` 0 issues
- [x] `govulncheck` no vulnerabilities

## Closes

Closes #98
Closes #99