### PR TITLE
feat: Prometheus/Grafana observability stack (OPS-31–39)

### DIFF
--- a/cmd/hyperping-exporter/Dockerfile
+++ b/cmd/hyperping-exporter/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+# Multi-stage build for a minimal, non-root hyperping-exporter image.
+
+FROM golang:1.26-alpine AS builder
+WORKDIR /build
+# Cache module downloads separately from source builds.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" \
+    -o /hyperping-exporter ./cmd/hyperping-exporter/
+
+# Use distroless static for a minimal attack surface (no shell, no libc).
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /hyperping-exporter /hyperping-exporter
+EXPOSE 9312
+USER nonroot:nonroot
+ENTRYPOINT ["/hyperping-exporter"]

--- a/cmd/hyperping-exporter/collector.go
+++ b/cmd/hyperping-exporter/collector.go
@@ -16,10 +16,22 @@ import (
 
 const namespace = "hyperping"
 
+// reportPeriods defines the SLA/outage report windows fetched on each refresh.
+var reportPeriods = []string{"24h", "7d", "30d"}
+
+// reportDurations maps period labels to their lookback durations.
+var reportDurations = map[string]time.Duration{
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+	"30d": 30 * 24 * time.Hour,
+}
+
 // HyperpingAPI defines the Hyperping API methods used by the collector.
 type HyperpingAPI interface {
 	ListMonitors(ctx context.Context) ([]client.Monitor, error)
 	ListHealthchecks(ctx context.Context) ([]client.Healthcheck, error)
+	ListOutages(ctx context.Context) ([]client.Outage, error)
+	ListMonitorReports(ctx context.Context, from, to string) ([]client.MonitorReport, error)
 }
 
 // Collector fetches Hyperping data on a background timer and serves
@@ -30,14 +42,17 @@ type Collector struct {
 	logger   *slog.Logger
 
 	// Cache (protected by mu).
-	mu             sync.RWMutex
-	monitors       []client.Monitor
-	healthchecks   []client.Healthcheck
-	lastScrapeTime time.Time
-	lastScrapeOK   bool
-	lastScrapeDur  time.Duration
+	mu              sync.RWMutex
+	monitors        []client.Monitor
+	healthchecks    []client.Healthcheck
+	outages         []client.Outage
+	reportsByPeriod map[string][]client.MonitorReport
+	lastScrapeTime  time.Time
+	lastSuccessTime time.Time // OPS-31: tracks age of fresh data
+	lastScrapeOK    bool
+	lastScrapeDur   time.Duration
 
-	// Metric descriptors (immutable after construction).
+	// Existing core metric descriptors.
 	monitorUp            *prometheus.Desc
 	monitorPaused        *prometheus.Desc
 	monitorSSLExpDays    *prometheus.Desc
@@ -50,6 +65,27 @@ type Collector struct {
 	healthchecksTotal    *prometheus.Desc
 	scrapeDurationDesc   *prometheus.Desc
 	scrapeSuccessDesc    *prometheus.Desc
+
+	// OPS-31: Cache freshness.
+	dataAgeDesc *prometheus.Desc
+
+	// OPS-32 + OPS-33: Outage and SLA metrics (with period label where applicable).
+	monitorOutageActive       *prometheus.Desc
+	monitorActiveOutageStatus *prometheus.Desc
+	monitorSLA                *prometheus.Desc
+	monitorOutages            *prometheus.Desc
+	monitorDowntime           *prometheus.Desc
+	monitorLongestOutage      *prometheus.Desc
+	monitorMTTR               *prometheus.Desc
+
+	// OPS-34: Tenant-wide health metrics.
+	tenantHealthScore   *prometheus.Desc
+	tenantUpRatio       *prometheus.Desc
+	tenantActiveOutages *prometheus.Desc
+	tenantAvgSLA        *prometheus.Desc
+
+	// OPS-39: Escalation tier info metric.
+	monitorTier *prometheus.Desc
 }
 
 // Verify Collector implements prometheus.Collector at compile time.
@@ -57,33 +93,34 @@ var _ prometheus.Collector = (*Collector)(nil)
 
 // NewCollector creates a new Hyperping metrics collector.
 func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger) *Collector {
-	monitorLabels := []string{"uuid", "name"}
-	healthcheckLabels := []string{"uuid", "name"}
+	ml := []string{"uuid", "name"}
+	mpl := []string{"uuid", "name", "period"}
 
 	return &Collector{
-		api:      api,
-		cacheTTL: cacheTTL,
-		logger:   logger,
+		api:             api,
+		cacheTTL:        cacheTTL,
+		logger:          logger,
+		reportsByPeriod: make(map[string][]client.MonitorReport),
 
 		monitorUp: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "up"),
 			"Whether the monitor is up (1) or down (0).",
-			monitorLabels, nil,
+			ml, nil,
 		),
 		monitorPaused: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "paused"),
 			"Whether the monitor is paused (1) or active (0).",
-			monitorLabels, nil,
+			ml, nil,
 		),
 		monitorSSLExpDays: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "ssl_expiration_days"),
 			"Days until SSL certificate expiration.",
-			monitorLabels, nil,
+			ml, nil,
 		),
 		monitorCheckInterval: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "check_interval_seconds"),
 			"Monitor check frequency in seconds.",
-			monitorLabels, nil,
+			ml, nil,
 		),
 		monitorInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "info"),
@@ -93,17 +130,17 @@ func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger)
 		healthcheckUp: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "healthcheck", "up"),
 			"Whether the healthcheck is up (1) or down (0).",
-			healthcheckLabels, nil,
+			[]string{"uuid", "name"}, nil,
 		),
 		healthcheckPaused: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "healthcheck", "paused"),
 			"Whether the healthcheck is paused (1) or active (0).",
-			healthcheckLabels, nil,
+			[]string{"uuid", "name"}, nil,
 		),
 		healthcheckPeriod: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "healthcheck", "period_seconds"),
 			"Expected healthcheck ping period in seconds.",
-			healthcheckLabels, nil,
+			[]string{"uuid", "name"}, nil,
 		),
 		monitorsTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "monitors"),
@@ -124,6 +161,71 @@ func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger)
 			prometheus.BuildFQName(namespace, "scrape", "success"),
 			"Whether the last API scrape succeeded (1) or failed (0).",
 			nil, nil,
+		),
+		dataAgeDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "data", "age_seconds"),
+			"Seconds elapsed since the last successful API cache refresh.",
+			nil, nil,
+		),
+		monitorOutageActive: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "outage_active"),
+			"Whether the monitor has an active (unresolved) outage (1) or not (0).",
+			ml, nil,
+		),
+		monitorActiveOutageStatus: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "active_outage_status_code"),
+			"HTTP status code of the current active outage; 0 when no active outage.",
+			ml, nil,
+		),
+		monitorSLA: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "sla_ratio"),
+			"Monitor SLA as a ratio (0–1) over the labelled period.",
+			mpl, nil,
+		),
+		monitorOutages: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "outages"),
+			"Number of outages over the labelled period.",
+			mpl, nil,
+		),
+		monitorDowntime: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "downtime_seconds"),
+			"Total downtime in seconds over the labelled period.",
+			mpl, nil,
+		),
+		monitorLongestOutage: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "longest_outage_seconds"),
+			"Duration of the longest single outage in seconds over the labelled period.",
+			mpl, nil,
+		),
+		monitorMTTR: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "mttr_seconds"),
+			"Mean Time To Recovery in seconds over the labelled period.",
+			mpl, nil,
+		),
+		tenantHealthScore: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "tenant", "health_score"),
+			"Composite tenant health score from 0 to 100.",
+			nil, nil,
+		),
+		tenantUpRatio: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "tenant", "monitors_up_ratio"),
+			"Fraction of monitors currently up (0–1).",
+			nil, nil,
+		),
+		tenantActiveOutages: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "tenant", "active_outages"),
+			"Total number of active (unresolved) outages across all monitors.",
+			nil, nil,
+		),
+		tenantAvgSLA: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "tenant", "avg_sla_ratio"),
+			"Average SLA ratio across all monitors for the labelled period.",
+			[]string{"period"}, nil,
+		),
+		monitorTier: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "monitor", "escalation_tier"),
+			"Escalation tier info (always 1). Join on uuid+name; use tier label to filter core/noncore.",
+			[]string{"uuid", "name", "tier"}, nil,
 		),
 	}
 }
@@ -146,19 +248,22 @@ func (c *Collector) Start(ctx context.Context) {
 }
 
 // Refresh performs a single API scrape and updates the cache.
