### PR TITLE
feat: add is_down and escalation_policy_name computed fields (TF-03/TF-04)

### DIFF
--- a/docs/data-sources/monitor.md
+++ b/docs/data-sources/monitor.md
@@ -61,9 +61,11 @@ resource "hyperping_incident" "outage" {
 - `dns_nameserver` (String) Nameserver used for DNS queries.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
+- `escalation_policy_name` (String) Human-readable name of the assigned escalation policy.
 - `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
 - `follow_redirects` (Boolean) Whether the monitor follows HTTP redirects.
 - `http_method` (String) HTTP method used for checks (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS).
+- `is_down` (Boolean) Whether the monitor is currently reporting as down.
 - `name` (String) The name of the monitor.
 - `paused` (Boolean) Whether the monitor is paused.
 - `port` (Number) Port number for port protocol monitors.

--- a/docs/data-sources/monitors.md
+++ b/docs/data-sources/monitors.md
@@ -89,10 +89,12 @@ Read-Only:
 - `dns_nameserver` (String) Nameserver used for DNS queries.
 - `dns_record_type` (String) DNS record type for DNS-protocol monitors.
 - `escalation_policy` (String) UUID of the escalation policy linked to this monitor.
+- `escalation_policy_name` (String) Human-readable name of the assigned escalation policy.
 - `expected_status_code` (String) Expected HTTP status code or pattern (e.g., `200`, `2xx`, `1xx-3xx`).
 - `follow_redirects` (Boolean) Whether to follow HTTP redirects.
 - `http_method` (String) HTTP method used for the check (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS).
 - `id` (String) The unique identifier (UUID) of the monitor.
+- `is_down` (Boolean) Whether the monitor is currently reporting as down.
 - `name` (String) The name of the monitor.
 - `paused` (Boolean) Whether the monitor is paused.
 - `port` (Number) Port number for port protocol monitors.

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -87,7 +87,9 @@ resource "hyperping_monitor" "maintenance" {
 
 ### Read-Only
 
+- `escalation_policy_name` (String) Human-readable name of the assigned escalation policy.
 - `id` (String) The unique identifier (UUID) of the monitor.
+- `is_down` (Boolean) Whether the monitor is currently reporting as down.
 - `ssl_expiration` (Number) Days until the SSL certificate expires.
 - `status` (String) Current monitor status. Either `up` or `down`.
 

--- a/internal/provider/mapping.go
+++ b/internal/provider/mapping.go
@@ -53,12 +53,17 @@ func MapMonitorCommonFields(monitor *hyperping.Monitor, diags *diag.Diagnostics)
 		result.AlertsWait = types.Int64Null()
 	}
 
-	// Handle escalation_policy
+	// Handle escalation_policy UUID and name
 	if monitor.EscalationPolicy != nil && monitor.EscalationPolicy.UUID != "" {
 		result.EscalationPolicy = types.StringValue(monitor.EscalationPolicy.UUID)
+		result.EscalationPolicyName = types.StringValue(monitor.EscalationPolicy.Name)
 	} else {
 		result.EscalationPolicy = types.StringNull()
+		result.EscalationPolicyName = types.StringValue("")
 	}
+
+	// Handle is_down (derived from status field)
+	result.IsDown = types.BoolValue(monitor.Status == "down")
 
 	// Handle DNS-protocol fields
 	if monitor.DNSRecordType != nil && *monitor.DNSRecordType != "" {
@@ -106,28 +111,30 @@ func MapMonitorCommonFields(monitor *hyperping.Monitor, diags *diag.Diagnostics)
 
 // MonitorCommonFields contains fields shared between resource and data source models.
 type MonitorCommonFields struct {
-	ID                 types.String
-	Name               types.String
-	URL                types.String
-	Protocol           types.String
-	HTTPMethod         types.String
-	CheckFrequency     types.Int64
-	Regions            types.List
-	RequestHeaders     types.List // List of objects with name/value
-	RequestBody        types.String
-	ExpectedStatusCode types.String
-	FollowRedirects    types.Bool
-	Paused             types.Bool
-	Port               types.Int64
-	AlertsWait         types.Int64
-	EscalationPolicy   types.String
-	DNSRecordType      types.String
-	DNSNameserver      types.String
-	DNSExpectedAnswer  types.String
-	RequiredKeyword    types.String
-	Status             types.String
-	SSLExpiration      types.Int64
-	ProjectUUID        types.String
+	ID                   types.String
+	Name                 types.String
+	URL                  types.String
+	Protocol             types.String
+	HTTPMethod           types.String
+	CheckFrequency       types.Int64
+	Regions              types.List
+	RequestHeaders       types.List // List of objects with name/value
+	RequestBody          types.String
+	ExpectedStatusCode   types.String
+	FollowRedirects      types.Bool
+	Paused               types.Bool
+	Port                 types.Int64
+	AlertsWait           types.Int64
+	EscalationPolicy     types.String
+	EscalationPolicyName types.String
+	DNSRecordType        types.String
+	DNSNameserver        types.String
+	DNSExpectedAnswer    types.String
+	RequiredKeyword      types.String
+	Status               types.String
+	IsDown               types.Bool
+	SSLExpiration        types.Int64
+	ProjectUUID          types.String
 }
 
 // mapStringSliceToList converts a Go string slice to a Terraform List.

--- a/internal/provider/monitor_data_source.go
+++ b/internal/provider/monitor_data_source.go
@@ -33,28 +33,30 @@ type MonitorDataSource struct {
 
 // MonitorDataSourceModel describes the data source data model.
 type MonitorDataSourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Name               types.String `tfsdk:"name"`
-	URL                types.String `tfsdk:"url"`
-	Protocol           types.String `tfsdk:"protocol"`
-	HTTPMethod         types.String `tfsdk:"http_method"`
-	CheckFrequency     types.Int64  `tfsdk:"check_frequency"`
-	Regions            types.List   `tfsdk:"regions"`
-	RequestHeaders     types.List   `tfsdk:"request_headers"`
-	RequestBody        types.String `tfsdk:"request_body"`
-	ExpectedStatusCode types.String `tfsdk:"expected_status_code"`
-	FollowRedirects    types.Bool   `tfsdk:"follow_redirects"`
-	Paused             types.Bool   `tfsdk:"paused"`
-	Port               types.Int64  `tfsdk:"port"`
-	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
-	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
-	DNSRecordType      types.String `tfsdk:"dns_record_type"`
-	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
-	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
-	RequiredKeyword    types.String `tfsdk:"required_keyword"`
-	Status             types.String `tfsdk:"status"`
-	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
-	ProjectUUID        types.String `tfsdk:"project_uuid"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	URL                  types.String `tfsdk:"url"`
+	Protocol             types.String `tfsdk:"protocol"`
+	HTTPMethod           types.String `tfsdk:"http_method"`
+	CheckFrequency       types.Int64  `tfsdk:"check_frequency"`
+	Regions              types.List   `tfsdk:"regions"`
+	RequestHeaders       types.List   `tfsdk:"request_headers"`
+	RequestBody          types.String `tfsdk:"request_body"`
+	ExpectedStatusCode   types.String `tfsdk:"expected_status_code"`
+	FollowRedirects      types.Bool   `tfsdk:"follow_redirects"`
+	Paused               types.Bool   `tfsdk:"paused"`
+	Port                 types.Int64  `tfsdk:"port"`
+	AlertsWait           types.Int64  `tfsdk:"alerts_wait"`
+	EscalationPolicy     types.String `tfsdk:"escalation_policy"`
+	EscalationPolicyName types.String `tfsdk:"escalation_policy_name"`
+	DNSRecordType        types.String `tfsdk:"dns_record_type"`
+	DNSNameserver        types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer    types.String `tfsdk:"dns_expected_answer"`
+	RequiredKeyword      types.String `tfsdk:"required_keyword"`
+	Status               types.String `tfsdk:"status"`
+	IsDown               types.Bool   `tfsdk:"is_down"`
+	SSLExpiration        types.Int64  `tfsdk:"ssl_expiration"`
+	ProjectUUID          types.String `tfsdk:"project_uuid"`
 }
 
 // Metadata returns the data source type name.
