### PR TITLE
fix: subscriber Read pagination off-by-one (page 0 skipped)

### DIFF
--- a/internal/provider/statuspage_subscriber_resource.go
+++ b/internal/provider/statuspage_subscriber_resource.go
@@ -229,7 +229,7 @@ func (r *StatusPageSubscriberResource) Read(ctx context.Context, req resource.Re
 		subscriberType = &t
 	}
 	var foundSubscriber *client.StatusPageSubscriber
-	page := 1
+	page := 0 // API uses 0-indexed pages
 	for {
 		pageNum := page
 		paginatedResp, err := r.client.ListSubscribers(ctx, state.StatusPageUUID.ValueString(), &pageNum, subscriberType)


### PR DESCRIPTION
## Summary

Subscriber Read started pagination at `page=1` but the Hyperping API uses 0-indexed pages. All subscribers on page 0 (first 20) were skipped, causing:

- `terraform import` fails with "no object exists"
- `terraform refresh` removes subscribers from state
- Affects ALL accounts with fewer than 20 subscribers (the vast majority)

## Root Cause

```go
// Before (bug): starts at page 1, skips page 0
page := 1

// After (fix): starts at page 0
page := 0 // API uses 0-indexed pages
```

## Impact

This is a **critical** bug — subscriber resources could not be imported, and any state refresh would silently remove them.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/... -race` all pass
- [x] `make lint` 0 issues
- [x] VCR cassettes confirm API uses `?page=0`