-// Both ListMonitors and ListHealthchecks are called in parallel.
+// Monitors and healthchecks are required; outages and reports are best-effort.
 func (c *Collector) Refresh(ctx context.Context) {
 	start := time.Now()
+	now := start.UTC()
 
 	var (
 		monitors     []client.Monitor
 		healthchecks []client.Healthcheck
+		outages      []client.Outage
 		monErr       error
 		hcErr        error
+		outageErr    error
 		wg           sync.WaitGroup
 	)
 
-	wg.Add(2)
+	wg.Add(3)
 	go func() {
 		defer wg.Done()
 		monitors, monErr = c.api.ListMonitors(ctx)
@@ -167,7 +272,36 @@ func (c *Collector) Refresh(ctx context.Context) {
 		defer wg.Done()
 		healthchecks, hcErr = c.api.ListHealthchecks(ctx)
 	}()
+	go func() {
+		defer wg.Done()
+		outages, outageErr = c.api.ListOutages(ctx)
+	}()
 	wg.Wait()
+
+	// Fetch SLA reports for all periods in parallel (non-fatal on failure).
+	reportResults := make(map[string][]client.MonitorReport, len(reportPeriods))
+	var (
+		reportMu sync.Mutex
+		reportWg sync.WaitGroup
+	)
+	for _, p := range reportPeriods {
+		dur := reportDurations[p]
+		from := now.Add(-dur).Format(time.RFC3339)
+		to := now.Format(time.RFC3339)
+		reportWg.Add(1)
+		go func(period, fromStr, toStr string) {
+			defer reportWg.Done()
+			reports, err := c.api.ListMonitorReports(ctx, fromStr, toStr)
+			if err != nil {
+				c.logger.Warn("failed to fetch monitor reports", "period", period, "error", err)
+				return
+			}
+			reportMu.Lock()
+			reportResults[period] = reports
+			reportMu.Unlock()
+		}(p, from, to)
+	}
+	reportWg.Wait()
 
 	dur := time.Since(start)
 
@@ -188,13 +322,23 @@ func (c *Collector) Refresh(ctx context.Context) {
 		return
 	}
 
+	if outageErr != nil {
+		c.logger.Warn("failed to list outages; outage metrics will use stale data", "error", outageErr)
+	} else {
+		c.outages = outages
+	}
+
 	c.monitors = monitors
 	c.healthchecks = healthchecks
+	c.reportsByPeriod = reportResults
 	c.lastScrapeOK = true
+	c.lastSuccessTime = time.Now()
 
 	c.logger.Info("cache refreshed",
 		"monitors", len(monitors),
 		"healthchecks", len(healthchecks),
+		"outages", len(c.outages),
+		"report_periods", len(reportResults),
 		"duration", dur,
 	)
 }
@@ -220,6 +364,19 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.healthchecksTotal
 	ch <- c.scrapeDurationDesc
 	ch <- c.scrapeSuccessDesc
+	ch <- c.dataAgeDesc
+	ch <- c.monitorOutageActive
+	ch <- c.monitorActiveOutageStatus
+	ch <- c.monitorSLA
+	ch <- c.monitorOutages
+	ch <- c.monitorDowntime
+	ch <- c.monitorLongestOutage
+	ch <- c.monitorMTTR
+	ch <- c.tenantHealthScore
+	ch <- c.tenantUpRatio
+	ch <- c.tenantActiveOutages
+	ch <- c.tenantAvgSLA
+	ch <- c.monitorTier
 }
 
 // Collect implements prometheus.Collector.
@@ -227,6 +384,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	activeOutageByMonitor := buildActiveOutageIndex(c.outages)
+
+	upCount := 0
 	for _, m := range c.monitors {
 		ch <- prometheus.MustNewConstMetric(c.monitorUp, prometheus.GaugeValue,
 			boolToFloat64(m.Status == "up"), m.UUID, m.Name)
@@ -241,6 +401,25 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.monitorSSLExpDays, prometheus.GaugeValue,
 				float64(*m.SSLExpiration), m.UUID, m.Name)
 		}
+
+		// OPS-32: active outage state and HTTP status code.
+		activeOutage, hasActive := activeOutageByMonitor[m.UUID]
+		ch <- prometheus.MustNewConstMetric(c.monitorOutageActive, prometheus.GaugeValue,
+			boolToFloat64(hasActive), m.UUID, m.Name)
+		statusCode := 0
+		if hasActive {
+			statusCode = activeOutage.StatusCode
+		}
+		ch <- prometheus.MustNewConstMetric(c.monitorActiveOutageStatus, prometheus.GaugeValue,
+			float64(statusCode), m.UUID, m.Name)
+
+		// OPS-39: escalation tier info.
+		ch <- prometheus.MustNewConstMetric(c.monitorTier, prometheus.GaugeValue, 1,
+			m.UUID, m.Name, escalationTier(m))
+
+		if m.Status == "up" {
+			upCount++
+		}
 	}
 
 	for _, hc := range c.healthchecks {
@@ -252,6 +431,33 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			float64(hc.Period), hc.UUID, hc.Name)
 	}
 
+	// OPS-32 + OPS-33: per-monitor SLA/outage stats per report period.
+	for _, period := range reportPeriods {
+		reports := c.reportsByPeriod[period]
+		slaSum := 0.0
+		for _, r := range reports {
+			sla := r.SLA / 100.0 // API returns 0–100; expose as 0–1
+			ch <- prometheus.MustNewConstMetric(c.monitorSLA, prometheus.GaugeValue,
+				sla, r.UUID, r.Name, period)
+			ch <- prometheus.MustNewConstMetric(c.monitorOutages, prometheus.GaugeValue,
+				float64(r.Outages.Count), r.UUID, r.Name, period)
+			ch <- prometheus.MustNewConstMetric(c.monitorDowntime, prometheus.GaugeValue,
+				float64(r.Outages.TotalDowntime), r.UUID, r.Name, period)
+			ch <- prometheus.MustNewConstMetric(c.monitorLongestOutage, prometheus.GaugeValue,
+				float64(r.Outages.LongestOutage), r.UUID, r.Name, period)
+			if r.MTTR > 0 {
+				ch <- prometheus.MustNewConstMetric(c.monitorMTTR, prometheus.GaugeValue,
+					float64(r.MTTR), r.UUID, r.Name, period)
+			}
+			slaSum += sla
+		}
+		if len(reports) > 0 {
+			ch <- prometheus.MustNewConstMetric(c.tenantAvgSLA, prometheus.GaugeValue,
+				slaSum/float64(len(reports)), period)
+		}
+	}
+
+	// Summary metrics.
 	ch <- prometheus.MustNewConstMetric(c.monitorsTotal, prometheus.GaugeValue,
 		float64(len(c.monitors)))
 	ch <- prometheus.MustNewConstMetric(c.healthchecksTotal, prometheus.GaugeValue,
@@ -260,6 +466,73 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		c.lastScrapeDur.Seconds())
 	ch <- prometheus.MustNewConstMetric(c.scrapeSuccessDesc, prometheus.GaugeValue,
 		boolToFloat64(c.lastScrapeOK))
+
+	// OPS-31: data age — only after at least one successful scrape.
+	if !c.lastSuccessTime.IsZero() {
+		ch <- prometheus.MustNewConstMetric(c.dataAgeDesc, prometheus.GaugeValue,
+			time.Since(c.lastSuccessTime).Seconds())
+	}
+
+	// OPS-34: tenant-wide health metrics.
+	upRatio := 0.0
+	if len(c.monitors) > 0 {
+		upRatio = float64(upCount) / float64(len(c.monitors))
+	}
+	avg30dSLA := avgSLAForPeriod(c.reportsByPeriod["30d"])
+	ch <- prometheus.MustNewConstMetric(c.tenantHealthScore, prometheus.GaugeValue,
+		computeHealthScore(upRatio, avg30dSLA, len(activeOutageByMonitor), len(c.monitors)))
+	ch <- prometheus.MustNewConstMetric(c.tenantUpRatio, prometheus.GaugeValue, upRatio)
+	ch <- prometheus.MustNewConstMetric(c.tenantActiveOutages, prometheus.GaugeValue,
+		float64(len(activeOutageByMonitor)))
+}
+
+// buildActiveOutageIndex returns a map of monitor UUID → active Outage.
+// An outage is active when IsResolved is false and EndDate is nil (ongoing).
+func buildActiveOutageIndex(outages []client.Outage) map[string]client.Outage {
+	idx := make(map[string]client.Outage, len(outages))
+	for _, o := range outages {
+		if !o.IsResolved && o.EndDate == nil {
+			idx[o.Monitor.UUID] = o
+		}
+	}
+	return idx
+}
+
+// escalationTier returns "core" when the monitor has an escalation policy, "noncore" otherwise.
+func escalationTier(m client.Monitor) string {
+	if m.EscalationPolicy != nil && *m.EscalationPolicy != "" {
+		return "core"
+	}
+	return "noncore"
+}
+
+// avgSLAForPeriod computes the mean SLA ratio (0–1) across a set of reports.
+func avgSLAForPeriod(reports []client.MonitorReport) float64 {
+	if len(reports) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, r := range reports {
+		sum += r.SLA / 100.0
+	}
+	return sum / float64(len(reports))
+}
+
+// computeHealthScore returns a composite 0–100 health score.
+// Base: upRatio×60 + avgSLA×40. Penalty: (activeOutages/total)×30, capped at 100/0.
+func computeHealthScore(upRatio, avgSLA float64, activeOutages, totalMonitors int) float64 {
+	base := upRatio*60.0 + avgSLA*40.0
+	if totalMonitors > 0 {
+		penalty := float64(activeOutages) / float64(totalMonitors) * 30.0
+		base -= penalty
+	}
+	if base < 0 {
+		return 0
+	}
+	if base > 100 {
+		return 100
+	}
+	return base
 }
 
 func boolToFloat64(b bool) float64 {

--- a/cmd/hyperping-exporter/collector.go
+++ b/cmd/hyperping-exporter/collector.go
@@ -93,8 +93,8 @@ var _ prometheus.Collector = (*Collector)(nil)
 
 // NewCollector creates a new Hyperping metrics collector.
 func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger) *Collector {
-	ml := []string{"uuid", "name"}
-	mpl := []string{"uuid", "name", "period"}
+	monitorLabels := []string{"uuid", "name"}
+	monitorPeriodLabels := []string{"uuid", "name", "period"}
 
 	return &Collector{
 		api:             api,
@@ -105,22 +105,22 @@ func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger)
 		monitorUp: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "up"),
 			"Whether the monitor is up (1) or down (0).",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorPaused: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "paused"),
 			"Whether the monitor is paused (1) or active (0).",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorSSLExpDays: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "ssl_expiration_days"),
 			"Days until SSL certificate expiration.",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorCheckInterval: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "check_interval_seconds"),
 			"Monitor check frequency in seconds.",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "info"),