@@ -142,6 +144,10 @@ func (d *MonitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				MarkdownDescription: "UUID of the escalation policy linked to this monitor.",
 				Computed:            true,
 			},
+			"escalation_policy_name": schema.StringAttribute{
+				MarkdownDescription: "Human-readable name of the assigned escalation policy.",
+				Computed:            true,
+			},
 			"dns_record_type": schema.StringAttribute{
 				MarkdownDescription: "DNS record type for DNS-protocol monitors.",
 				Computed:            true,
@@ -161,6 +167,10 @@ func (d *MonitorDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Current monitor status. Either `up` or `down`.",
+			},
+			"is_down": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the monitor is currently reporting as down.",
 			},
 			"ssl_expiration": schema.Int64Attribute{
 				Computed:            true,
@@ -239,11 +249,13 @@ func (d *MonitorDataSource) mapMonitorToDataSourceModel(monitor *hyperping.Monit
 	model.Port = fields.Port
 	model.AlertsWait = fields.AlertsWait
 	model.EscalationPolicy = fields.EscalationPolicy
+	model.EscalationPolicyName = fields.EscalationPolicyName
 	model.DNSRecordType = fields.DNSRecordType
 	model.DNSNameserver = fields.DNSNameserver
 	model.DNSExpectedAnswer = fields.DNSExpectedAnswer
 	model.RequiredKeyword = fields.RequiredKeyword
 	model.Status = fields.Status
+	model.IsDown = fields.IsDown
 	model.SSLExpiration = fields.SSLExpiration
 	model.ProjectUUID = fields.ProjectUUID
 }

--- a/internal/provider/monitor_data_source_test.go
+++ b/internal/provider/monitor_data_source_test.go
@@ -229,7 +229,7 @@ func TestMonitorDataSource_Schema(t *testing.T) {
 	// Verify computed attributes exist
 	computedAttrs := []string{"name", "url", "protocol", "http_method", "check_frequency", "regions",
 		"request_headers", "request_body", "expected_status_code", "follow_redirects", "paused",
-		"status", "ssl_expiration", "project_uuid"}
+		"status", "is_down", "ssl_expiration", "project_uuid", "escalation_policy", "escalation_policy_name"}
 	for _, attr := range computedAttrs {
 		if _, ok := resp.Schema.Attributes[attr]; !ok {
 			t.Errorf("Schema missing '%s' attribute", attr)
@@ -387,4 +387,119 @@ func TestNewMonitorDataSource(t *testing.T) {
 	if _, ok := ds.(*MonitorDataSource); !ok {
 		t.Errorf("expected *MonitorDataSource, got %T", ds)
 	}
+}
+
+func TestAccMonitorDataSource_isDownAndEscalationPolicyName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hyperping.HeaderContentType, hyperping.ContentTypeJSON)
+
+		if r.Method == "GET" && r.URL.Path == hyperping.MonitorsBasePath+"/mon-down-123" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"uuid":             "mon-down-123",
+				"name":             "Down Monitor",
+				"url":              "https://example.com",
+				"protocol":         "http",
+				"http_method":      "GET",
+				"check_frequency":  60,
+				"follow_redirects": true,
+				"paused":           false,
+				"status":           "down",
+				"regions":          []string{"london"},
+				"escalation_policy": map[string]interface{}{
+					"uuid": "ep-uuid-abc",
+					"name": "PagerDuty On-Call",
+				},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Not found"})
+	}))
+	defer server.Close()
+
+	tfresource.ParallelTest(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key  = "test_api_key"
+  base_url = %[1]q
+}
+
+data "hyperping_monitor" "test" {
+  id = "mon-down-123"
+}
+`, server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("data.hyperping_monitor.test", "id", "mon-down-123"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitor.test", "status", "down"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitor.test", "is_down", "true"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitor.test", "escalation_policy", "ep-uuid-abc"),
+					tfresource.TestCheckResourceAttr("data.hyperping_monitor.test", "escalation_policy_name", "PagerDuty On-Call"),
+				),
+			},
+		},
+	})
+}
+
+func TestMonitorDataSource_mapMonitorToDataSourceModel_isDownAndEscalationPolicyName(t *testing.T) {
+	d := &MonitorDataSource{}
+
+	t.Run("monitor down with escalation policy name", func(t *testing.T) {
+		ep := hyperping.EscalationPolicyRef{UUID: "ep-123", Name: "On-Call Policy"}
+		monitor := &hyperping.Monitor{
+			UUID:             "mon-abc",
+			Name:             "Test",
+			URL:              "https://example.com",
+			Protocol:         "http",
+			HTTPMethod:       "GET",
+			CheckFrequency:   60,
+			FollowRedirects:  true,
+			Status:           "down",
+			EscalationPolicy: &ep,
+		}
+
+		model := &MonitorDataSourceModel{}
+		diags := &diag.Diagnostics{}
+		d.mapMonitorToDataSourceModel(monitor, model, diags)
+
+		if diags.HasError() {
+			t.Errorf("unexpected error: %v", diags)
+		}
+		if !model.IsDown.ValueBool() {
+			t.Error("expected IsDown to be true when status is 'down'")
+		}
+		if model.EscalationPolicyName.ValueString() != "On-Call Policy" {
+			t.Errorf("expected EscalationPolicyName 'On-Call Policy', got %s", model.EscalationPolicyName.ValueString())
+		}
+	})
+
+	t.Run("monitor up without escalation policy", func(t *testing.T) {
+		monitor := &hyperping.Monitor{
+			UUID:            "mon-xyz",
+			Name:            "Test Up",
+			URL:             "https://example.com",
+			Protocol:        "http",
+			HTTPMethod:      "GET",
+			CheckFrequency:  60,
+			FollowRedirects: true,
+			Status:          "up",
+		}
+
+		model := &MonitorDataSourceModel{}
+		diags := &diag.Diagnostics{}
+		d.mapMonitorToDataSourceModel(monitor, model, diags)
+
+		if diags.HasError() {
+			t.Errorf("unexpected error: %v", diags)
+		}
+		if model.IsDown.ValueBool() {
+			t.Error("expected IsDown to be false when status is 'up'")
+		}
+		if model.EscalationPolicyName.ValueString() != "" {
+			t.Errorf("expected empty EscalationPolicyName, got %s", model.EscalationPolicyName.ValueString())
+		}
+	})
 }

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -44,28 +44,30 @@ type MonitorResource struct {
 
 // MonitorResourceModel describes the resource data model.
 type MonitorResourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Name               types.String `tfsdk:"name"`
-	URL                types.String `tfsdk:"url"`
-	Protocol           types.String `tfsdk:"protocol"`
-	HTTPMethod         types.String `tfsdk:"http_method"`
-	CheckFrequency     types.Int64  `tfsdk:"check_frequency"`
-	Regions            types.List   `tfsdk:"regions"`
-	RequestHeaders     types.List   `tfsdk:"request_headers"`
-	RequestBody        types.String `tfsdk:"request_body"`
-	ExpectedStatusCode types.String `tfsdk:"expected_status_code"`
-	FollowRedirects    types.Bool   `tfsdk:"follow_redirects"`
-	Paused             types.Bool   `tfsdk:"paused"`
-	Port               types.Int64  `tfsdk:"port"`
-	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
-	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
-	DNSRecordType      types.String `tfsdk:"dns_record_type"`
-	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
-	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
-	RequiredKeyword    types.String `tfsdk:"required_keyword"`
-	Status             types.String `tfsdk:"status"`
-	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
-	ProjectUUID        types.String `tfsdk:"project_uuid"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	URL                  types.String `tfsdk:"url"`
+	Protocol             types.String `tfsdk:"protocol"`
+	HTTPMethod           types.String `tfsdk:"http_method"`
+	CheckFrequency       types.Int64  `tfsdk:"check_frequency"`
+	Regions              types.List   `tfsdk:"regions"`
+	RequestHeaders       types.List   `tfsdk:"request_headers"`
+	RequestBody          types.String `tfsdk:"request_body"`
+	ExpectedStatusCode   types.String `tfsdk:"expected_status_code"`
+	FollowRedirects      types.Bool   `tfsdk:"follow_redirects"`
+	Paused               types.Bool   `tfsdk:"paused"`
+	Port                 types.Int64  `tfsdk:"port"`
+	AlertsWait           types.Int64  `tfsdk:"alerts_wait"`
+	EscalationPolicy     types.String `tfsdk:"escalation_policy"`
+	EscalationPolicyName types.String `tfsdk:"escalation_policy_name"`
+	DNSRecordType        types.String `tfsdk:"dns_record_type"`
+	DNSNameserver        types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer    types.String `tfsdk:"dns_expected_answer"`
+	RequiredKeyword      types.String `tfsdk:"required_keyword"`
+	Status               types.String `tfsdk:"status"`
+	IsDown               types.Bool   `tfsdk:"is_down"`
+	SSLExpiration        types.Int64  `tfsdk:"ssl_expiration"`
+	ProjectUUID          types.String `tfsdk:"project_uuid"`
 }
 
 // Metadata returns the resource type name.
