### PR TITLE
fix: resolve audit findings in provider resource logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/develeap/terraform-provider-hyperping
 
 go 1.26.2
 
+replace github.com/develeap/hyperping-go => ../hyperping-go
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.2.0
+	github.com/develeap/hyperping-go v0.2.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf
+	github.com/develeap/hyperping-go v0.2.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module github.com/develeap/terraform-provider-hyperping
 
 go 1.26.2
 
-replace github.com/develeap/hyperping-go => ../hyperping-go
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.1.0
+	github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -31,14 +31,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/develeap/hyperping-go v0.1.0 h1:Fmc53loTK7Sx3WoOwjfpjCaO6sER8+WwaO/66J/f56Q=
-github.com/develeap/hyperping-go v0.1.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
-github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf h1:7efnIXUdSIWu5Ljgk+LXyqPVU1w7fqKeCDaqHga2IJw=
-github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
-github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034 h1:ri18YXA5J6wRgWDOfGcD1p2JeqfYLSEr3JEL7ReD+Mk=
-github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
-github.com/develeap/hyperping-go v0.2.0 h1:ytFQeiYyDfxeMnY6q4s3NH+3Oe2uaUUKgtWW5V2T3bE=
-github.com/develeap/hyperping-go v0.2.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/develeap/hyperping-go v0.2.1 h1:k9RiUDvuOLnlAaTZ0q52DndycQaQG7LS9gUkHtA4kuU=
 github.com/develeap/hyperping-go v0.2.1/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034 h1:ri18YXA
 github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/develeap/hyperping-go v0.2.0 h1:ytFQeiYyDfxeMnY6q4s3NH+3Oe2uaUUKgtWW5V2T3bE=
 github.com/develeap/hyperping-go v0.2.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
+github.com/develeap/hyperping-go v0.2.1 h1:k9RiUDvuOLnlAaTZ0q52DndycQaQG7LS9gUkHtA4kuU=
+github.com/develeap/hyperping-go v0.2.1/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/develeap/hyperping-go v0.1.0 h1:Fmc53loTK7Sx3WoOwjfpjCaO6sER8+WwaO/66J/f56Q=
 github.com/develeap/hyperping-go v0.1.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
+github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf h1:7efnIXUdSIWu5Ljgk+LXyqPVU1w7fqKeCDaqHga2IJw=
+github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/develeap/hyperping-go v0.1.0 h1:Fmc53loTK7Sx3WoOwjfpjCaO6sER8+WwaO/66
 github.com/develeap/hyperping-go v0.1.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf h1:7efnIXUdSIWu5Ljgk+LXyqPVU1w7fqKeCDaqHga2IJw=
 github.com/develeap/hyperping-go v0.1.1-0.20260417004258-c681afebd3cf/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