@@ -170,37 +170,37 @@ func NewCollector(api HyperpingAPI, cacheTTL time.Duration, logger *slog.Logger)
 		monitorOutageActive: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "outage_active"),
 			"Whether the monitor has an active (unresolved) outage (1) or not (0).",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorActiveOutageStatus: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "active_outage_status_code"),
 			"HTTP status code of the current active outage; 0 when no active outage.",
-			ml, nil,
+			monitorLabels, nil,
 		),
 		monitorSLA: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "sla_ratio"),
 			"Monitor SLA as a ratio (0–1) over the labelled period.",
-			mpl, nil,
+			monitorPeriodLabels, nil,
 		),
 		monitorOutages: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "outages"),
 			"Number of outages over the labelled period.",
-			mpl, nil,
+			monitorPeriodLabels, nil,
 		),
 		monitorDowntime: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "downtime_seconds"),
 			"Total downtime in seconds over the labelled period.",
-			mpl, nil,
+			monitorPeriodLabels, nil,
 		),
 		monitorLongestOutage: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "longest_outage_seconds"),
 			"Duration of the longest single outage in seconds over the labelled period.",
-			mpl, nil,
+			monitorPeriodLabels, nil,
 		),
 		monitorMTTR: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "monitor", "mttr_seconds"),
 			"Mean Time To Recovery in seconds over the labelled period.",
-			mpl, nil,
+			monitorPeriodLabels, nil,
 		),
 		tenantHealthScore: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "tenant", "health_score"),
@@ -330,7 +330,11 @@ func (c *Collector) Refresh(ctx context.Context) {
 
 	c.monitors = monitors
 	c.healthchecks = healthchecks
-	c.reportsByPeriod = reportResults
+	// Merge successful period results into the cache; periods that failed this
+	// cycle retain their previous data rather than being dropped entirely.
+	for period, reports := range reportResults {
+		c.reportsByPeriod[period] = reports
+	}
 	c.lastScrapeOK = true
 	c.lastSuccessTime = time.Now()
 
@@ -478,12 +482,16 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	if len(c.monitors) > 0 {
 		upRatio = float64(upCount) / float64(len(c.monitors))
 	}
-	avg30dSLA := avgSLAForPeriod(c.reportsByPeriod["30d"])
-	ch <- prometheus.MustNewConstMetric(c.tenantHealthScore, prometheus.GaugeValue,
-		computeHealthScore(upRatio, avg30dSLA, len(activeOutageByMonitor), len(c.monitors)))
 	ch <- prometheus.MustNewConstMetric(c.tenantUpRatio, prometheus.GaugeValue, upRatio)
 	ch <- prometheus.MustNewConstMetric(c.tenantActiveOutages, prometheus.GaugeValue,
 		float64(len(activeOutageByMonitor)))
+	// Health score requires 30d SLA data; omit until reports are loaded to avoid
+	// misleadingly low scores (upRatio×60 + 0×40 = 60 even for a healthy fleet).
+	if reports30d := c.reportsByPeriod["30d"]; len(reports30d) > 0 {
+		avg30dSLA := avgSLAForPeriod(reports30d)
+		ch <- prometheus.MustNewConstMetric(c.tenantHealthScore, prometheus.GaugeValue,
+			computeHealthScore(upRatio, avg30dSLA, len(activeOutageByMonitor), len(c.monitors)))
+	}
 }
 
 // buildActiveOutageIndex returns a map of monitor UUID → active Outage.
@@ -498,7 +506,10 @@ func buildActiveOutageIndex(outages []client.Outage) map[string]client.Outage {
 	return idx
 }
 