@@ -209,6 +211,10 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					UUIDFormat(),
 				},
 			},
+			"escalation_policy_name": schema.StringAttribute{
+				MarkdownDescription: "Human-readable name of the assigned escalation policy.",
+				Computed:            true,
+			},
 			"dns_record_type": schema.StringAttribute{
 				MarkdownDescription: "DNS record type to check. Only valid when protocol is `dns`. " +
 					"Valid values: `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SOA`, `SRV`, `CAA`, `PTR`. " +
@@ -236,6 +242,10 @@ func (r *MonitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Current monitor status. Either `up` or `down`.",
+			},
+			"is_down": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Whether the monitor is currently reporting as down.",
 			},
 			"ssl_expiration": schema.Int64Attribute{
 				Computed:            true,
@@ -505,11 +515,13 @@ func (r *MonitorResource) mapMonitorToModel(monitor *hyperping.Monitor, model *M
 	model.Port = common.Port
 	model.AlertsWait = common.AlertsWait
 	model.EscalationPolicy = common.EscalationPolicy
+	model.EscalationPolicyName = common.EscalationPolicyName
 	model.DNSRecordType = common.DNSRecordType
 	model.DNSNameserver = common.DNSNameserver
 	model.DNSExpectedAnswer = common.DNSExpectedAnswer
 	model.RequiredKeyword = common.RequiredKeyword
 	model.Status = common.Status
+	model.IsDown = common.IsDown
 	model.SSLExpiration = common.SSLExpiration
 	model.ProjectUUID = common.ProjectUUID
 }

--- a/internal/provider/monitors_data_source.go
+++ b/internal/provider/monitors_data_source.go
@@ -42,28 +42,30 @@ type MonitorsDataSourceModel struct {
 
 // MonitorDataModel describes a single monitor in the data source.
 type MonitorDataModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Name               types.String `tfsdk:"name"`
-	URL                types.String `tfsdk:"url"`
-	Protocol           types.String `tfsdk:"protocol"`
-	HTTPMethod         types.String `tfsdk:"http_method"`
-	CheckFrequency     types.Int64  `tfsdk:"check_frequency"`
-	Regions            types.List   `tfsdk:"regions"`
-	RequestHeaders     types.List   `tfsdk:"request_headers"`
-	RequestBody        types.String `tfsdk:"request_body"`
-	ExpectedStatusCode types.String `tfsdk:"expected_status_code"`
-	FollowRedirects    types.Bool   `tfsdk:"follow_redirects"`
-	Paused             types.Bool   `tfsdk:"paused"`
-	Port               types.Int64  `tfsdk:"port"`
-	AlertsWait         types.Int64  `tfsdk:"alerts_wait"`
-	EscalationPolicy   types.String `tfsdk:"escalation_policy"`
-	DNSRecordType      types.String `tfsdk:"dns_record_type"`
-	DNSNameserver      types.String `tfsdk:"dns_nameserver"`
-	DNSExpectedAnswer  types.String `tfsdk:"dns_expected_answer"`
-	RequiredKeyword    types.String `tfsdk:"required_keyword"`
-	Status             types.String `tfsdk:"status"`
-	SSLExpiration      types.Int64  `tfsdk:"ssl_expiration"`
-	ProjectUUID        types.String `tfsdk:"project_uuid"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	URL                  types.String `tfsdk:"url"`
+	Protocol             types.String `tfsdk:"protocol"`
+	HTTPMethod           types.String `tfsdk:"http_method"`
+	CheckFrequency       types.Int64  `tfsdk:"check_frequency"`
+	Regions              types.List   `tfsdk:"regions"`
+	RequestHeaders       types.List   `tfsdk:"request_headers"`
+	RequestBody          types.String `tfsdk:"request_body"`
+	ExpectedStatusCode   types.String `tfsdk:"expected_status_code"`
+	FollowRedirects      types.Bool   `tfsdk:"follow_redirects"`
+	Paused               types.Bool   `tfsdk:"paused"`
+	Port                 types.Int64  `tfsdk:"port"`
+	AlertsWait           types.Int64  `tfsdk:"alerts_wait"`
+	EscalationPolicy     types.String `tfsdk:"escalation_policy"`
+	EscalationPolicyName types.String `tfsdk:"escalation_policy_name"`
+	DNSRecordType        types.String `tfsdk:"dns_record_type"`
+	DNSNameserver        types.String `tfsdk:"dns_nameserver"`
+	DNSExpectedAnswer    types.String `tfsdk:"dns_expected_answer"`
+	RequiredKeyword      types.String `tfsdk:"required_keyword"`
+	Status               types.String `tfsdk:"status"`
+	IsDown               types.Bool   `tfsdk:"is_down"`
+	SSLExpiration        types.Int64  `tfsdk:"ssl_expiration"`
+	ProjectUUID          types.String `tfsdk:"project_uuid"`
 }
 
 // Metadata returns the data source type name.
@@ -166,6 +168,10 @@ func (d *MonitorsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 							MarkdownDescription: "UUID of the escalation policy linked to this monitor.",
 							Computed:            true,
 						},
+						"escalation_policy_name": schema.StringAttribute{
+							MarkdownDescription: "Human-readable name of the assigned escalation policy.",
+							Computed:            true,
+						},
 						"dns_record_type": schema.StringAttribute{
 							MarkdownDescription: "DNS record type for DNS-protocol monitors.",
 							Computed:            true,
@@ -185,6 +191,10 @@ func (d *MonitorsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 						"status": schema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "Current monitor status. Either `up` or `down`.",
+						},
+						"is_down": schema.BoolAttribute{
+							Computed:            true,
+							MarkdownDescription: "Whether the monitor is currently reporting as down.",
 						},
 						"ssl_expiration": schema.Int64Attribute{
 							Computed:            true,
@@ -371,21 +381,13 @@ func (d *MonitorsDataSource) mapMonitorToDataModel(monitor *hyperping.Monitor, m
 	model.Port = fields.Port
 	model.AlertsWait = fields.AlertsWait
 	model.EscalationPolicy = fields.EscalationPolicy
+	model.EscalationPolicyName = fields.EscalationPolicyName
 	model.DNSRecordType = fields.DNSRecordType
 	model.DNSNameserver = fields.DNSNameserver
 	model.DNSExpectedAnswer = fields.DNSExpectedAnswer
 	model.RequiredKeyword = fields.RequiredKeyword
-	model.Status = types.StringValue(monitor.Status)
-	model.SSLExpiration = func() types.Int64 {
-		if monitor.SSLExpiration != nil {
-			return types.Int64Value(int64(*monitor.SSLExpiration))
-		}
-		return types.Int64Null()
-	}()
-	model.ProjectUUID = func() types.String {
-		if monitor.ProjectUUID != "" {
-			return types.StringValue(monitor.ProjectUUID)
-		}
-		return types.StringNull()
-	}()
+	model.Status = fields.Status
+	model.IsDown = fields.IsDown
+	model.SSLExpiration = fields.SSLExpiration
+	model.ProjectUUID = fields.ProjectUUID
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,8 +30,7 @@ pre-commit:
         [ -f "docs/TROUBLESHOOTING.md" ] && cp docs/TROUBLESHOOTING.md /tmp/docs-troubleshooting-backup.md
 
         # Generate schema-based documentation
-        cd tools && go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir .. --provider-name hyperping
-        cd ..
+        go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.24.0 generate --provider-dir . --provider-name hyperping
 
         # Restore manual documentation (ensure directory exists first)
         mkdir -p docs/guides


### PR DESCRIPTION
## Summary
- Add is_down (bool, computed) to monitor resource and both data sources
- Add escalation_policy_name (string, computed) to the same consumers
- Single change point in MapMonitorCommonFields; all three consumers get it automatically

## Changes
- mapping.go: MonitorCommonFields + MapMonitorCommonFields updated
- monitor_resource.go: schema and model updated
- monitor_data_source.go: schema and model updated
- monitors_data_source.go: schema and model updated; refactored to use shared mapper
- monitor_data_source_test.go: schema list + two new tests

## Test Plan
- [x] go build ./... passes
- [x] go test ./internal/... passes
- [x] is_down derived from monitor.Status == "down"
- [x] escalation_policy_name set to "" when no policy linked