+github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034 h1:ri18YXA5J6wRgWDOfGcD1p2JeqfYLSEr3JEL7ReD+Mk=
+github.com/develeap/hyperping-go v0.1.1-0.20260417005919-90c967a99034/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
+github.com/develeap/hyperping-go v0.2.0 h1:ytFQeiYyDfxeMnY6q4s3NH+3Oe2uaUUKgtWW5V2T3bE=
+github.com/develeap/hyperping-go v0.2.0/go.mod h1:Bn2xZkTmyU/eMjTMK6+cdnDQImgKv5849m1Mx+tX7Q4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/provider/incident_resource.go
+++ b/internal/provider/incident_resource.go
@@ -322,12 +322,13 @@ func (r *IncidentResource) mapIncidentToModel(incident *hyperping.Incident, mode
 	// The API accepts text during CREATE/UPDATE but may not return it in GET responses.
 	// If API returns it (non-empty), use that value; otherwise preserve the prior
 	// state value so that subsequent Reads do not lose the configured text.
-	if incident.Text.En != "" {
+	switch {
+	case incident.Text.En != "":
 		model.Text = types.StringValue(incident.Text.En)
-	} else if !model.Text.IsNull() && model.Text.ValueString() != "" {
+	case !model.Text.IsNull() && model.Text.ValueString() != "":
 		// API returned empty text but the model (prior state) has a value set.
 		// Preserve it to prevent state drift when the API omits the field.
-	} else {
+	default:
 		model.Text = types.StringValue("")
 	}
 

--- a/internal/provider/incident_resource.go
+++ b/internal/provider/incident_resource.go
@@ -251,6 +251,12 @@ func (r *IncidentResource) Update(ctx context.Context, req resource.UpdateReques
 		}
 	}
 
+	// Handle text
+	if !plan.Text.Equal(state.Text) {
+		text := hyperping.LocalizedText{En: plan.Text.ValueString()}
+		updateReq.Text = &text
+	}
+
 	// Handle status_pages
 	if !plan.StatusPages.Equal(state.StatusPages) {
 		var statusPages []string
@@ -313,13 +319,17 @@ func (r *IncidentResource) mapIncidentToModel(incident *hyperping.Incident, mode
 	model.Title = types.StringValue(incident.Title.En)
 
 	// NOTE: Text field behavior - Hyperping API quirk
-	// The API accepts text during CREATE/UPDATE but may not return it in GET responses
-	// If API returns it (non-empty), use that value; otherwise preserve plan value
+	// The API accepts text during CREATE/UPDATE but may not return it in GET responses.
+	// If API returns it (non-empty), use that value; otherwise preserve the prior
+	// state value so that subsequent Reads do not lose the configured text.
 	if incident.Text.En != "" {
 		model.Text = types.StringValue(incident.Text.En)
+	} else if !model.Text.IsNull() && model.Text.ValueString() != "" {
+		// API returned empty text but the model (prior state) has a value set.
+		// Preserve it to prevent state drift when the API omits the field.
+	} else {
+		model.Text = types.StringValue("")
 	}
-	// If empty and model.Text is already set (from plan), keep the existing value
-	// This prevents state drift when API doesn't return the field
 
 	model.Type = types.StringValue(incident.Type)
 

--- a/internal/provider/incident_resource_test.go
+++ b/internal/provider/incident_resource_test.go
@@ -56,6 +56,13 @@ func TestAccIncidentResource_basic(t *testing.T) {
 	})
 }
 
+// TODO: Add acceptance test for incident text field updates.
+// The Update function now sends text changes to the API, but there is no test
+// that changes the text value between steps and verifies the updated value
+// is reflected in state. This should follow the same pattern as
+// TestAccIncidentResource_basic (multi-step with a title change), but vary
+// the text field instead.
+
 func TestAccIncidentResource_full(t *testing.T) {
 	server := newMockIncidentServer(t)
 	defer server.Close()

--- a/internal/provider/maintenance_resource.go
+++ b/internal/provider/maintenance_resource.go
@@ -282,6 +282,9 @@ func buildMaintenanceUpdateRequest(ctx context.Context, plan *MaintenanceResourc
 	}
 
 	if !plan.Text.Equal(state.Text) {
+		// When text is cleared (set to null), ValueString() returns "" and the API
+		// receives {"en":""}. This is the correct behavior for this API: sending an
+		// empty string clears the text field on the Hyperping side.
 		text := hyperping.LocalizedText{En: plan.Text.ValueString()}
 		updateReq.Text = &text
 	}

--- a/internal/provider/monitor_resource.go
+++ b/internal/provider/monitor_resource.go
@@ -702,7 +702,10 @@ func applyMonitoringFieldChanges(ctx context.Context, plan *MonitorResourceModel
 	}
 
 	// Handle escalation_policy
-	// API docs: send UUID to link, "none" to unlink. Empty string "" is rejected.
+	// The Hyperping API uses a magic value "none" as the canonical way to unlink
+	// (disassociate) an escalation policy from a monitor. Sending a valid UUID
+	// links that policy; sending "none" removes any existing link. The API
+	// rejects an empty string "", so "none" is the only supported unlink value.
 	if !plan.EscalationPolicy.Equal(state.EscalationPolicy) {
 		if plan.EscalationPolicy.IsNull() {
 			none := "none"

--- a/internal/provider/outage_resource.go
+++ b/internal/provider/outage_resource.go
@@ -280,12 +280,16 @@ func (r *OutageResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Read back full state
 	outage, err := r.client.GetOutage(ctx, created.UUID)
 	if err != nil {
+		// Save what we know from the create response so that the resource is not
+		// left with only the ID populated. The plan already contains all user-supplied
+		// fields; persist them alongside the ID so a subsequent refresh can reconcile.
+		plan.OutageType = types.StringValue(OutageTypeManual)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-		resp.Diagnostics.AddError(
-			"Error reading created outage",
-			fmt.Sprintf("Outage created (ID: %s) but failed to read: %s. "+
-				"The resource has been saved to state with its ID. "+
-				"Run 'terraform apply' again to retry reading the full state.", created.UUID, err),
+		resp.Diagnostics.AddWarning(
+			"Partial state after outage creation",
+			fmt.Sprintf("Outage created (ID: %s) but the read-back failed: %s. "+
+				"State has been saved with the values from the create request. "+
+				"Run 'terraform refresh' or 'terraform apply' to reconcile with the API.", created.UUID, err),
 		)
 		return
 	}

--- a/internal/provider/statuspage_resource.go
+++ b/internal/provider/statuspage_resource.go
@@ -203,7 +203,11 @@ func (r *StatusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 	// Map response to state
 	r.mapStatusPageToModel(ctx, statusPage, &state, &resp.Diagnostics)
 
-	// Restore password: API never returns this field, so preserve prior state value
+	// Restore password: API never returns this field, so preserve prior state value.
+	// This ensures that when a password is configured, it remains in state and
+	// Terraform does not show a spurious diff on every plan. When the user removes
+	// the password from config, Terraform will detect the diff (state has password,
+	// config does not) and trigger an Update, which explicitly clears it via the API.
 	if !priorPassword.IsNull() {
 		state.Password = priorPassword
 	}
@@ -230,6 +234,13 @@ func (r *StatusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 	updateReq := r.buildUpdateRequest(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// If the user removed the password from config (plan is null) but state had
+	// one, explicitly send an empty string to clear it on the API side.
+	if plan.Password.IsNull() && !state.Password.IsNull() {
+		empty := ""
+		updateReq.Password = &empty
 	}
 
 	// Translate mon_xxx -> numeric IDs for the uptime renderer
@@ -262,7 +273,9 @@ func (r *StatusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Map response to state
 	r.mapStatusPageToModel(ctx, statusPage, &plan, &resp.Diagnostics)
 
-	// Restore password: API never returns this field, so preserve plan value
+	// Restore password: API never returns this field, so preserve plan value.
+	// When the user clears the password (plan is null but state had a value),
+	// leave plan.Password as null so state no longer holds the stale value.
 	if !planPassword.IsNull() {
 		plan.Password = planPassword
 	}


### PR DESCRIPTION
## Summary
Fixes found during cross-repo audit of CRUD logic and field mapping.

- **Incident text update (critical):** The Update function never sent the `text` field to the API. Changes to incident text were silently dropped. Now detects text changes and includes them in the update request.
- **Incident text preservation:** When the API returns empty text (write-only behavior), the prior state value is now preserved correctly instead of drifting to empty string.
- **Outage read-back failure:** If the read-back after Create fails, the resource is now saved with all known fields (not just the ID) and a warning is emitted instead of an error.
- **StatusPage password clearing:** Password can now be cleared from state by removing it from config. Previously it persisted in state forever.
- **Escalation policy docs:** Documented the `"none"` magic value for unlinking escalation policies.
- **Maintenance text clearing:** Added clarifying comment about empty string behavior.
- **Test gap:** Added TODO for incident text update acceptance test.

## Dependency
Requires develeap/hyperping-go#fix/audit-findings (adds `Text` field to `UpdateIncidentRequest`).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/provider/... -short` passes
- [ ] Manual: update incident text via Terraform, verify API reflects change