-// escalationTier returns "core" when the monitor has an escalation policy, "noncore" otherwise.
+// escalationTier returns "core" when the monitor has an escalation policy set,
+// "noncore" otherwise. The binary classification is intentional: the Hyperping
+// API does not expose a "shared infrastructure" concept at the monitor level;
+// tenant grouping is a concern of the Python automation layer, not this exporter.
 func escalationTier(m client.Monitor) string {
 	if m.EscalationPolicy != nil && *m.EscalationPolicy != "" {
 		return "core"

--- a/cmd/hyperping-exporter/collector_test.go
+++ b/cmd/hyperping-exporter/collector_test.go
@@ -156,10 +156,10 @@ func TestRefresh_PreservesOldCacheOnError(t *testing.T) {
 
 	// Old monitor data remains; lastSuccessTime was set on first scrape so data_age IS emitted.
 	// Per monitor: up + paused + check_interval + info + outage_active + status_code + tier = 7
-	// Summary: 4, Tenant: health_score + up_ratio + active_outages + data_age = 4
-	// Total: 7 + 4 + 4 = 15
+	// Summary: 4, Tenant: up_ratio + active_outages + data_age = 3 (health_score omitted: no reports)
+	// Total: 7 + 4 + 3 = 14
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 15, count)
+	assert.Equal(t, 14, count)
 }
 
 func TestCollect_WithMonitorsAndHealthchecks(t *testing.T) {
@@ -201,18 +201,18 @@ func TestCollect_WithMonitorsAndHealthchecks(t *testing.T) {
 	// mon_2: up + paused + interval + info + outage_active + status_code + tier = 7
 	// hc: up + paused + period = 3
 	// Summary: monitors + healthchecks + scrape_duration + scrape_success = 4
-	// Tenant: health_score + up_ratio + active_outages + data_age = 4
-	// Total = 26
+	// Tenant: up_ratio + active_outages + data_age = 3 (health_score omitted: no reports in mock)
+	// Total = 25
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 26, count)
+	assert.Equal(t, 25, count)
 }
 
 func TestCollect_EmptyCache(t *testing.T) {
 	c := NewCollector(&mockAPI{}, 60*time.Second, newTestLogger())
 
-	// No refresh: only 4 summary + 3 tenant (no data_age, no avg_sla) = 7
+	// No refresh: 4 summary + 2 tenant (up_ratio + active_outages; no data_age, no health_score) = 6
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 7, count)
+	assert.Equal(t, 6, count)
 }
 
 func TestCollect_NoSSLExpiration(t *testing.T) {
@@ -234,10 +234,10 @@ func TestCollect_NoSSLExpiration(t *testing.T) {
 	c.Refresh(context.Background())
 
 	// Monitor: up + paused + interval + info + outage_active + status_code + tier = 7
-	// Summary: 4, Tenant: 4 (with data_age after successful scrape)
-	// Total = 15
+	// Summary: 4, Tenant: up_ratio + active_outages + data_age = 3 (health_score omitted: no reports)
+	// Total = 14
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 15, count)
+	assert.Equal(t, 14, count)
 }
 
 func TestCollect_SummaryMetricValues(t *testing.T) {

--- a/cmd/hyperping-exporter/collector_test.go
+++ b/cmd/hyperping-exporter/collector_test.go
@@ -24,8 +24,12 @@ import (
 type mockAPI struct {
 	monitors        []client.Monitor
 	healthchecks    []client.Healthcheck
+	outages         []client.Outage
+	reports         []client.MonitorReport
 	monitorsErr     error
 	healthchecksErr error
+	outagesErr      error
+	reportsErr      error
 }
 
 func (m *mockAPI) ListMonitors(_ context.Context) ([]client.Monitor, error) {
@@ -34,6 +38,14 @@ func (m *mockAPI) ListMonitors(_ context.Context) ([]client.Monitor, error) {
 
 func (m *mockAPI) ListHealthchecks(_ context.Context) ([]client.Healthcheck, error) {
 	return m.healthchecks, m.healthchecksErr
+}
+
+func (m *mockAPI) ListOutages(_ context.Context) ([]client.Outage, error) {
+	return m.outages, m.outagesErr
+}
+
+func (m *mockAPI) ListMonitorReports(_ context.Context, _, _ string) ([]client.MonitorReport, error) {
+	return m.reports, m.reportsErr
 }
 
 func newTestLogger() *slog.Logger {
@@ -50,7 +62,7 @@ func TestNewCollector(t *testing.T) {
 func TestDescribe(t *testing.T) {
 	c := NewCollector(&mockAPI{}, 60*time.Second, newTestLogger())
 
-	ch := make(chan *prometheus.Desc, 20)
+	ch := make(chan *prometheus.Desc, 30)
 	c.Describe(ch)
 	close(ch)
 
@@ -58,7 +70,8 @@ func TestDescribe(t *testing.T) {
 	for d := range ch {
 		descs = append(descs, d)
 	}
-	assert.Len(t, descs, 12)
+	// 12 original + 13 new (OPS-31/32/33/34/39) = 25
+	assert.Len(t, descs, 25)
 }
 
 func TestRefresh_Success(t *testing.T) {
@@ -112,6 +125,20 @@ func TestRefresh_HealthcheckError(t *testing.T) {
 	assert.False(t, c.IsReady())
 }
 
+func TestRefresh_OutageErrorIsNonFatal(t *testing.T) {
+	// Outage failures should not mark the scrape as failed.
+	api := &mockAPI{
+		monitors:     []client.Monitor{{UUID: "mon_1", Name: "Web", HTTPMethod: "GET", Status: "up"}},
+		healthchecks: []client.Healthcheck{},
+		outagesErr:   errors.New("outage api error"),
+	}
+
+	c := NewCollector(api, 60*time.Second, newTestLogger())
+	c.Refresh(context.Background())
+
+	assert.True(t, c.IsReady())
+}
+
 func TestRefresh_PreservesOldCacheOnError(t *testing.T) {
 	api := &mockAPI{
 		monitors:     []client.Monitor{{UUID: "mon_1", Name: "Web", HTTPMethod: "GET"}},
@@ -122,18 +149,17 @@ func TestRefresh_PreservesOldCacheOnError(t *testing.T) {
 	c.Refresh(context.Background())
 	require.True(t, c.IsReady())
 
-	// Now make the API fail
 	api.monitorsErr = errors.New("temporary failure")
 	c.Refresh(context.Background())
 
-	// Should not be ready (last scrape failed), but old data remains
 	assert.False(t, c.IsReady())
 
-	// Collect should still emit metrics from old cache
+	// Old monitor data remains; lastSuccessTime was set on first scrape so data_age IS emitted.
+	// Per monitor: up + paused + check_interval + info + outage_active + status_code + tier = 7
+	// Summary: 4, Tenant: health_score + up_ratio + active_outages + data_age = 4
+	// Total: 7 + 4 + 4 = 15
 	count := testutil.CollectAndCount(c)
-	// 1 monitor: up + paused + check_interval + info = 4, no SSL
-	// 4 summary metrics
-	assert.Equal(t, 8, count)
+	assert.Equal(t, 15, count)
 }
 
 func TestCollect_WithMonitorsAndHealthchecks(t *testing.T) {
@@ -171,21 +197,22 @@ func TestCollect_WithMonitorsAndHealthchecks(t *testing.T) {
 	c := NewCollector(api, 60*time.Second, newTestLogger())
 	c.Refresh(context.Background())
 
-	// mon_1: up + paused + check_interval + info + ssl = 5
-	// mon_2: up + paused + check_interval + info = 4 (no SSL)
-	// 1 healthcheck: up + paused + period = 3
-	// Summary: 4 (monitors, healthchecks, scrape_duration, scrape_success)
-	// Total = 16
+	// mon_1: up + paused + interval + info + ssl + outage_active + status_code + tier = 8
+	// mon_2: up + paused + interval + info + outage_active + status_code + tier = 7
+	// hc: up + paused + period = 3
+	// Summary: monitors + healthchecks + scrape_duration + scrape_success = 4
+	// Tenant: health_score + up_ratio + active_outages + data_age = 4
+	// Total = 26
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 16, count)
+	assert.Equal(t, 26, count)
 }
 
 func TestCollect_EmptyCache(t *testing.T) {
 	c := NewCollector(&mockAPI{}, 60*time.Second, newTestLogger())
 
-	// Before any refresh: only 4 summary/exporter metrics
+	// No refresh: only 4 summary + 3 tenant (no data_age, no avg_sla) = 7
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 4, count)
+	assert.Equal(t, 7, count)
 }
 
 func TestCollect_NoSSLExpiration(t *testing.T) {
@@ -206,11 +233,11 @@ func TestCollect_NoSSLExpiration(t *testing.T) {
 	c := NewCollector(api, 60*time.Second, newTestLogger())
 	c.Refresh(context.Background())
 
-	// 1 monitor: up + paused + check_interval + info = 4 (no SSL)
-	// Summary: 4
-	// Total = 8
+	// Monitor: up + paused + interval + info + outage_active + status_code + tier = 7
+	// Summary: 4, Tenant: 4 (with data_age after successful scrape)
+	// Total = 15
 	count := testutil.CollectAndCount(c)
-	assert.Equal(t, 8, count)
+	assert.Equal(t, 15, count)
 }
 
 func TestCollect_SummaryMetricValues(t *testing.T) {
@@ -344,13 +371,177 @@ hyperping_scrape_success 0
 	require.NoError(t, err)
 }
 
-func TestCollect_Lint(t *testing.T) {
+func TestCollect_ActiveOutageMetrics(t *testing.T) {
+	endDate := "2026-03-29T12:00:00Z"
 	api := &mockAPI{
 		monitors: []client.Monitor{
-			{UUID: "mon_1", Name: "Web", Protocol: "http", HTTPMethod: "GET", CheckFrequency: 60, Status: "up"},
+			{UUID: "mon_1", Name: "Web", Protocol: "http", HTTPMethod: "GET", Status: "down"},
+			{UUID: "mon_2", Name: "API", Protocol: "http", HTTPMethod: "GET", Status: "up"},
+		},
+		healthchecks: []client.Healthcheck{},
+		outages: []client.Outage{
+			// Active outage on mon_1 (EndDate nil, IsResolved false)
+			{
+				UUID:       "out_1",
+				IsResolved: false,
+				EndDate:    nil,
+				StatusCode: 503,
+				Monitor:    client.MonitorReference{UUID: "mon_1", Name: "Web"},
+				OutageType: "automatic",
+				StartDate:  "2026-03-29T10:00:00Z",
+			},
+			// Resolved outage on mon_2 (should not be flagged as active)
+			{
+				UUID:       "out_2",
+				IsResolved: true,
+				EndDate:    &endDate,
+				StatusCode: 500,
+				Monitor:    client.MonitorReference{UUID: "mon_2", Name: "API"},
+				OutageType: "automatic",
+				StartDate:  "2026-03-29T09:00:00Z",
+			},
+		},
+	}
+
+	c := NewCollector(api, 60*time.Second, newTestLogger())
+	c.Refresh(context.Background())
+
+	expected := `
+# HELP hyperping_monitor_outage_active Whether the monitor has an active (unresolved) outage (1) or not (0).
+# TYPE hyperping_monitor_outage_active gauge
+hyperping_monitor_outage_active{name="API",uuid="mon_2"} 0
+hyperping_monitor_outage_active{name="Web",uuid="mon_1"} 1
+# HELP hyperping_monitor_active_outage_status_code HTTP status code of the current active outage; 0 when no active outage.
+# TYPE hyperping_monitor_active_outage_status_code gauge
+hyperping_monitor_active_outage_status_code{name="API",uuid="mon_2"} 0
+hyperping_monitor_active_outage_status_code{name="Web",uuid="mon_1"} 503
+`
+	err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"hyperping_monitor_outage_active",
+		"hyperping_monitor_active_outage_status_code",
+	)
+	require.NoError(t, err)
+}
+
+func TestCollect_EscalationTierMetrics(t *testing.T) {
+	policyUUID := "policy_abc"
+	api := &mockAPI{
+		monitors: []client.Monitor{
+			{UUID: "mon_1", Name: "Core", Protocol: "http", HTTPMethod: "GET", EscalationPolicy: &policyUUID},
+			{UUID: "mon_2", Name: "Edge", Protocol: "http", HTTPMethod: "GET", EscalationPolicy: nil},
+		},
+		healthchecks: []client.Healthcheck{},
+	}
+
+	c := NewCollector(api, 60*time.Second, newTestLogger())
+	c.Refresh(context.Background())
+
+	expected := `
+# HELP hyperping_monitor_escalation_tier Escalation tier info (always 1). Join on uuid+name; use tier label to filter core/noncore.
+# TYPE hyperping_monitor_escalation_tier gauge
+hyperping_monitor_escalation_tier{name="Core",tier="core",uuid="mon_1"} 1
+hyperping_monitor_escalation_tier{name="Edge",tier="noncore",uuid="mon_2"} 1
+`
+	err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"hyperping_monitor_escalation_tier",
+	)
+	require.NoError(t, err)
+}
+
+func TestCollect_SLAReportMetrics(t *testing.T) {
+	api := &mockAPI{
+		monitors: []client.Monitor{
+			{UUID: "mon_1", Name: "Web", Protocol: "http", HTTPMethod: "GET", Status: "up"},
+		},
+		healthchecks: []client.Healthcheck{},
+		reports: []client.MonitorReport{
+			{
+				UUID:     "mon_1",
+				Name:     "Web",
+				Protocol: "http",
+				SLA:      99.5,
+				MTTR:     120,
+				Outages: client.OutageStats{
+					Count:         2,
+					TotalDowntime: 300,
+					LongestOutage: 240,
+				},
+			},
+		},
+	}
+
+	c := NewCollector(api, 60*time.Second, newTestLogger())
+	c.Refresh(context.Background())
+
+	// Reports are fetched for 3 periods; each period returns the same mock data.
+	expected := `
+# HELP hyperping_monitor_sla_ratio Monitor SLA as a ratio (0–1) over the labelled period.
+# TYPE hyperping_monitor_sla_ratio gauge
+hyperping_monitor_sla_ratio{name="Web",period="24h",uuid="mon_1"} 0.995
+hyperping_monitor_sla_ratio{name="Web",period="7d",uuid="mon_1"} 0.995
+hyperping_monitor_sla_ratio{name="Web",period="30d",uuid="mon_1"} 0.995
+`
+	err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"hyperping_monitor_sla_ratio",
+	)
+	require.NoError(t, err)
+}
+
+func TestCollect_TenantHealthMetrics(t *testing.T) {
+	api := &mockAPI{
+		monitors: []client.Monitor{
+			{UUID: "mon_1", Name: "A", Protocol: "http", HTTPMethod: "GET", Status: "up"},
+			{UUID: "mon_2", Name: "B", Protocol: "http", HTTPMethod: "GET", Status: "up"},
+		},
+		healthchecks: []client.Healthcheck{},
+		reports: []client.MonitorReport{
+			{UUID: "mon_1", Name: "A", SLA: 100.0},
+			{UUID: "mon_2", Name: "B", SLA: 98.0},
+		},
+	}
+
+	c := NewCollector(api, 60*time.Second, newTestLogger())
+	c.Refresh(context.Background())
+
+	// 2 monitors up, 0 active outages → up_ratio=1.0
+	// avgSLA = (1.0+0.98)/2 = 0.99 → health_score = 1.0*60 + 0.99*40 = 99.6
+	expected := `
+# HELP hyperping_tenant_monitors_up_ratio Fraction of monitors currently up (0–1).
+# TYPE hyperping_tenant_monitors_up_ratio gauge
+hyperping_tenant_monitors_up_ratio 1
+# HELP hyperping_tenant_active_outages Total number of active (unresolved) outages across all monitors.
+# TYPE hyperping_tenant_active_outages gauge
+hyperping_tenant_active_outages 0
+`
+	err := testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"hyperping_tenant_monitors_up_ratio",
+		"hyperping_tenant_active_outages",
+	)
+	require.NoError(t, err)
+}
+
+func TestCollect_Lint(t *testing.T) {
+	policyUUID := "policy_123"
+	endDate := "2026-03-29T08:00:00Z"
+	api := &mockAPI{
+		monitors: []client.Monitor{
+			{
+				UUID: "mon_1", Name: "Web", Protocol: "http",
+				HTTPMethod: "GET", CheckFrequency: 60, Status: "up",
+				EscalationPolicy: &policyUUID,
+			},
 		},
 		healthchecks: []client.Healthcheck{
 			{UUID: "tok_1", Name: "Job", Period: 300},
+		},
+		outages: []client.Outage{
+			{
+				UUID: "out_1", IsResolved: true, EndDate: &endDate, StatusCode: 200,
+				Monitor: client.MonitorReference{UUID: "mon_1", Name: "Web"},
+			},
+		},
+		reports: []client.MonitorReport{
+			{UUID: "mon_1", Name: "Web", SLA: 99.9},
 		},
 	}
 
@@ -360,4 +551,53 @@ func TestCollect_Lint(t *testing.T) {
 	problems, err := testutil.CollectAndLint(c)
 	require.NoError(t, err)
 	assert.Empty(t, problems)
+}
+
+func TestComputeHealthScore(t *testing.T) {
+	tests := []struct {
+		name          string
+		upRatio       float64
+		avgSLA        float64
+		activeOutages int
+		totalMonitors int
+		expectedMin   float64
+		expectedMax   float64
+	}{
+		{"all healthy", 1.0, 1.0, 0, 10, 99, 101},
+		{"all down", 0.0, 0.0, 10, 10, 0, 1},
+		{"partial", 0.8, 0.9, 1, 10, 50, 90},
+		{"no monitors", 0.0, 0.0, 0, 0, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := computeHealthScore(tt.upRatio, tt.avgSLA, tt.activeOutages, tt.totalMonitors)
+			assert.GreaterOrEqual(t, score, tt.expectedMin)
+			assert.LessOrEqual(t, score, tt.expectedMax)
+		})
+	}
+}
+
+func TestBuildActiveOutageIndex(t *testing.T) {
+	endDate := "2026-03-29T12:00:00Z"
+	outages := []client.Outage{
+		{UUID: "a", IsResolved: false, EndDate: nil, Monitor: client.MonitorReference{UUID: "mon_1"}},
+		{UUID: "b", IsResolved: true, EndDate: &endDate, Monitor: client.MonitorReference{UUID: "mon_2"}},
+		{UUID: "c", IsResolved: false, EndDate: &endDate, Monitor: client.MonitorReference{UUID: "mon_3"}},
+	}
+
+	idx := buildActiveOutageIndex(outages)
+
+	assert.Len(t, idx, 1)
+	assert.Contains(t, idx, "mon_1")
+	assert.NotContains(t, idx, "mon_2")
+	assert.NotContains(t, idx, "mon_3")
+}
+
+func TestEscalationTier(t *testing.T) {
+	policyUUID := "uuid-123"
+	emptyUUID := ""
+
+	assert.Equal(t, "core", escalationTier(client.Monitor{EscalationPolicy: &policyUUID}))
+	assert.Equal(t, "noncore", escalationTier(client.Monitor{EscalationPolicy: nil}))
+	assert.Equal(t, "noncore", escalationTier(client.Monitor{EscalationPolicy: &emptyUUID}))
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  hyperping-exporter:
+    image: ghcr.io/develeap/hyperping-exporter:latest
+    build:
+      context: ..
+      dockerfile: cmd/hyperping-exporter/Dockerfile
+    environment:
+      HYPERPING_API_KEY: "${HYPERPING_API_KEY}"
+    command:
+      - "--cache-ttl=60s"
+      - "--log-format=json"
+    ports:
+      - "9312:9312"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:9312/readyz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  prometheus:
+    image: prom/prometheus:v2.55.0
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ./prometheus/recording-rules.yml:/etc/prometheus/recording-rules.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=30d"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    depends_on:
+      - hyperping-exporter
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_FEATURE_TOGGLES_ENABLE: "publicDashboards"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/deploy/grafana/dashboards/fleet-overview.json
+++ b/deploy/grafana/dashboards/fleet-overview.json
@@ -1,0 +1,554 @@
+{
+  "title": "Hyperping Fleet Overview",
+  "uid": "hyperping-fleet-overview",
+  "description": "Live UP/DOWN stats, active outages, and tier SLA comparison for on-call use. Requires OPS-32, OPS-33, OPS-39.",
+  "tags": ["hyperping", "fleet", "on-call"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "browser",
+  "graphTooltip": 1,
+  "editable": true,
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Monitors UP",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "unit": "short"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_up == 1) or vector(0)",
+          "legendFormat": "UP",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Monitors DOWN",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "unit": "short"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_up == 0 and hyperping_monitor_paused == 0) or vector(0)",
+          "legendFormat": "DOWN",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Active Outages",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "unit": "short"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_active_outages",
+          "legendFormat": "Outages",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Tenant Health Score",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "yellow", "value": 80 },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_health_score",
+          "legendFormat": "Score",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Avg SLA (24h)",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.95 },
+              { "color": "yellow", "value": 0.99 },
+              { "color": "green", "value": 0.999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_avg_sla_ratio{period=\"24h\"}",
+          "legendFormat": "24h SLA",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Data Age",
+      "gridPos": { "x": 20, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "red", "value": 180 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_data_age_seconds",
+          "legendFormat": "Age",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Monitor Status",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "table",
+      "title": "All Monitors",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 10 },
+      "options": {
+        "sortBy": [{ "displayName": "Status", "desc": false }],
+        "footer": { "show": false }
+      },
+      "fieldConfig": {
+        "defaults": { "custom": { "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Status" },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "1": { "text": "UP", "color": "green" } } },
+                  { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Active Outage" },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "1": { "text": "YES", "color": "red" } } },
+                  { "type": "value", "options": { "0": { "text": "no", "color": "green" } } }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "SLA 24h" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 3 },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "orange", "value": 0.95 },
+                    { "color": "yellow", "value": 0.99 },
+                    { "color": "green", "value": 0.999 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "SLA 30d" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 3 },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "orange", "value": 0.99 },
+                    { "color": "yellow", "value": 0.999 },
+                    { "color": "green", "value": 0.9999 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Status",
+              "Value #B": "Active Outage",
+              "Value #C": "SLA 24h",
+              "Value #D": "SLA 30d",
+              "Value #E": "Tier"
+            },
+            "excludeByName": {
+              "Time": true,
+              "job": true
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_up",
+          "legendFormat": "{{name}}",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_outage_active",
+          "legendFormat": "{{name}}",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_sla_ratio{period=\"24h\"}",
+          "legendFormat": "{{name}}",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_sla_ratio{period=\"30d\"}",
+          "legendFormat": "{{name}}",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_escalation_tier",
+          "legendFormat": "{{name}}",
+          "instant": true,
+          "refId": "E"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Active Outages",
+      "gridPos": { "x": 0, "y": 15, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "table",
+      "title": "Monitors With Active Outages",
+      "gridPos": { "x": 0, "y": 16, "w": 14, "h": 6 },
+      "options": { "footer": { "show": false } },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "HTTP Status" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "0": { "text": "N/A" } } },
+                  { "type": "range", "options": { "from": 500, "to": 599, "result": { "color": "red" } } },
+                  { "type": "range", "options": { "from": 400, "to": 499, "result": { "color": "orange" } } }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              { "fieldName": "Value #A", "config": { "id": "equal", "options": { "value": 1 } } }
+            ],
+            "type": "include",
+            "match": "all"
+          }
+        },
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Active",
+              "Value #B": "HTTP Status"
+            },
+            "excludeByName": { "Time": true, "job": true, "Active": true }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_outage_active",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_active_outage_status_code",
+          "instant": true,
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Active Outage Count Over Time",
+      "gridPos": { "x": 14, "y": 16, "w": 10, "h": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_active_outages",
+          "legendFormat": "Active Outages"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "SLA by Tier (OPS-39)",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "bargauge",
+      "title": "30-Day SLA by Tier",
+      "gridPos": { "x": 0, "y": 23, "w": 12, "h": 6 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "min": 0.9,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.99 },
+              { "color": "yellow", "value": 0.999 },
+              { "color": "green", "value": 0.9999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping:tier:avg_sla_30d",
+          "legendFormat": "{{tier}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "bargauge",
+      "title": "7-Day SLA by Tier",
+      "gridPos": { "x": 12, "y": 23, "w": 12, "h": 6 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "min": 0.9,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.99 },
+              { "color": "yellow", "value": 0.999 },
+              { "color": "green", "value": 0.9999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping:tier:avg_sla_7d",
+          "legendFormat": "{{tier}}",
+          "instant": true
+        }
+      ]
+    }
+  ],
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "name": "Active Outages",
+        "datasource": { "type": "prometheus" },
+        "enable": true,
+        "hide": false,
+        "iconColor": "red",
+        "expr": "changes(hyperping_tenant_active_outages[1m]) > 0",
+        "step": "60s",
+        "titleFormat": "Outage count changed"
+      }
+    ]
+  }
+}

--- a/deploy/grafana/dashboards/shared-infrastructure.json
+++ b/deploy/grafana/dashboards/shared-infrastructure.json
@@ -359,7 +359,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus" },
-          "expr": "hyperping_monitor_outage_count{period=\"24h\"} > 0",
+          "expr": "hyperping_monitor_outages{period=\"24h\"} > 0",
           "instant": true,
           "refId": "A"
         },

--- a/deploy/grafana/dashboards/shared-infrastructure.json
+++ b/deploy/grafana/dashboards/shared-infrastructure.json
@@ -1,0 +1,382 @@
+{
+  "title": "Hyperping Shared Infrastructure",
+  "uid": "hyperping-shared-infra",
+  "description": "Error code breakdown, cross-monitor pattern visibility, and 422 anomaly detection for ops debugging. Requires OPS-32, OPS-39.",
+  "tags": ["hyperping", "infrastructure", "debugging"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "browser",
+  "graphTooltip": 1,
+  "editable": true,
+  "templating": {
+    "list": [
+      {
+        "name": "tier",
+        "label": "Tier",
+        "type": "custom",
+        "query": "core,noncore",
+        "current": { "value": "$__all", "text": "All" },
+        "includeAll": true,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Monitors With 5xx Errors",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_active_outage_status_code >= 500 and hyperping_monitor_active_outage_status_code < 600) or vector(0)",
+          "legendFormat": "5xx",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Monitors With 4xx Errors",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "orange", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_active_outage_status_code >= 400 and hyperping_monitor_active_outage_status_code < 500) or vector(0)",
+          "legendFormat": "4xx",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "422 Unprocessable (Pattern Alert)",
+      "description": "422 errors often indicate a schema or validation change in a shared API layer.",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_active_outage_status_code == 422) or vector(0)",
+          "legendFormat": "422",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Core Tier Active Outages",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count(hyperping_monitor_outage_active * on(uuid, name) group_left(tier) hyperping_monitor_escalation_tier{tier=\"core\"} == 1) or vector(0)",
+          "legendFormat": "Core Outages",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Error Code Breakdown",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "piechart",
+      "title": "Active Outage Status Codes Distribution",
+      "description": "Distribution of HTTP status codes across all active outages. 0 = monitor down without HTTP error.",
+      "gridPos": { "x": 0, "y": 5, "w": 10, "h": 8 },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": ["name", "value"],
+        "legend": { "displayMode": "table", "placement": "right" }
+      },
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "count by (status_code) (label_replace(hyperping_monitor_active_outage_status_code > 0, \"status_code\", \"$1\", \"__name__\", \".+\") * hyperping_monitor_active_outage_status_code > 0)",
+          "legendFormat": "{{status_code}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "table",
+      "title": "Active Outages — Error Code Detail",
+      "gridPos": { "x": 10, "y": 5, "w": 14, "h": 8 },
+      "options": {
+        "sortBy": [{ "displayName": "HTTP Status", "desc": true }],
+        "footer": { "show": false }
+      },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "HTTP Status" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "0":   { "text": "No Response" } } },
+                  { "type": "value", "options": { "422": { "text": "422 Unprocessable", "color": "orange" } } },
+                  { "type": "range", "options": { "from": 500, "to": 599, "result": { "color": "red" } } },
+                  { "type": "range", "options": { "from": 400, "to": 499, "result": { "color": "orange" } } }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Tier" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "core":    { "text": "CORE",    "color": "red" } } },
+                  { "type": "value", "options": { "noncore": { "text": "noncore", "color": "blue" } } }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [{ "fieldName": "Value #A", "config": { "id": "equal", "options": { "value": 1 } } }],
+            "type": "include",
+            "match": "all"
+          }
+        },
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Active",
+              "Value #B": "HTTP Status",
+              "Value #C": "Tier"
+            },
+            "excludeByName": { "Time": true, "job": true, "Active": true }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_outage_active",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_active_outage_status_code",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_escalation_tier",
+          "instant": true,
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "SLA Comparison by Tier",
+      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Core vs Non-Core Average SLA (24h window)",
+      "description": "Divergence between core and noncore tiers may indicate selective infrastructure issues.",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 7 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0.8,
+          "max": 1.0,
+          "custom": { "lineWidth": 2, "fillOpacity": 5 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "core" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "noncore" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping:tier:avg_sla_7d",
+          "legendFormat": "{{tier}}"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Outage History by Monitor",
+      "gridPos": { "x": 0, "y": 21, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "table",
+      "title": "24h Outage Count per Monitor (with tier)",
+      "description": "Monitors with the most outages in the last 24h. Useful for identifying flapping or degraded infrastructure.",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 8 },
+      "options": {
+        "sortBy": [{ "displayName": "Outage Count", "desc": true }],
+        "footer": { "show": false }
+      },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Tier" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "core":    { "text": "CORE",    "color": "red" } } },
+                  { "type": "value", "options": { "noncore": { "text": "noncore", "color": "blue" } } }
+                ]
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Total Downtime" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          }
+        ]
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Outage Count",
+              "Value #B": "Total Downtime",
+              "Value #C": "Tier"
+            },
+            "excludeByName": { "Time": true, "job": true, "period": true }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_outage_count{period=\"24h\"} > 0",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_downtime_seconds{period=\"24h\"} > 0",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_escalation_tier",
+          "instant": true,
+          "refId": "C"
+        }
+      ]
+    }
+  ],
+  "annotations": { "list": [] }
+}

