### PR TITLE
refactor: replace all hardcoded enum values with constant references

### DIFF
--- a/docs/resources/maintenance.md
+++ b/docs/resources/maintenance.md
@@ -72,7 +72,7 @@ output "maintenance_name" {
 ### Optional
 
 - `notification_minutes` (Number) Number of minutes before the maintenance to notify subscribers. Defaults to `60`. Only used when notification_option is `scheduled`. Must be at least 1.
-- `notification_option` (String) When to notify subscribers. Valid values: `scheduled`, `immediate`. Defaults to `scheduled`.
+- `notification_option` (String) When to notify subscribers. Valid values: `none`, `scheduled`, `immediate`. Defaults to `scheduled`.
 - `status_pages` (List of String) List of status page UUIDs to display this maintenance on.
 - `text` (String) The description text of the maintenance (English).
 - `title` (String) The public title of the maintenance window (English).

--- a/internal/client/CONTRACT_QUICK_REFERENCE.md
+++ b/internal/client/CONTRACT_QUICK_REFERENCE.md
@@ -160,7 +160,7 @@ RunContractTest(t, ContractTestConfig{
 ### Monitor
 
 ```go
-AllowedProtocols = []string{"http", "port", "icmp"}
+AllowedProtocols = []string{"http", "port", "icmp", "dns"}
 AllowedMethods = []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
 AllowedRegions = []string{"london", "frankfurt", "paris", "amsterdam", "singapore", "sydney", "tokyo", "seoul", "mumbai", "bangalore", "virginia", "california", "sanfrancisco", "nyc", "toronto", "saopaulo", "bahrain", "capetown"}
 AllowedFrequencies = []int{10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400}
@@ -176,7 +176,7 @@ AllowedIncidentUpdateTypes = []string{"investigating", "identified", "update", "
 ### Maintenance
 
 ```go
-AllowedNotificationOptions = []string{"scheduled", "immediate"}
+AllowedNotificationOptions = []string{"none", "scheduled", "immediate"}
 ```
 
 ### Status Page
@@ -184,7 +184,7 @@ AllowedNotificationOptions = []string{"scheduled", "immediate"}
 ```go
 AllowedStatusPageThemes = []string{"light", "dark", "system"}
 AllowedStatusPageFonts = []string{"system-ui", "Lato", "Manrope", "Inter", "Open Sans", "Montserrat", "Poppins", "Roboto", "Raleway", "Nunito", "Merriweather", "DM Sans", "Work Sans"}
-AllowedLanguages = []string{"en", "fr", "de", "ru", "nl", "es", "it", "pt", "ja", "zh"}
+AllowedLanguages = []string{"en", "fr", "de", "ru", "nl", "pl", "sv"}
 ```
 
 ### Subscriber

--- a/internal/provider/healthcheck_resource.go
+++ b/internal/provider/healthcheck_resource.go
@@ -109,7 +109,7 @@ func (r *HealthcheckResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:            true,
 			},
 			"period_type": schema.StringAttribute{
-				MarkdownDescription: "Unit for `period_value`. Valid values: `seconds`, `minutes`, `hours`, `days`.",
+				MarkdownDescription: "Unit for `period_value`. Valid values: " + formatValidValues(client.AllowedPeriodTypes) + ".",
 				Optional:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(client.AllowedPeriodTypes...),
@@ -120,7 +120,7 @@ func (r *HealthcheckResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:            true,
 			},
 			"grace_period_type": schema.StringAttribute{
-				MarkdownDescription: "Unit for `grace_period_value`. Valid values: `seconds`, `minutes`, `hours`, `days`.",
+				MarkdownDescription: "Unit for `grace_period_value`. Valid values: " + formatValidValues(client.AllowedPeriodTypes) + ".",
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(client.AllowedPeriodTypes...),

--- a/internal/provider/incident_resource.go
+++ b/internal/provider/incident_resource.go
@@ -82,7 +82,7 @@ func (r *IncidentResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The type of incident. Valid values: `outage`, `incident`. Defaults to `incident`.",
+				MarkdownDescription: "The type of incident. Valid values: " + formatValidValues(client.AllowedIncidentTypes) + ". Defaults to `incident`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("incident"),

--- a/internal/provider/incident_update_resource.go
+++ b/internal/provider/incident_update_resource.go
@@ -81,7 +81,7 @@ func (r *IncidentUpdateResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"type": schema.StringAttribute{
-				MarkdownDescription: "The type of update. Valid values: `investigating`, `identified`, `update`, `monitoring`, `resolved`.",
+				MarkdownDescription: "The type of update. Valid values: " + formatValidValues(client.AllowedIncidentUpdateTypes) + ".",
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(client.AllowedIncidentUpdateTypes...),

--- a/internal/provider/maintenance_resource.go
+++ b/internal/provider/maintenance_resource.go
@@ -123,7 +123,7 @@ func (r *MaintenanceResource) Schema(_ context.Context, _ resource.SchemaRequest
 				ElementType:         types.StringType,
 			},
 			"notification_option": schema.StringAttribute{
-				MarkdownDescription: "When to notify subscribers. Valid values: `scheduled`, `immediate`. Defaults to `scheduled`.",
+				MarkdownDescription: "When to notify subscribers. Valid values: " + formatValidValues(client.AllowedNotificationOptions) + ". Defaults to `scheduled`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("scheduled"),

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -102,7 +102,7 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "The protocol type. Valid values: `http`, `port`, `icmp`, `dns`. Defaults to `http`.",
+				MarkdownDescription: "The protocol type. Valid values: " + formatValidValues(client.AllowedProtocols) + ". Defaults to `http`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("http"),
@@ -111,7 +111,7 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"http_method": schema.StringAttribute{
-				MarkdownDescription: "HTTP method to use. Only valid when protocol is `http`. Valid values: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`. Defaults to `GET`.",
+				MarkdownDescription: "HTTP method to use. Only valid when protocol is `http`. Valid values: " + formatValidValues(client.AllowedMethods) + ". Defaults to `GET`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             stringdefault.StaticString("GET"),
@@ -120,12 +120,12 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"check_frequency": schema.Int64Attribute{
-				MarkdownDescription: "Check frequency in seconds. Valid values: `10`, `20`, `30`, `60`, `120`, `180`, `300`, `600`, `1800`, `3600`, `21600`, `43200`, `86400`. Defaults to `60`.",
+				MarkdownDescription: "Check frequency in seconds. Valid values: " + formatValidInts(client.AllowedFrequencies) + ". Defaults to `60`.",
 				Optional:            true,
 				Computed:            true,
 				Default:             int64default.StaticInt64(client.DefaultMonitorFrequency),
 				Validators: []validator.Int64{
-					int64validator.OneOf(10, 20, 30, 60, 120, 180, 300, 600, 1800, 3600, 21600, 43200, 86400),
+					int64validator.OneOf(toInt64Slice(client.AllowedFrequencies)...),
 				},
 			},
 			"regions": schema.ListAttribute{
@@ -211,7 +211,7 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"dns_record_type": schema.StringAttribute{
 				MarkdownDescription: "DNS record type to check. Only valid when protocol is `dns`. " +
-					"Valid values: `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SOA`, `SRV`, `CAA`, `PTR`. " +
+					"Valid values: " + formatValidValues(client.AllowedDNSRecordTypes) + ". " +
 					"Defaults to `A` (set by the API if omitted).",
 				Optional: true,
 				Computed: true,

--- a/internal/provider/monitor_resource_validation_test.go
+++ b/internal/provider/monitor_resource_validation_test.go
@@ -120,41 +120,6 @@ func TestMonitorResource_Schema(t *testing.T) {
 	}
 }
 
-func TestAllowedRegions(t *testing.T) {
-	// Verify client.AllowedRegions contains expected values
-	// From official API documentation (18 regions)
-	// See: https://hyperping.com/docs/api/monitors/create
-	expectedRegions := []string{
-		// Europe
-		"london", "frankfurt", "paris", "amsterdam",
-		// Asia Pacific
-		"singapore", "sydney", "tokyo", "seoul", "mumbai", "bangalore",
-		// North America
-		"virginia", "california", "sanfrancisco", "nyc", "toronto",
-		// South America
-		"saopaulo",
-		// Middle East
-		"bahrain",
-		// Africa
-		"capetown",
-	}
-
-	if len(client.AllowedRegions) != len(expectedRegions) {
-		t.Errorf("Expected %d regions, got %d", len(expectedRegions), len(client.AllowedRegions))
-	}
-
-	regionMap := make(map[string]bool)
-	for _, r := range client.AllowedRegions {
-		regionMap[r] = true
-	}
-
-	for _, expected := range expectedRegions {
-		if !regionMap[expected] {
-			t.Errorf("Expected region %q not found in client.AllowedRegions", expected)
-		}
-	}
-}
-
 // monitorToModelCase defines a single test scenario for mapMonitorToModel.
 type monitorToModelCase struct {
 	name    string

--- a/internal/provider/monitoring_locations_data_source_test.go
+++ b/internal/provider/monitoring_locations_data_source_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -110,6 +111,7 @@ func TestMonitoringLocationsDataSource_Schema(t *testing.T) {
 
 // T29 + T30: Acceptance test for monitoring locations data source
 func TestAccMonitoringLocationsDataSource_basic(t *testing.T) {
+	regionCount := strconv.Itoa(len(client.AllowedRegions))
 	server := newMinimalMockServer(t)
 	defer server.Close()
 
@@ -120,8 +122,8 @@ func TestAccMonitoringLocationsDataSource_basic(t *testing.T) {
 				Config: testAccMonitoringLocationsDataSourceConfig(server.URL),
 				Check: tfresource.ComposeAggregateTestCheckFunc(
 					// T29: All 8 locations returned
-					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "locations.#", "18"),
-					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "ids.#", "18"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "locations.#", regionCount),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitoring_locations.all", "ids.#", regionCount),
 					// T30: Known IDs present
 					tfresource.TestCheckTypeSetElemAttr("data.hyperping_monitoring_locations.all", "ids.*", "london"),
 					tfresource.TestCheckTypeSetElemAttr("data.hyperping_monitoring_locations.all", "ids.*", "frankfurt"),

--- a/internal/provider/schema_helpers.go
+++ b/internal/provider/schema_helpers.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatValidValues formats a slice of string values for use in MarkdownDescription.
+// Each value is wrapped in backticks and joined with ", ".
+// Example: ["a", "b", "c"] -> "`a`, `b`, `c`"
+func formatValidValues(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = "`" + v + "`"
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// formatValidInts formats a slice of int values for use in MarkdownDescription.
+// Each value is wrapped in backticks and joined with ", ".
+// Example: [10, 20, 30] -> "`10`, `20`, `30`"
+func formatValidInts(values []int) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("`%d`", v)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+// toInt64Slice converts a []int to []int64 for use with int64validator.OneOf.
+func toInt64Slice(values []int) []int64 {
+	result := make([]int64, len(values))
+	for i, v := range values {
+		result[i] = int64(v)
+	}
+	return result
+}

--- a/internal/provider/statuspage_resource_schema.go
+++ b/internal/provider/statuspage_resource_schema.go
@@ -105,7 +105,7 @@ func (r *StatusPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 						Computed:            true,
 						Default:             stringdefault.StaticString("system"),
 						Validators: []validator.String{
-							stringvalidator.OneOf("light", "dark", "system"),
+							stringvalidator.OneOf(client.AllowedStatusPageThemes...),
 						},
 					},
 					"font": schema.StringAttribute{
@@ -114,11 +114,7 @@ func (r *StatusPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 						Computed:            true,
 						Default:             stringdefault.StaticString("Inter"),
 						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"system-ui", "Lato", "Manrope", "Inter", "Open Sans",
-								"Montserrat", "Poppins", "Roboto", "Raleway", "Nunito",
-								"Merriweather", "DM Sans", "Work Sans",
-							),
+							stringvalidator.OneOf(client.AllowedStatusPageFonts...),
 						},
 					},
 					"accent_color": schema.StringAttribute{

--- a/internal/provider/statuspage_subscriber_resource.go
+++ b/internal/provider/statuspage_subscriber_resource.go
@@ -83,7 +83,7 @@ func (r *StatusPageSubscriberResource) Schema(ctx context.Context, req resource.
 				MarkdownDescription: "Subscriber type: email, sms, or teams (slack not supported via API)",
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("email", "sms", "teams"),
+					stringvalidator.OneOf(client.AllowedSubscriberTypes...),
 					NoSlackSubscriberType(),
 				},
 				PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
## Summary

Eliminates 17 hardcoded enum references across production code, tests, and docs. After this change, adding a new region/protocol/font/frequency/etc. requires updating ONLY `models_common.go` + the metadata map — everything else self-adjusts.

## Problem

Every time Hyperping adds an enum value (like `capetown`), we had to update 5+ files manually. Tests broke on count assertions, schema descriptions went stale, inline validators rejected valid values.

## Changes

### New: `schema_helpers.go`
- `formatValidValues([]string)` — generates `` `a`, `b`, `c` `` for MarkdownDescription
- `formatValidInts([]int)` — same for integer lists
- `toInt64Slice([]int)` — converts `[]int` to `[]int64` for `int64validator.OneOf`

### Inline OneOf validators → constant references (6 fixes)
- `statuspage_resource_schema.go` — themes, fonts now use `AllowedStatusPageThemes/Fonts`
- `statuspage_subscriber_resource.go` — types now use `AllowedSubscriberTypes`
- `monitor_resource.go` — frequencies now use `toInt64Slice(AllowedFrequencies)`

### Schema descriptions → dynamic generation (8 fixes)
- `monitor_resource.go` — protocol, method, frequency, DNS types
- `maintenance_resource.go` — notification options (also fixes missing `"none"`)
- `healthcheck_resource.go` — period types (both attributes)
- `incident_resource.go` — incident types
- `incident_update_resource.go` — update types

### Test assertions → dynamic (2 fixes)
- Deleted redundant `TestAllowedRegions` (replaced by existing `TestMonitoringLocations_AllRegionsCovered`)
- `monitoring_locations_data_source_test.go` — `"18"` → `strconv.Itoa(len(client.AllowedRegions))`

### Stale docs fixed
- `CONTRACT_QUICK_REFERENCE.md` — protocols (+dns), notifications (+none), languages (7 not 10)

## Result

Adding a new enum value now requires:
1. Add to `Allowed*` in `models_common.go`
2. Add metadata if applicable (e.g., `monitoringLocations` map for regions)

That's it. No test changes, no schema changes, no doc changes.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/... -race` all pass
- [x] `make lint` 0 issues
- [x] Docs auto-regenerated (maintenance description now shows "none")