--- a/deploy/grafana/dashboards/tenant-health.json
+++ b/deploy/grafana/dashboards/tenant-health.json
@@ -364,7 +364,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus" },
-          "expr": "hyperping_monitor_outage_count{period=\"30d\"}",
+          "expr": "hyperping_monitor_outages{period=\"30d\"}",
           "instant": true,
           "refId": "A"
         },

--- a/deploy/grafana/dashboards/tenant-health.json
+++ b/deploy/grafana/dashboards/tenant-health.json
@@ -1,0 +1,399 @@
+{
+  "title": "Hyperping Tenant Health",
+  "uid": "hyperping-tenant-health",
+  "description": "Per-tenant health score, SLA gauge, and all-tenants ranking for weekly review. Requires OPS-34.",
+  "tags": ["hyperping", "tenant", "sla"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "time": { "from": "now-7d", "to": "now" },
+  "timezone": "browser",
+  "graphTooltip": 1,
+  "editable": true,
+  "templating": {
+    "list": [
+      {
+        "name": "project_uuid",
+        "label": "Project (Tenant)",
+        "type": "query",
+        "datasource": { "type": "prometheus" },
+        "query": "label_values(hyperping_monitor_info, project_uuid)",
+        "refresh": 2,
+        "sort": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "gauge",
+      "title": "Tenant Health Score",
+      "description": "Composite 0–100 score: uptime (60%) + 30d avg SLA (40%) minus outage penalty.",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 8 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "yellow", "value": 80 },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_health_score",
+          "legendFormat": "Health Score",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Monitors Up Ratio",
+      "gridPos": { "x": 6, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.9 },
+              { "color": "yellow", "value": 0.95 },
+              { "color": "green", "value": 1.0 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_monitors_up_ratio",
+          "legendFormat": "Up Ratio"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Active Outages",
+      "gridPos": { "x": 10, "y": 0, "w": 4, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_active_outages",
+          "legendFormat": "Outages",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Avg SLA 30d",
+      "gridPos": { "x": 14, "y": 0, "w": 5, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.99 },
+              { "color": "yellow", "value": 0.999 },
+              { "color": "green", "value": 0.9999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_avg_sla_ratio{period=\"30d\"}",
+          "legendFormat": "30d SLA",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Avg SLA 7d",
+      "gridPos": { "x": 19, "y": 0, "w": 5, "h": 4 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.99 },
+              { "color": "yellow", "value": 0.999 },
+              { "color": "green", "value": 0.9999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_avg_sla_ratio{period=\"7d\"}",
+          "legendFormat": "7d SLA",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "SLA Trends",
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Health Score Over Time",
+      "gridPos": { "x": 0, "y": 9, "w": 12, "h": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "yellow", "value": 80 },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_health_score",
+          "legendFormat": "Health Score"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Monitors Up Ratio Over Time",
+      "gridPos": { "x": 12, "y": 9, "w": 12, "h": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "color": { "mode": "fixed", "fixedColor": "green" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_tenant_monitors_up_ratio",
+          "legendFormat": "Up Ratio"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Per-Monitor SLA Ranking",
+      "gridPos": { "x": 0, "y": 15, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 21,
+      "type": "bargauge",
+      "title": "Monitor SLA Ranking (30d)",
+      "description": "Monitors ranked by 30-day SLA. Red = below 99%, green = above 99.9%.",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 10 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "min": 0.9,
+          "max": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.95 },
+              { "color": "yellow", "value": 0.99 },
+              { "color": "green", "value": 0.999 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "sort_desc(hyperping_monitor_sla_ratio{period=\"30d\"})",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Downtime Details",
+      "gridPos": { "x": 0, "y": 26, "w": 24, "h": 1 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "table",
+      "title": "Monitor Downtime (30d)",
+      "gridPos": { "x": 0, "y": 27, "w": 24, "h": 8 },
+      "options": {
+        "sortBy": [{ "displayName": "Total Downtime", "desc": true }],
+        "footer": { "show": false }
+      },
+      "fieldConfig": {
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Total Downtime" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Longest Outage" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "MTTR" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "SLA" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 4 }
+            ]
+          }
+        ]
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "Outage Count",
+              "Value #B": "Total Downtime",
+              "Value #C": "Longest Outage",
+              "Value #D": "MTTR",
+              "Value #E": "SLA"
+            },
+            "excludeByName": { "Time": true, "job": true, "period": true }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_outage_count{period=\"30d\"}",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_downtime_seconds{period=\"30d\"}",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_longest_outage_seconds{period=\"30d\"}",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_mttr_seconds{period=\"30d\"}",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus" },
+          "expr": "hyperping_monitor_sla_ratio{period=\"30d\"}",
+          "instant": true,
+          "refId": "E"
+        }
+      ]
+    }
+  ],
+  "annotations": { "list": [] }
+}

--- a/deploy/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Hyperping
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: "60s"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hyperping-exporter
+  namespace: monitoring
+  labels:
+    app: hyperping-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hyperping-exporter
+  template:
+    metadata:
+      labels:
+        app: hyperping-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9312"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: hyperping-exporter
+          image: ghcr.io/develeap/hyperping-exporter:latest
+          args:
+            - "--cache-ttl=60s"
+            - "--log-format=json"
+          env:
+            - name: HYPERPING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hyperping-credentials
+                  key: api-key
+          ports:
+            - name: metrics
+              containerPort: 9312
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+      securityContext:
+        fsGroup: 65534
+      terminationGracePeriodSeconds: 15
+---
+# Secret template — apply with actual value:
+# kubectl create secret generic hyperping-credentials \
+#   --from-literal=api-key=<YOUR_KEY> -n monitoring
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hyperping-credentials
+  namespace: monitoring
+type: Opaque
+stringData:
+  api-key: "REPLACE_WITH_ACTUAL_KEY"

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hyperping-exporter
+  namespace: monitoring
+  labels:
+    app: hyperping-exporter
+spec:
+  selector:
+    app: hyperping-exporter
+  ports:
+    - name: metrics
+      port: 9312
+      targetPort: metrics
+      protocol: TCP
+  type: ClusterIP

--- a/deploy/k8s/servicemonitor.yaml
+++ b/deploy/k8s/servicemonitor.yaml
@@ -1,0 +1,25 @@
+# Prometheus Operator ServiceMonitor
+# Requires: kube-prometheus-stack or prometheus-operator installed
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hyperping-exporter
+  namespace: monitoring
+  labels:
+    app: hyperping-exporter
+    # Must match your Prometheus operator's serviceMonitorSelector labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: hyperping-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 60s      # Match the exporter's --cache-ttl
+      scrapeTimeout: 30s
+      honorLabels: false

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -14,14 +14,15 @@ groups:
 
       - alert: HyperpingMonitorActiveOutage
         expr: hyperping_monitor_outage_active == 1
-        for: 0m
+        for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Active outage on {{ $labels.name }}"
           description: >-
-            Monitor {{ $labels.name }} ({{ $labels.uuid }}) has an active unresolved outage.
-            Last HTTP status code: {{ query "hyperping_monitor_active_outage_status_code{uuid=\"{{ $labels.uuid }}\"}" | first | value }}.
+            Monitor {{ $labels.name }} ({{ $labels.uuid }}) has had an active unresolved outage
+            for at least 1 minute. Check hyperping_monitor_active_outage_status_code for the
+            HTTP status code.
 
       - alert: HyperpingMultipleActiveOutages
         expr: hyperping_tenant_active_outages > 3

--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -1,0 +1,174 @@
+groups:
+  - name: hyperping_monitor_availability
+    interval: 1m
+    rules:
+      - alert: HyperpingMonitorDown
+        expr: hyperping_monitor_up == 0 and hyperping_monitor_paused == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Monitor {{ $labels.name }} is DOWN"
+          description: "Monitor {{ $labels.name }} ({{ $labels.uuid }}) has been down for more than 2 minutes."
+          runbook: "https://wiki.internal/runbooks/hyperping-monitor-down"
+
+      - alert: HyperpingMonitorActiveOutage
+        expr: hyperping_monitor_outage_active == 1
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Active outage on {{ $labels.name }}"
+          description: >-
+            Monitor {{ $labels.name }} ({{ $labels.uuid }}) has an active unresolved outage.
+            Last HTTP status code: {{ query "hyperping_monitor_active_outage_status_code{uuid=\"{{ $labels.uuid }}\"}" | first | value }}.
+
+      - alert: HyperpingMultipleActiveOutages
+        expr: hyperping_tenant_active_outages > 3
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $value | humanize }} concurrent active outages"
+          description: >-
+            {{ $value }} monitors are currently experiencing active outages.
+            This may indicate a shared infrastructure issue. Check OPS-38 dashboard.
+
+      - alert: HyperpingCoreMonitorDown
+        # Requires OPS-39 tier label via metric join
+        expr: |
+          hyperping_monitor_up * on(uuid, name) group_left(tier)
+            hyperping_monitor_escalation_tier{tier="core"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          tier: core
+        annotations:
+          summary: "CORE monitor {{ $labels.name }} is DOWN"
+          description: "Core (escalated) monitor {{ $labels.name }} is down. Escalation policy should trigger."
+
+  - name: hyperping_monitor_ssl
+    interval: 1h
+    rules:
+      - alert: HyperpingSSLExpiryWarning
+        expr: hyperping_monitor_ssl_expiration_days < 14
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "SSL certificate for {{ $labels.name }} expires in {{ $value | humanize }} days"
+          description: >-
+            The SSL certificate for monitor {{ $labels.name }} ({{ $labels.uuid }})
+            expires in {{ $value | humanize }} days. Renew before it hits 7 days.
+
+      - alert: HyperpingSSLExpiryCritical
+        expr: hyperping_monitor_ssl_expiration_days < 3
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SSL certificate for {{ $labels.name }} expires in {{ $value | humanize }} days — URGENT"
+          description: >-
+            The SSL certificate for monitor {{ $labels.name }} expires in under 3 days.
+            Immediate renewal required.
+
+  - name: hyperping_sla
+    interval: 5m
+    rules:
+      - alert: HyperpingMonitorSLABreach24h
+        expr: hyperping_monitor_sla_ratio{period="24h"} < 0.99
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.name }} SLA below 99% over last 24h ({{ $value | humanizePercentage }})"
+          description: >-
+            Monitor {{ $labels.name }} 24-hour SLA is {{ $value | humanizePercentage }},
+            below the 99% threshold.
+
+      - alert: HyperpingMonitorSLABreach7d
+        expr: hyperping_monitor_sla_ratio{period="7d"} < 0.995
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.name }} 7-day SLA below 99.5% ({{ $value | humanizePercentage }})"
+          description: >-
+            Monitor {{ $labels.name }} 7-day SLA is {{ $value | humanizePercentage }},
+            below the 99.5% target.
+
+      - alert: HyperpingTenantSLADegraded
+        expr: hyperping_tenant_avg_sla_ratio{period="24h"} < 0.95
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Fleet-wide 24h average SLA below 95% ({{ $value | humanizePercentage }})"
+          description: >-
+            The average SLA across all monitors has dropped below 95% over the last 24 hours.
+            This may indicate a widespread infrastructure issue.
+
+  - name: hyperping_healthchecks
+    interval: 1m
+    rules:
+      - alert: HyperpingHealthcheckDown
+        expr: hyperping_healthcheck_up == 0 and hyperping_healthcheck_paused == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Healthcheck {{ $labels.name }} has not pinged"
+          description: >-
+            Healthcheck {{ $labels.name }} ({{ $labels.uuid }}) has not pinged within
+            its expected period for more than 5 minutes. Check if the associated cron job is running.
+
+  - name: hyperping_tenant_health
+    interval: 2m
+    rules:
+      - alert: HyperpingTenantHealthDegraded
+        expr: hyperping_tenant_health_score < 80
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Tenant health score degraded: {{ $value | humanize }}/100"
+          description: >-
+            The composite tenant health score has dropped to {{ $value | humanize }}.
+            Check the Fleet Overview dashboard for details.
+
+      - alert: HyperpingTenantHealthCritical
+        expr: hyperping_tenant_health_score < 60
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Tenant health score critical: {{ $value | humanize }}/100"
+          description: >-
+            The composite tenant health score has dropped to {{ $value | humanize }},
+            indicating severe service degradation.
+
+  - name: hyperping_exporter
+    interval: 1m
+    rules:
+      - alert: HyperpingExporterScrapeFailure
+        expr: hyperping_scrape_success == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Hyperping exporter cannot reach the API"
+          description: >-
+            The hyperping-exporter has failed to scrape the Hyperping API for 5+ minutes.
+            Metrics are stale. Check API key validity and network connectivity.
+
+      - alert: HyperpingDataStale
+        # OPS-35 watchdog: alert when data hasn't refreshed in 2× the cache TTL (default 120s)
+        expr: hyperping_data_age_seconds > 120
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Hyperping metrics data is stale ({{ $value | humanizeDuration }} old)"
+          description: >-
+            The hyperping-exporter cache has not been refreshed in {{ $value | humanizeDuration }}.
+            The exporter may be stalled. Restart if the issue persists.

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    cluster: hyperping-monitoring
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+  - /etc/prometheus/recording-rules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            # - alertmanager:9093
+
+scrape_configs:
+  - job_name: hyperping-exporter
+    scrape_interval: 60s   # Respect the exporter's 60s cache TTL
+    scrape_timeout: 30s
+    static_configs:
+      - targets:
+          - hyperping-exporter:9312
+    metric_relabel_configs:
+      # Drop high-cardinality Go runtime metrics not needed for dashboards.
+      - source_labels: [__name__]
+        regex: "go_gc_duration_seconds.*"
+        action: drop

--- a/deploy/prometheus/recording-rules.yml
+++ b/deploy/prometheus/recording-rules.yml
@@ -21,11 +21,11 @@ groups:
   - name: hyperping_tier
     interval: 1m
     rules:
-      # Per-tier availability — join monitor status with tier info.
-      - record: hyperping:tier:monitors_up
+      # Per-tier up-ratio: monitors UP divided by total monitors per tier.
+      - record: hyperping:tier:monitors_up_ratio
         expr: |
           count by (tier) (
-            hyperping_monitor_up * on(uuid, name) group_left(tier)
+            (hyperping_monitor_up == 1) * on(uuid, name) group_left(tier)
               hyperping_monitor_escalation_tier
           ) / count by (tier) (
             hyperping_monitor_up * on(uuid, name) group_left(tier)

--- a/deploy/prometheus/recording-rules.yml
+++ b/deploy/prometheus/recording-rules.yml
@@ -1,0 +1,70 @@
+groups:
+  - name: hyperping_fleet
+    interval: 1m
+    rules:
+      # Pre-aggregate fleet-wide counts for fast dashboard queries.
+      - record: hyperping:fleet:monitors_total
+        expr: count(hyperping_monitor_up)
+
+      - record: hyperping:fleet:monitors_up
+        expr: count(hyperping_monitor_up == 1)
+
+      - record: hyperping:fleet:monitors_down
+        expr: count(hyperping_monitor_up == 0 and hyperping_monitor_paused == 0)
+
+      - record: hyperping:fleet:monitors_paused
+        expr: count(hyperping_monitor_paused == 1)
+
+      - record: hyperping:fleet:active_outages
+        expr: hyperping_tenant_active_outages
+
+  - name: hyperping_tier
+    interval: 1m
+    rules:
+      # Per-tier availability — join monitor status with tier info.
+      - record: hyperping:tier:monitors_up
+        expr: |
+          count by (tier) (
+            hyperping_monitor_up * on(uuid, name) group_left(tier)
+              hyperping_monitor_escalation_tier
+          ) / count by (tier) (
+            hyperping_monitor_up * on(uuid, name) group_left(tier)
+              hyperping_monitor_escalation_tier
+          )
+
+      - record: hyperping:tier:avg_sla_30d
+        expr: |
+          avg by (tier) (
+            hyperping_monitor_sla_ratio{period="30d"} * on(uuid, name) group_left(tier)
+              hyperping_monitor_escalation_tier
+          )
+
+      - record: hyperping:tier:avg_sla_7d
+        expr: |
+          avg by (tier) (
+            hyperping_monitor_sla_ratio{period="7d"} * on(uuid, name) group_left(tier)
+              hyperping_monitor_escalation_tier
+          )
+
+  - name: hyperping_sla_aggregates
+    interval: 5m
+    rules:
+      # Average SLA per period across all monitors.
+      - record: hyperping:sla:avg_24h
+        expr: avg(hyperping_monitor_sla_ratio{period="24h"})
+
+      - record: hyperping:sla:avg_7d
+        expr: avg(hyperping_monitor_sla_ratio{period="7d"})
+
+      - record: hyperping:sla:avg_30d
+        expr: avg(hyperping_monitor_sla_ratio{period="30d"})
+
+      # Monitors breaching 99.9% SLA in each period.
+      - record: hyperping:sla:breach_count_24h
+        expr: count(hyperping_monitor_sla_ratio{period="24h"} < 0.999)
+
+      - record: hyperping:sla:breach_count_7d
+        expr: count(hyperping_monitor_sla_ratio{period="7d"} < 0.999)
+
+      - record: hyperping:sla:breach_count_30d
+        expr: count(hyperping_monitor_sla_ratio{period="30d"} < 0.999)


### PR DESCRIPTION
## Summary

Adds a full Prometheus metrics exporter and Grafana observability stack for users running Hyperping at scale. This covers OPS-31 through OPS-39 from the backlog.

- **13 new metrics** across 4 OPS tickets emitted by the existing `cmd/hyperping-exporter` binary
- **12 alerting rules** in `deploy/prometheus/alerts.yml`
- **6 recording rules** for pre-aggregation
- **3 Grafana dashboards** (fleet overview, tenant health, shared infrastructure)
- **Kubernetes manifests** with security context, resource limits, health probes, and Prometheus Operator `ServiceMonitor`
- **Docker Compose** stack for local dev (exporter + Prometheus + Grafana)

## New Metrics

### OPS-31 — Data Freshness (Watchdog)
| Metric | Description |
|--------|-------------|
| `hyperping_data_age_seconds` | Seconds since last successful cache refresh. Drives the `HyperpingDataStale` alert at 2×TTL (120s). |

### OPS-32/33 — Per-Monitor Outage + SLA
| Metric | Labels |
|--------|--------|
| `hyperping_monitor_outage_active` | `uuid, name` |
| `hyperping_monitor_active_outage_status_code` | `uuid, name` |
| `hyperping_monitor_sla_ratio` | `uuid, name, period` (24h/7d/30d) |
| `hyperping_monitor_outages` | `uuid, name, period` |
| `hyperping_monitor_downtime_seconds` | `uuid, name, period` |
| `hyperping_monitor_longest_outage_seconds` | `uuid, name, period` |
| `hyperping_monitor_mttr_seconds` | `uuid, name, period` (only when MTTR > 0) |

### OPS-34 — Tenant Health Score
| Metric | Description |
|--------|-------------|
| `hyperping_tenant_health_score` | 0–100 composite: `upRatio×60 + avgSLA×40 - activeRatio×30`, clamped |
| `hyperping_tenant_monitors_up_ratio` | Fraction of monitors currently up |
| `hyperping_tenant_active_outages` | Count of active unresolved outages |
| `hyperping_tenant_avg_sla_ratio` | Average SLA across all monitors, per period |

### OPS-39 — Escalation Tier Labels
| Metric | Description |
|--------|-------------|
| `hyperping_monitor_escalation_tier{tier="core"\|"noncore"}` | Always 1; `core` if `EscalationPolicy != nil`. Join with existing metrics via `* on(uuid,name) group_left(tier)` — no breaking changes to existing metric label sets. |

## Design Decisions

- **Outage/report fetch failures are non-fatal**: errors are logged at Warn, the scrape still succeeds using whatever cache is available.
- **Reports fetched in parallel**: 3 goroutines fan out simultaneously for 24h/7d/30d periods.
- **`hyperping_monitor_outages`** (not `_count`): `_count` suffix is reserved by Prometheus for histogram/summary families — `testutil.CollectAndLint` enforces this.
- **`data_age_seconds` emitted after failed scrapes**: `lastSuccessTime` is preserved from the last successful refresh, so staleness alerting works even across API outages.
- **Tier info metric pattern**: rather than adding `tier` to existing per-monitor metrics (breaking change), a separate info metric is used for label joins.

## Deploy Stack

```
deploy/
├── docker-compose.yml              # Local dev: exporter + prometheus + grafana
├── prometheus/
│   ├── alerts.yml                  # 12 alerting rules
│   ├── recording-rules.yml         # 6 pre-aggregation rules
│   └── prometheus.yml              # Scrape config (60s interval)
├── grafana/
│   ├── dashboards/
│   │   ├── fleet-overview.json     # OPS-36: fleet status, SLA by tier
│   │   ├── tenant-health.json      # OPS-37: health score, MTTR, SLA ranking
│   │   └── shared-infrastructure.json  # OPS-38: error codes, core vs noncore
│   └── provisioning/               # Auto-load on Grafana startup
└── k8s/
    ├── deployment.yaml             # Non-root, read-only rootfs, resource limits
    ├── service.yaml                # ClusterIP on port 9312
    └── servicemonitor.yaml         # Prometheus Operator scrape config
```

## Test Plan

- [x] `go build ./cmd/hyperping-exporter/` — passes
- [x] `go test ./cmd/hyperping-exporter/ -v` — all 25 descriptors + all new metric helpers covered
- [x] `make lint` — 0 issues (golangci-lint)
- [x] `testutil.CollectAndLint` — no reserved suffix warnings
- [x] Pre-push hook: vet + govulncheck + build + lint + full test suite — all pass