### PR TITLE
test: raise cmd/migrate-pingdom coverage to 70%+

### DIFF
--- a/cmd/migrate-pingdom/converter/check_test.go
+++ b/cmd/migrate-pingdom/converter/check_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package converter
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+func TestConvert_DispatchByType(t *testing.T) {
+	tests := []struct {
+		name             string
+		check            pingdom.Check
+		wantSupported    bool
+		wantProtocol     string
+		wantUnsupported  string
+		wantNotesNonZero bool
+	}{
+		{
+			name:          "http",
+			check:         pingdom.Check{Type: "http", Hostname: "a.example.com"},
+			wantSupported: true,
+			wantProtocol:  "http",
+		},
+		{
+			name:          "https",
+			check:         pingdom.Check{Type: "https", Hostname: "a.example.com", Encryption: true},
+			wantSupported: true,
+			wantProtocol:  "http",
+		},
+		{
+			name:          "tcp",
+			check:         pingdom.Check{Type: "tcp", Hostname: "db.example.com", Port: 5432},
+			wantSupported: true,
+			wantProtocol:  "port",
+		},
+		{
+			name:          "ping",
+			check:         pingdom.Check{Type: "ping", Hostname: "host.example.com"},
+			wantSupported: true,
+			wantProtocol:  "icmp",
+		},
+		{
+			name:             "smtp",
+			check:            pingdom.Check{Type: "smtp", Hostname: "mail.example.com"},
+			wantSupported:    true,
+			wantProtocol:     "port",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "pop3",
+			check:            pingdom.Check{Type: "pop3", Hostname: "mail.example.com"},
+			wantSupported:    true,
+			wantProtocol:     "port",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "imap",
+			check:            pingdom.Check{Type: "imap", Hostname: "mail.example.com"},
+			wantSupported:    true,
+			wantProtocol:     "port",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "dns unsupported",
+			check:            pingdom.Check{Type: "dns", Hostname: "example.com"},
+			wantSupported:    false,
+			wantUnsupported:  "dns",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "udp unsupported",
+			check:            pingdom.Check{Type: "udp", Hostname: "example.com"},
+			wantSupported:    false,
+			wantUnsupported:  "udp",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "transaction unsupported",
+			check:            pingdom.Check{Type: "transaction", Hostname: "example.com"},
+			wantSupported:    false,
+			wantUnsupported:  "transaction",
+			wantNotesNonZero: true,
+		},
+		{
+			name:             "unknown type",
+			check:            pingdom.Check{Type: "weirdo", Hostname: "example.com"},
+			wantSupported:    false,
+			wantUnsupported:  "weirdo",
+			wantNotesNonZero: true,
+		},
+	}
+
+	c := NewCheckConverter()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := c.Convert(tt.check)
+
+			if result.Supported != tt.wantSupported {
+				t.Fatalf("Supported = %v, want %v", result.Supported, tt.wantSupported)
+			}
+			if tt.wantSupported {
+				if result.Monitor == nil {
+					t.Fatal("expected Monitor non-nil for supported type")
+				}
+				if result.Monitor.Protocol != tt.wantProtocol {
+					t.Errorf("Protocol = %q, want %q", result.Monitor.Protocol, tt.wantProtocol)
+				}
+			} else if result.UnsupportedType != tt.wantUnsupported {
+				t.Errorf("UnsupportedType = %q, want %q", result.UnsupportedType, tt.wantUnsupported)
+			}
+			if tt.wantNotesNonZero && len(result.Notes) == 0 {
+				t.Error("expected at least one note")
+			}
+		})
+	}
+}
+
+func TestConvertHTTPCheck_FieldMapping(t *testing.T) {
+	postBody := `{"hello":"world"}`
+	check := pingdom.Check{
+		Type:              "https",
+		Hostname:          "api.example.com",
+		URL:               "/v1/health",
+		Encryption:        true,
+		Resolution:        5,
+		Paused:            true,
+		PostData:          postBody,
+		ShouldContain:     "ok",
+		VerifyCertificate: false,
+		RequestHeaders: map[string]string{
+			"X-Test": "value",
+		},
+		Tags: []pingdom.Tag{
+			{Name: "production", Type: "u"},
+			{Name: "api", Type: "u"},
+		},
+		ProbeFilters: []string{"region:NA"},
+	}
+
+	result := NewCheckConverter().Convert(check)
+	if !result.Supported {
+		t.Fatalf("expected supported, got unsupported (%s)", result.UnsupportedType)
+	}
+	m := result.Monitor
+	if m == nil {
+		t.Fatal("expected non-nil monitor")
+	}
+	if got, want := m.URL, "https://api.example.com/v1/health"; got != want {
+		t.Errorf("URL = %q, want %q", got, want)
+	}
+	if m.HTTPMethod != "POST" {
+		t.Errorf("HTTPMethod = %q, want POST (because PostData was set)", m.HTTPMethod)
+	}
+	if m.RequestBody == nil || *m.RequestBody != postBody {
+		t.Errorf("RequestBody = %v, want %q", m.RequestBody, postBody)
+	}
+	if m.RequiredKeyword == nil || *m.RequiredKeyword != "ok" {
+		t.Errorf("RequiredKeyword = %v, want %q", m.RequiredKeyword, "ok")
+	}
+	if m.ExpectedStatusCode != "200" {
+		t.Errorf("ExpectedStatusCode = %q, want 200", m.ExpectedStatusCode)
+	}
+	if !m.Paused {
+		t.Error("Paused = false, want true")
+	}
+	if len(m.RequestHeaders) != 1 || m.RequestHeaders[0].Name != "X-Test" || m.RequestHeaders[0].Value != "value" {
+		t.Errorf("RequestHeaders = %#v", m.RequestHeaders)
+	}
+	// VerifyCertificate=false flips FollowRedirects to true (per existing logic);
+	// VerifyCertificate=true would flip it false.
+	if m.FollowRedirects == nil {
+		t.Error("FollowRedirects = nil, want non-nil for HTTPS check")
+	}
+}
+
+func TestConvertHTTPCheck_HTTPProtocolNoEncryption(t *testing.T) {
+	check := pingdom.Check{
+		Type:       "http",
+		Hostname:   "site.example.com",
+		URL:        "/",
+		Encryption: false,
+	}
+	m := NewCheckConverter().Convert(check).Monitor
+	if m.URL != "http://site.example.com/" {
+		t.Errorf("URL = %q, want http://site.example.com/", m.URL)
+	}
+	if m.HTTPMethod != "GET" {
+		t.Errorf("HTTPMethod = %q, want GET", m.HTTPMethod)
+	}
+	if m.RequestBody != nil {
+		t.Errorf("RequestBody = %v, want nil", m.RequestBody)
+	}
+}
+
+func TestConvertTCPCheck_PortDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     int
+		wantPort int
+	}{
+		{"explicit port", 5432, 5432},
+		{"zero defaults to 80", 0, 80},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := pingdom.Check{Type: "tcp", Hostname: "db.example.com", Port: tt.port}
+			m := NewCheckConverter().Convert(check).Monitor
+			if m.Port == nil || *m.Port != tt.wantPort {
+				t.Errorf("Port = %v, want %d", m.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertSMTPCheck_PortDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		encryption bool
+		explicit   int
+		wantPort   int
+	}{
+		{"plain default", false, 0, 25},
+		{"encrypted default", true, 0, 587},
+		{"explicit overrides", false, 2525, 2525},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewCheckConverter().Convert(pingdom.Check{
+				Type:       "smtp",
+				Hostname:   "mail.example.com",
+				Port:       tt.explicit,
+				Encryption: tt.encryption,
+			}).Monitor
+			if m.Port == nil || *m.Port != tt.wantPort {
+				t.Errorf("Port = %v, want %d", m.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertPOP3Check_PortDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		encryption bool
+		wantPort   int
+	}{
+		{"plain", false, 110},
+		{"encrypted", true, 995},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewCheckConverter().Convert(pingdom.Check{
+				Type:       "pop3",
+				Hostname:   "mail.example.com",
+				Encryption: tt.encryption,
+			}).Monitor
+			if m.Port == nil || *m.Port != tt.wantPort {
+				t.Errorf("Port = %v, want %d", m.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertIMAPCheck_PortDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		encryption bool
+		wantPort   int
+	}{
+		{"plain", false, 143},
+		{"encrypted", true, 993},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewCheckConverter().Convert(pingdom.Check{
+				Type:       "imap",
+				Hostname:   "mail.example.com",
+				Encryption: tt.encryption,
+			}).Monitor
+			if m.Port == nil || *m.Port != tt.wantPort {
+				t.Errorf("Port = %v, want %d", m.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertPingCheck_Fields(t *testing.T) {
+	check := pingdom.Check{
+		Type:         "ping",
+		Hostname:     "host.example.com",
+		Resolution:   1,
+		Paused:       true,
+		ProbeFilters: []string{"region:EU"},
+	}
+	m := NewCheckConverter().Convert(check).Monitor
+	if m.Protocol != "icmp" {
+		t.Errorf("Protocol = %q, want icmp", m.Protocol)
+	}
+	if m.URL != "host.example.com" {
+		t.Errorf("URL = %q, want host.example.com", m.URL)
+	}
+	if !m.Paused {
+		t.Error("Paused = false, want true")
+	}
+}
+
+func TestConvertFrequency(t *testing.T) {
+	tests := []struct {
+		minutes int
+		want    int
+	}{
+		{1, 60},
+		{5, 300},
+		{10, 600},
+		{30, 1800},
+		{60, 3600},
+		// Pingdom supports 15-minute checks too; should round to nearest allowed.
+		{15, 600}, // 900s; allowed list jumps 600 -> 1800; 600 is closer.
+	}
+	for _, tt := range tests {
+		got := ConvertFrequency(tt.minutes)
+		if got != tt.want {
+			t.Errorf("ConvertFrequency(%d) = %d, want %d", tt.minutes, got, tt.want)
+		}
+	}
+}
+
+func TestConvertRegions(t *testing.T) {
+	sortedSet := func(in []string) []string {
+		out := append([]string{}, in...)
+		sort.Strings(out)
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		filters []string
+		want    []string
+	}{
+		{
+			name:    "empty defaults",
+			filters: nil,
+			want:    []string{"frankfurt", "london", "singapore", "virginia"},
+		},
+		{
+			name:    "NA",
+			filters: []string{"region:NA"},
+			want:    []string{"oregon", "virginia"},
+		},
+		{
+			name:    "EU",
+			filters: []string{"region:EU"},
+			want:    []string{"frankfurt", "london"},
+		},
+		{
+			name:    "APAC",
+			filters: []string{"region:APAC"},
+			want:    []string{"singapore", "sydney", "tokyo"},
+		},
+		{
+			name:    "LATAM",
+			filters: []string{"region:LATAM"},
+			want:    []string{"saopaulo"},
+		},
+		{
+			name:    "NA+EU dedup",
+			filters: []string{"region:NA", "region:EU", "region:NA"},
+			want:    []string{"frankfurt", "london", "oregon", "virginia"},
+		},
+		{
+			name:    "unknown filter falls back",
+			filters: []string{"region:MARS"},
+			want:    []string{"london", "virginia"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortedSet(ConvertRegions(tt.filters))
+			if len(got) != len(tt.want) {
+				t.Fatalf("regions = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("regions = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/migrate-pingdom/converter/check_test.go
+++ b/cmd/migrate-pingdom/converter/check_test.go
@@ -171,10 +171,57 @@ func TestConvertHTTPCheck_FieldMapping(t *testing.T) {
 	if len(m.RequestHeaders) != 1 || m.RequestHeaders[0].Name != "X-Test" || m.RequestHeaders[0].Value != "value" {
 		t.Errorf("RequestHeaders = %#v", m.RequestHeaders)
 	}
-	// VerifyCertificate=false flips FollowRedirects to true (per existing logic);
-	// VerifyCertificate=true would flip it false.
-	if m.FollowRedirects == nil {
-		t.Error("FollowRedirects = nil, want non-nil for HTTPS check")
+	// HTTPS branch overrides FollowRedirects with !VerifyCertificate.
+	// VerifyCertificate=false here, so FollowRedirects must be true.
+	if m.FollowRedirects == nil || !*m.FollowRedirects {
+		t.Errorf("FollowRedirects = %v, want non-nil pointing to true (VerifyCertificate=false on HTTPS)", m.FollowRedirects)
+	}
+}
+
+// TestConvertHTTPCheck_VerifyCertificateFlipsFollowRedirects locks in the
+// (admittedly odd) production behaviour where VerifyCertificate on an HTTPS
+// check is what controls FollowRedirects. Tested as a property — flipping
+// VerifyCertificate must flip FollowRedirects — so the test does not pretend
+// to endorse the semantic mapping.
+func TestConvertHTTPCheck_VerifyCertificateFlipsFollowRedirects(t *testing.T) {
+	tests := []struct {
+		name              string
+		verifyCertificate bool
+		wantFollow        bool
+	}{
+		{"verify=false → follow=true", false, true},
+		{"verify=true → follow=false", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewCheckConverter().Convert(pingdom.Check{
+				Type:              "https",
+				Hostname:          "api.example.com",
+				URL:               "/",
+				Encryption:        true,
+				VerifyCertificate: tt.verifyCertificate,
+			}).Monitor
+			if m.FollowRedirects == nil {
+				t.Fatal("FollowRedirects is nil, want non-nil for HTTPS check")
+			}
+			if *m.FollowRedirects != tt.wantFollow {
+				t.Errorf("FollowRedirects = %v, want %v", *m.FollowRedirects, tt.wantFollow)
+			}
+		})
+	}
+}
+
+// TestConvertHTTPCheck_NoEncryptionFollowsRedirects covers the non-HTTPS path
+// where the initial true value survives unchanged.
+func TestConvertHTTPCheck_NoEncryptionFollowsRedirects(t *testing.T) {
+	m := NewCheckConverter().Convert(pingdom.Check{
+		Type:              "http",
+		Hostname:          "site.example.com",
+		Encryption:        false,
+		VerifyCertificate: true, // ignored when Encryption is false
+	}).Monitor
+	if m.FollowRedirects == nil || !*m.FollowRedirects {
+		t.Errorf("FollowRedirects = %v, want non-nil pointing to true (HTTP default)", m.FollowRedirects)
 	}
 }
 

--- a/cmd/migrate-pingdom/converter/tags_test.go
+++ b/cmd/migrate-pingdom/converter/tags_test.go
@@ -67,14 +67,6 @@ func TestGenerateName(t *testing.T) {
 			want:  "[UNKNOWN]-Service-Monitor",
 		},
 		{
-			name: "long name truncated to 30 chars",
-			check: pingdom.Check{
-				Name: strings.Repeat("ABCD ", 20), // many words, very long
-			},
-			// Each "ABCD " becomes "Abcd"; concatenated to "AbcdAbcd...". 30-char cutoff.
-			want: "[UNKNOWN]-Service-" + strings.Repeat("Abcd", 8)[:30],
-		},
-		{
 			name: "qa environment",
 			check: pingdom.Check{
 				Name: "Reports",
@@ -141,36 +133,70 @@ func TestTagsToString(t *testing.T) {
 	}
 }
 
-// Indirectly exercise the category aliases that GenerateName covers.
+// TestExtractCategory_AllAliases indirectly exercises the category aliases that
+// GenerateName covers. Cases are kept in a slice rather than a map so subtest
+// order is deterministic (helps when running with -shuffle and when reading
+// failure output).
 func TestExtractCategory_AllAliases(t *testing.T) {
-	cases := map[string]string{
-		"api":         "API",
-		"web":         "Web",
-		"website":     "Web",
-		"database":    "Database",
-		"cache":       "Cache",
-		"memcached":   "Cache",
-		"queue":       "Queue",
-		"cdn":         "CDN",
-		"dns":         "DNS",
-		"mail":        "Mail",
-		"smtp":        "Mail",
-		"email":       "Mail",
-		"service":     "Service",
-		"app":         "App",
-		"application": "App",
+	cases := []struct {
+		tag, want string
+	}{
+		{"api", "API"},
+		{"web", "Web"},
+		{"website", "Web"},
+		{"database", "Database"},
+		{"cache", "Cache"},
+		{"memcached", "Cache"},
+		{"queue", "Queue"},
+		{"cdn", "CDN"},
+		{"dns", "DNS"},
+		{"mail", "Mail"},
+		{"smtp", "Mail"},
+		{"email", "Mail"},
+		{"service", "Service"},
+		{"app", "App"},
+		{"application", "App"},
 	}
-	for tag, want := range cases {
-		t.Run(tag, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
 			check := pingdom.Check{
 				Name: "Foo",
-				Tags: []pingdom.Tag{{Name: "prod"}, {Name: tag}},
+				Tags: []pingdom.Tag{{Name: "prod"}, {Name: tc.tag}},
 			}
 			got := GenerateName(check)
-			expected := "[PROD]-" + want + "-Foo"
+			expected := "[PROD]-" + tc.want + "-Foo"
 			if got != expected {
 				t.Errorf("got %q, want %q", got, expected)
 			}
 		})
+	}
+}
+
+// TestGenerateName_LongNameTruncated checks the length cap as a property
+// rather than pinning a specific 30-char value: future tweaks to the cap or
+// the casing rules don't require recomputing a hand-built expected string,
+// only updating the cap constant in the assertion.
+func TestGenerateName_LongNameTruncated(t *testing.T) {
+	const cap = 30
+	long := strings.Repeat("ABCD ", 20) // 100 chars before sanitisation
+	got := GenerateName(pingdom.Check{Name: long})
+
+	const prefix = "[UNKNOWN]-Service-"
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("got %q, missing env/category prefix %q", got, prefix)
+	}
+	svc := strings.TrimPrefix(got, prefix)
+	if len(svc) > cap {
+		t.Errorf("service-name length = %d, want <= %d", len(svc), cap)
+	}
+	// Confirm the long input actually exercised the truncation path,
+	// otherwise this test would silently degrade if the cap moved.
+	if len(svc) != cap {
+		t.Errorf("expected truncation to exactly %d chars (input is far longer), got %d", cap, len(svc))
+	}
+	for _, r := range svc {
+		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			t.Errorf("unexpected non-alphanumeric char %q in service name %q", r, svc)
+		}
 	}
 }

--- a/cmd/migrate-pingdom/converter/tags_test.go
+++ b/cmd/migrate-pingdom/converter/tags_test.go
@@ -195,7 +195,7 @@ func TestGenerateName_LongNameTruncated(t *testing.T) {
 		t.Errorf("expected truncation to exactly %d chars (input is far longer), got %d", cap, len(svc))
 	}
 	for _, r := range svc {
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') {
 			t.Errorf("unexpected non-alphanumeric char %q in service name %q", r, svc)
 		}
 	}

--- a/cmd/migrate-pingdom/converter/tags_test.go
+++ b/cmd/migrate-pingdom/converter/tags_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+func TestGenerateName(t *testing.T) {
+	tests := []struct {
+		name  string
+		check pingdom.Check
+		want  string
+	}{
+		{
+			name: "production api basic",
+			check: pingdom.Check{
+				Name: "API Health Check",
+				Tags: []pingdom.Tag{{Name: "production"}, {Name: "api"}},
+			},
+			want: "[PROD]-API-ApiHealthCheck",
+		},
+		{
+			name: "staging with customer prefix",
+			check: pingdom.Check{
+				Name: "Customer Portal",
+				Tags: []pingdom.Tag{
+					{Name: "staging"},
+					{Name: "customer-acme"},
+					{Name: "web"},
+				},
+			},
+			want: "[STAGING-ACME]-Web-CustomerPortal",
+		},
+		{
+			name: "tenant prefix",
+			check: pingdom.Check{
+				Name: "Worker Health",
+				Tags: []pingdom.Tag{
+					{Name: "prod"},
+					{Name: "tenant-acme"},
+					{Name: "worker"},
+				},
+			},
+			want: "[PROD-ACME]-Worker-WorkerHealth",
+		},
+		{
+			name:  "no tags falls back to UNKNOWN/Service",
+			check: pingdom.Check{Name: "Simple Monitor"},
+			want:  "[UNKNOWN]-Service-SimpleMonitor",
+		},
+		{
+			name: "name has prefix Production - is stripped",
+			check: pingdom.Check{
+				Name: "Production - User Login",
+				Tags: []pingdom.Tag{{Name: "prod"}, {Name: "api"}},
+			},
+			want: "[PROD]-API-UserLogin",
+		},
+		{
+			name:  "empty service name falls back to Monitor",
+			check: pingdom.Check{Name: "!!!"},
+			want:  "[UNKNOWN]-Service-Monitor",
+		},
+		{
+			name: "long name truncated to 30 chars",
+			check: pingdom.Check{
+				Name: strings.Repeat("ABCD ", 20), // many words, very long
+			},
+			// Each "ABCD " becomes "Abcd"; concatenated to "AbcdAbcd...". 30-char cutoff.
+			want: "[UNKNOWN]-Service-" + strings.Repeat("Abcd", 8)[:30],
+		},
+		{
+			name: "qa environment",
+			check: pingdom.Check{
+				Name: "Reports",
+				Tags: []pingdom.Tag{{Name: "qa"}, {Name: "backend"}},
+			},
+			want: "[QA]-Backend-Reports",
+		},
+		{
+			name: "test environment",
+			check: pingdom.Check{
+				Name: "Smoke",
+				Tags: []pingdom.Tag{{Name: "test"}, {Name: "frontend"}},
+			},
+			want: "[TEST]-Frontend-Smoke",
+		},
+		{
+			name: "dev environment, db category alias",
+			check: pingdom.Check{
+				Name: "Postgres",
+				Tags: []pingdom.Tag{{Name: "dev"}, {Name: "db"}},
+			},
+			want: "[DEV]-Database-Postgres",
+		},
+		{
+			name: "case insensitive tags",
+			check: pingdom.Check{
+				Name: "Cache",
+				Tags: []pingdom.Tag{{Name: "PRODUCTION"}, {Name: "REDIS"}},
+			},
+			want: "[PROD]-Cache-Cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateName(tt.check)
+			if got != tt.want {
+				t.Errorf("GenerateName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagsToString(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []pingdom.Tag
+		want string
+	}{
+		{name: "nil", tags: nil, want: ""},
+		{name: "empty", tags: []pingdom.Tag{}, want: ""},
+		{
+			name: "multiple",
+			tags: []pingdom.Tag{{Name: "prod"}, {Name: "api"}},
+			want: "prod, api",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TagsToString(tt.tags); got != tt.want {
+				t.Errorf("TagsToString = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Indirectly exercise the category aliases that GenerateName covers.
+func TestExtractCategory_AllAliases(t *testing.T) {
+	cases := map[string]string{
+		"api":         "API",
+		"web":         "Web",
+		"website":     "Web",
+		"database":    "Database",
+		"cache":       "Cache",
+		"memcached":   "Cache",
+		"queue":       "Queue",
+		"cdn":         "CDN",
+		"dns":         "DNS",
+		"mail":        "Mail",
+		"smtp":        "Mail",
+		"email":       "Mail",
+		"service":     "Service",
+		"app":         "App",
+		"application": "App",
+	}
+	for tag, want := range cases {
+		t.Run(tag, func(t *testing.T) {
+			check := pingdom.Check{
+				Name: "Foo",
+				Tags: []pingdom.Tag{{Name: "prod"}, {Name: tag}},
+			}
+			got := GenerateName(check)
+			expected := "[PROD]-" + want + "-Foo"
+			if got != expected {
+				t.Errorf("got %q, want %q", got, expected)
+			}
+		})
+	}
+}

--- a/cmd/migrate-pingdom/generator/helpers_test.go
+++ b/cmd/migrate-pingdom/generator/helpers_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update-golden", false, "rewrite testdata/*.golden files with current output")
+
+// goldenAssert compares got to the contents of testdata/<name>. With
+// -update-golden, the file is rewritten instead. testdata/ is created on demand
+// so a deleted golden is regenerated rather than failing in a confusing way.
+func goldenAssert(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil { //nolint:gosec // testdata only
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (run: go test ./cmd/migrate-pingdom/generator -update-golden)", path, err)
+	}
+	if got != string(want) {
+		t.Errorf("output does not match %s\nrun -update-golden after intentional changes\n--- got ---\n%s\n--- want ---\n%s", name, got, string(want))
+	}
+}

--- a/cmd/migrate-pingdom/generator/import_test.go
+++ b/cmd/migrate-pingdom/generator/import_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+func makeChecks() ([]pingdom.Check, []converter.ConversionResult) {
+	checks := []pingdom.Check{
+		{
+			ID:       1,
+			Name:     "API",
+			Type:     "http",
+			Hostname: "api.example.com",
+			URL:      "/health",
+			Tags:     []pingdom.Tag{{Name: "production"}, {Name: "api"}},
+		},
+		{
+			ID:       2,
+			Name:     "DNS",
+			Type:     "dns",
+			Hostname: "example.com",
+		},
+		{
+			ID:       3,
+			Name:     "Web",
+			Type:     "http",
+			Hostname: "site.example.com",
+			Tags:     []pingdom.Tag{{Name: "production"}, {Name: "web"}},
+		},
+	}
+	conv := converter.NewCheckConverter()
+	results := make([]converter.ConversionResult, len(checks))
+	for i, c := range checks {
+		results[i] = conv.Convert(c)
+	}
+	return checks, results
+}
+
+func TestGenerateImportScript_Shape(t *testing.T) {
+	checks, results := makeChecks()
+	created := map[int]string{
+		1: "mon_aaaa",
+		// check 2 is unsupported, check 3 not yet created
+	}
+
+	out := NewImportGenerator("").GenerateImportScript(checks, results, created)
+
+	if !strings.HasPrefix(out, "#!/bin/bash\n") {
+		t.Errorf("expected shebang, got:\n%s", out)
+	}
+	if !strings.Contains(out, "set -e") {
+		t.Errorf("expected set -e in script:\n%s", out)
+	}
+	if !strings.Contains(out, "terraform import hyperping_monitor.") {
+		t.Errorf("expected import command:\n%s", out)
+	}
+	if !strings.Contains(out, `"mon_aaaa"`) {
+		t.Errorf("expected created UUID:\n%s", out)
+	}
+	if strings.Contains(out, "Pingdom Check 2") {
+		t.Errorf("unsupported check 2 should not appear in script:\n%s", out)
+	}
+	if !strings.Contains(out, "# Skipping Pingdom Check 3") {
+		t.Errorf("expected skip comment for uncreated check 3:\n%s", out)
+	}
+	if !strings.Contains(out, "Imported 1 resources") {
+		t.Errorf("expected count summary:\n%s", out)
+	}
+}
+
+func TestGenerateImportScript_Prefix(t *testing.T) {
+	checks, results := makeChecks()
+	created := map[int]string{1: "mon_aaaa"}
+	out := NewImportGenerator("pd_").GenerateImportScript(checks, results, created)
+	if !strings.Contains(out, "terraform import hyperping_monitor.pd_") {
+		t.Errorf("expected prefix in import target:\n%s", out)
+	}
+}
+
+func TestGenerateImportCommands_Shape(t *testing.T) {
+	checks, results := makeChecks()
+	created := map[int]string{1: "mon_aaaa"}
+	out := NewImportGenerator("").GenerateImportCommands(checks, results, created)
+
+	if strings.HasPrefix(out, "#!/bin/bash") {
+		t.Errorf("import commands form should not contain shebang:\n%s", out)
+	}
+	if !strings.Contains(out, "terraform import hyperping_monitor.") {
+		t.Errorf("expected import command:\n%s", out)
+	}
+	if strings.Contains(out, "set -e") {
+		t.Errorf("set -e should not be in commands form:\n%s", out)
+	}
+	if strings.Contains(out, "Pingdom Check 3") {
+		t.Errorf("uncreated check 3 should not appear:\n%s", out)
+	}
+	if strings.Contains(out, "Pingdom Check 2") {
+		t.Errorf("unsupported check 2 should not appear:\n%s", out)
+	}
+}
+
+func TestGenerateImportScript_NoResources(t *testing.T) {
+	out := NewImportGenerator("").GenerateImportScript(nil, nil, nil)
+	if !strings.Contains(out, "Imported 0 resources") {
+		t.Errorf("expected zero count for empty input:\n%s", out)
+	}
+}

--- a/cmd/migrate-pingdom/generator/import_test.go
+++ b/cmd/migrate-pingdom/generator/import_test.go
@@ -43,36 +43,18 @@ func makeChecks() ([]pingdom.Check, []converter.ConversionResult) {
 	return checks, results
 }
 
-func TestGenerateImportScript_Shape(t *testing.T) {
+// TestGenerateImportScript_Golden snapshots the full script for a representative
+// input mix (one created, one unsupported, one supported-but-not-created). The
+// script is user-facing and shells get sensitive to subtle shape regressions
+// (echo placement, semicolons, comment vs command), so we pin the entire output.
+func TestGenerateImportScript_Golden(t *testing.T) {
 	checks, results := makeChecks()
 	created := map[int]string{
 		1: "mon_aaaa",
 		// check 2 is unsupported, check 3 not yet created
 	}
-
-	out := NewImportGenerator("").GenerateImportScript(checks, results, created)
-
-	if !strings.HasPrefix(out, "#!/bin/bash\n") {
-		t.Errorf("expected shebang, got:\n%s", out)
-	}
-	if !strings.Contains(out, "set -e") {
-		t.Errorf("expected set -e in script:\n%s", out)
-	}
-	if !strings.Contains(out, "terraform import hyperping_monitor.") {
-		t.Errorf("expected import command:\n%s", out)
-	}
-	if !strings.Contains(out, `"mon_aaaa"`) {
-		t.Errorf("expected created UUID:\n%s", out)
-	}
-	if strings.Contains(out, "Pingdom Check 2") {
-		t.Errorf("unsupported check 2 should not appear in script:\n%s", out)
-	}
-	if !strings.Contains(out, "# Skipping Pingdom Check 3") {
-		t.Errorf("expected skip comment for uncreated check 3:\n%s", out)
-	}
-	if !strings.Contains(out, "Imported 1 resources") {
-		t.Errorf("expected count summary:\n%s", out)
-	}
+	got := NewImportGenerator("").GenerateImportScript(checks, results, created)
+	goldenAssert(t, "import.sh.golden", got)
 }
 
 func TestGenerateImportScript_Prefix(t *testing.T) {

--- a/cmd/migrate-pingdom/generator/terraform_test.go
+++ b/cmd/migrate-pingdom/generator/terraform_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	hyperping "github.com/develeap/hyperping-go"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+func intPtr(n int) *int    { return &n }
+func boolPtr(b bool) *bool { return &b }
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestTerraformName(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		input  string
+		want   string
+	}{
+		{name: "simple", input: "api", want: "api"},
+		{name: "spaces", input: "API Health", want: "api_health"},
+		{name: "brackets stripped", input: "[PROD]-API-Service", want: "api_service"},
+		{name: "leading number", input: "123-foo", want: "monitor_123_foo"},
+		{name: "with prefix", prefix: "p_", input: "API", want: "p_api"},
+		{name: "empty becomes monitor", input: "", want: "monitor"},
+		{name: "only special", input: "!!!", want: "monitor"},
+		{name: "trims underscores", input: "---abc---", want: "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewTerraformGenerator(tt.prefix)
+			got := g.terraformName(tt.input)
+			if got != tt.want {
+				t.Errorf("terraformName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEscapeHCL(t *testing.T) {
+	if got := escapeHCL(`he said "hi"`); got != `he said \"hi\"` {
+		t.Errorf("escapeHCL quotes = %q", got)
+	}
+	if got := escapeHCL("a\\b"); got != `a\\b` {
+		t.Errorf("escapeHCL backslash = %q", got)
+	}
+}
+
+func TestFormatStringList(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want string
+	}{
+		{nil, "[]"},
+		{[]string{}, "[]"},
+		{[]string{"a"}, `["a"]`},
+		{[]string{"a", "b"}, `["a", "b"]`},
+	}
+	for _, tt := range tests {
+		if got := formatStringList(tt.in); got != tt.want {
+			t.Errorf("formatStringList(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestBuildOptionalHelpers(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(*hyperping.CreateMonitorRequest) string
+		mon  *hyperping.CreateMonitorRequest
+		want string
+	}{
+		{"http_method default GET omitted", buildOptionalHTTPMethod, &hyperping.CreateMonitorRequest{HTTPMethod: "GET"}, ""},
+		{"http_method empty omitted", buildOptionalHTTPMethod, &hyperping.CreateMonitorRequest{}, ""},
+		{"http_method POST emitted", buildOptionalHTTPMethod, &hyperping.CreateMonitorRequest{HTTPMethod: "POST"}, "  http_method = \"POST\"\n"},
+
+		{"frequency 60 omitted", buildOptionalCheckFrequency, &hyperping.CreateMonitorRequest{CheckFrequency: 60}, ""},
+		{"frequency 300 emitted", buildOptionalCheckFrequency, &hyperping.CreateMonitorRequest{CheckFrequency: 300}, "  check_frequency = 300\n"},
+
+		{"empty regions omitted", buildOptionalRegions, &hyperping.CreateMonitorRequest{}, ""},
+		{"regions emitted", buildOptionalRegions, &hyperping.CreateMonitorRequest{Regions: []string{"london", "virginia"}}, "  regions = [\"london\", \"virginia\"]\n"},
+
+		{"port nil omitted", buildOptionalPort, &hyperping.CreateMonitorRequest{}, ""},
+		{"port zero omitted", buildOptionalPort, &hyperping.CreateMonitorRequest{Port: intPtr(0)}, ""},
+		{"port emitted", buildOptionalPort, &hyperping.CreateMonitorRequest{Port: intPtr(5432)}, "  port = 5432\n"},
+
+		{"follow nil omitted", buildOptionalFollowRedirects, &hyperping.CreateMonitorRequest{}, ""},
+		{"follow true omitted", buildOptionalFollowRedirects, &hyperping.CreateMonitorRequest{FollowRedirects: boolPtr(true)}, ""},
+		{"follow false emitted", buildOptionalFollowRedirects, &hyperping.CreateMonitorRequest{FollowRedirects: boolPtr(false)}, "  follow_redirects = false\n"},
+
+		{"status default omitted", buildOptionalExpectedStatus, &hyperping.CreateMonitorRequest{ExpectedStatusCode: "200"}, ""},
+		{"status empty omitted", buildOptionalExpectedStatus, &hyperping.CreateMonitorRequest{}, ""},
+		{"status 201 emitted", buildOptionalExpectedStatus, &hyperping.CreateMonitorRequest{ExpectedStatusCode: "201"}, "  expected_status_code = \"201\"\n"},
+
+		{"keyword nil omitted", buildOptionalRequiredKeyword, &hyperping.CreateMonitorRequest{}, ""},
+		{"keyword empty omitted", buildOptionalRequiredKeyword, &hyperping.CreateMonitorRequest{RequiredKeyword: strPtr("")}, ""},
+		{"keyword emitted", buildOptionalRequiredKeyword, &hyperping.CreateMonitorRequest{RequiredKeyword: strPtr("ok")}, "  required_keyword = \"ok\"\n"},
+
+		{"body nil omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{}, ""},
+		{"body empty omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr("")}, ""},
+		// Note: escapeHCL + %q double-escapes quotes/backslashes; this test pins current behaviour.
+		{"body emitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr(`hello`)}, "  request_body = \"hello\"\n"},
+
+		{"paused false omitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{}, ""},
+		{"paused true emitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{Paused: true}, "  paused = true\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn(tt.mon); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildOptionalRequestHeaders(t *testing.T) {
+	if got := buildOptionalRequestHeaders(&hyperping.CreateMonitorRequest{}); got != "" {
+		t.Errorf("expected empty for no headers, got %q", got)
+	}
+	mon := &hyperping.CreateMonitorRequest{
+		RequestHeaders: []hyperping.RequestHeader{
+			{Name: "X-Foo", Value: "bar"},
+		},
+	}
+	got := buildOptionalRequestHeaders(mon)
+	want := "  request_headers = [\n    {\n      name  = \"X-Foo\"\n      value = \"bar\"\n    },\n  ]\n"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestGenerateHCL_SupportedHTTP(t *testing.T) {
+	check := pingdom.Check{
+		ID:           1,
+		Name:         "API",
+		Type:         "http",
+		Hostname:     "api.example.com",
+		URL:          "/health",
+		Tags:         []pingdom.Tag{{Name: "production"}, {Name: "api"}},
+		ProbeFilters: []string{"region:NA"},
+	}
+	results := []converter.ConversionResult{
+		converter.NewCheckConverter().Convert(check),
+	}
+
+	g := NewTerraformGenerator("")
+	hcl := g.GenerateHCL([]pingdom.Check{check}, results)
+
+	for _, want := range []string{
+		"# Pingdom Check ID: 1",
+		"# Original Name: API",
+		"# Type: http",
+		"# Tags: production, api",
+		`resource "hyperping_monitor"`,
+		"protocol = \"http\"",
+		"url      = \"http://api.example.com/health\"",
+	} {
+		if !strings.Contains(hcl, want) {
+			t.Errorf("HCL missing %q\n---\n%s", want, hcl)
+		}
+	}
+}
+
+func TestGenerateHCL_Unsupported(t *testing.T) {
+	check := pingdom.Check{ID: 7, Name: "DNS Check", Type: "dns", Hostname: "x"}
+	results := []converter.ConversionResult{
+		converter.NewCheckConverter().Convert(check),
+	}
+	hcl := NewTerraformGenerator("").GenerateHCL([]pingdom.Check{check}, results)
+
+	if !strings.Contains(hcl, "# UNSUPPORTED: dns") {
+		t.Errorf("missing unsupported comment:\n%s", hcl)
+	}
+	if strings.Contains(hcl, `resource "hyperping_monitor"`) {
+		t.Errorf("should not emit a resource for unsupported check:\n%s", hcl)
+	}
+}
+
+func TestGenerateHCL_PrefixApplied(t *testing.T) {
+	check := pingdom.Check{
+		ID:       2,
+		Name:     "Web",
+		Type:     "http",
+		Hostname: "site.example.com",
+		Tags:     []pingdom.Tag{{Name: "production"}, {Name: "web"}},
+	}
+	results := []converter.ConversionResult{
+		converter.NewCheckConverter().Convert(check),
+	}
+	hcl := NewTerraformGenerator("pd_").GenerateHCL([]pingdom.Check{check}, results)
+	if !strings.Contains(hcl, `resource "hyperping_monitor" "pd_`) {
+		t.Errorf("expected prefix in resource name:\n%s", hcl)
+	}
+}
+
+func TestGenerateHCL_Empty(t *testing.T) {
+	hcl := NewTerraformGenerator("").GenerateHCL(nil, nil)
+	if !strings.HasPrefix(hcl, "# Generated from Pingdom export") {
+		t.Errorf("expected header for empty input, got:\n%s", hcl)
+	}
+}
+
+func TestGenerateHCL_Notes(t *testing.T) {
+	check := pingdom.Check{ID: 3, Name: "Mail", Type: "smtp", Hostname: "mail.example.com"}
+	results := []converter.ConversionResult{
+		converter.NewCheckConverter().Convert(check),
+	}
+	hcl := NewTerraformGenerator("").GenerateHCL([]pingdom.Check{check}, results)
+	if !strings.Contains(hcl, "  # NOTE:") {
+		t.Errorf("expected NOTE in HCL:\n%s", hcl)
+	}
+}

--- a/cmd/migrate-pingdom/generator/terraform_test.go
+++ b/cmd/migrate-pingdom/generator/terraform_test.go
@@ -107,8 +107,14 @@ func TestBuildOptionalHelpers(t *testing.T) {
 
 		{"body nil omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{}, ""},
 		{"body empty omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr("")}, ""},
-		// Note: escapeHCL + %q double-escapes quotes/backslashes; this test pins current behaviour.
-		{"body emitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr(`hello`)}, "  request_body = \"hello\"\n"},
+		{"body emitted (ASCII-safe)", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr("hello")}, "  request_body = \"hello\"\n"},
+		// TODO: pinning the current double-escape behaviour. terraform.go formats
+		// already-escaped strings with %q, which escapes them a second time. For input
+		// {"a":1}, the runtime output is `"{\\\"a\\\":1}"` (3 backslashes before each
+		// quote) instead of the HCL-correct `"{\"a\":1}"`. When the bug is fixed (drop
+		// %q in favour of QuoteHCL, or stop pre-escaping), this expectation becomes
+		// "  request_body = \"{\\\"a\\\":1}\"\n" — see the PR body for context.
+		{"body emitted (current double-escape)", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr(`{"a":1}`)}, "  request_body = \"{\\\\\\\"a\\\\\\\":1}\"\n"},
 
 		{"paused false omitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{}, ""},
 		{"paused true emitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{Paused: true}, "  paused = true\n"},
@@ -138,36 +144,48 @@ func TestBuildOptionalRequestHeaders(t *testing.T) {
 	}
 }
 
-func TestGenerateHCL_SupportedHTTP(t *testing.T) {
-	check := pingdom.Check{
-		ID:           1,
-		Name:         "API",
-		Type:         "http",
-		Hostname:     "api.example.com",
-		URL:          "/health",
-		Tags:         []pingdom.Tag{{Name: "production"}, {Name: "api"}},
-		ProbeFilters: []string{"region:NA"},
+// TestGenerateHCL_Golden snapshots a representative mix of supported and
+// unsupported checks. Inputs are deliberately ASCII-only and avoid any field
+// that would introduce non-deterministic output (request headers — map
+// iteration; probe-filter-derived regions — set→slice). A field-ordering or
+// whitespace regression here would silently ship broken HCL to users, so we
+// pin the full output rather than substring-asserting.
+func TestGenerateHCL_Golden(t *testing.T) {
+	checks := []pingdom.Check{
+		{
+			ID:         1,
+			Name:       "API Health",
+			Type:       "https",
+			Hostname:   "api.example.com",
+			URL:        "/health",
+			Encryption: true,
+			Resolution: 5,
+			Tags:       []pingdom.Tag{{Name: "production"}, {Name: "api"}},
+		},
+		{
+			ID:         2,
+			Name:       "Database",
+			Type:       "tcp",
+			Hostname:   "db.example.com",
+			Port:       5432,
+			Resolution: 1,
+			Tags:       []pingdom.Tag{{Name: "production"}, {Name: "database"}},
+		},
+		{
+			ID:       3,
+			Name:     "DNS Lookup",
+			Type:     "dns",
+			Hostname: "example.com",
+		},
 	}
-	results := []converter.ConversionResult{
-		converter.NewCheckConverter().Convert(check),
+	conv := converter.NewCheckConverter()
+	results := make([]converter.ConversionResult, len(checks))
+	for i, c := range checks {
+		results[i] = conv.Convert(c)
 	}
 
-	g := NewTerraformGenerator("")
-	hcl := g.GenerateHCL([]pingdom.Check{check}, results)
-
-	for _, want := range []string{
-		"# Pingdom Check ID: 1",
-		"# Original Name: API",
-		"# Type: http",
-		"# Tags: production, api",
-		`resource "hyperping_monitor"`,
-		"protocol = \"http\"",
-		"url      = \"http://api.example.com/health\"",
-	} {
-		if !strings.Contains(hcl, want) {
-			t.Errorf("HCL missing %q\n---\n%s", want, hcl)
-		}
-	}
+	got := NewTerraformGenerator("").GenerateHCL(checks, results)
+	goldenAssert(t, "monitors.tf.golden", got)
 }
 
 func TestGenerateHCL_Unsupported(t *testing.T) {

--- a/cmd/migrate-pingdom/generator/terraform_test.go
+++ b/cmd/migrate-pingdom/generator/terraform_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 func intPtr(n int) *int    { return &n }
@@ -46,12 +47,17 @@ func TestTerraformName(t *testing.T) {
 	}
 }
 
+// The local escapeHCL helper that this test originally covered was removed
+// in PR #138 (sec: HCL injection hardening) in favour of the shared
+// migrate.EscapeHCL/QuoteHCL pair. The generator now calls migrate.QuoteHCL
+// directly, so we exercise that here to keep coverage on the HCL-quoting
+// path the package depends on.
 func TestEscapeHCL(t *testing.T) {
-	if got := escapeHCL(`he said "hi"`); got != `he said \"hi\"` {
-		t.Errorf("escapeHCL quotes = %q", got)
+	if got := migrate.EscapeHCL(`he said "hi"`); got != `he said \"hi\"` {
+		t.Errorf("EscapeHCL quotes = %q", got)
 	}
-	if got := escapeHCL("a\\b"); got != `a\\b` {
-		t.Errorf("escapeHCL backslash = %q", got)
+	if got := migrate.EscapeHCL("a\\b"); got != `a\\b` {
+		t.Errorf("EscapeHCL backslash = %q", got)
 	}
 }
 
@@ -108,13 +114,12 @@ func TestBuildOptionalHelpers(t *testing.T) {
 		{"body nil omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{}, ""},
 		{"body empty omitted", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr("")}, ""},
 		{"body emitted (ASCII-safe)", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr("hello")}, "  request_body = \"hello\"\n"},
-		// TODO: pinning the current double-escape behaviour. terraform.go formats
-		// already-escaped strings with %q, which escapes them a second time. For input
-		// {"a":1}, the runtime output is `"{\\\"a\\\":1}"` (3 backslashes before each
-		// quote) instead of the HCL-correct `"{\"a\":1}"`. When the bug is fixed (drop
-		// %q in favour of QuoteHCL, or stop pre-escaping), this expectation becomes
-		// "  request_body = \"{\\\"a\\\":1}\"\n" — see the PR body for context.
-		{"body emitted (current double-escape)", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr(`{"a":1}`)}, "  request_body = \"{\\\\\\\"a\\\\\\\":1}\"\n"},
+		// The earlier double-escape bug (terraform.go formatting an already-escaped
+		// string with %q) was fixed in PR #138, which switched the generator to
+		// migrate.QuoteHCL. For input {"a":1} the correct HCL output is
+		// `"{\"a\":1}"` (1 backslash before each quote), encoded here as the
+		// Go literal "  request_body = \"{\\\"a\\\":1}\"\n".
+		{"body emitted (json escaped once)", buildOptionalRequestBody, &hyperping.CreateMonitorRequest{RequestBody: strPtr(`{"a":1}`)}, "  request_body = \"{\\\"a\\\":1}\"\n"},
 
 		{"paused false omitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{}, ""},
 		{"paused true emitted", buildOptionalPaused, &hyperping.CreateMonitorRequest{Paused: true}, "  paused = true\n"},

--- a/cmd/migrate-pingdom/generator/testdata/import.sh.golden
+++ b/cmd/migrate-pingdom/generator/testdata/import.sh.golden
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Generated Terraform import script for Pingdom -> Hyperping migration
+# Run this after applying the Terraform configuration
+
+set -e
+
+echo "Importing Hyperping resources into Terraform state..."
+echo ""
+
+# Pingdom Check 1: API
+echo "Importing hyperping_monitor.api_api..."
+terraform import hyperping_monitor.api_api "mon_aaaa" || echo "Warning: Import failed for api_api"
+echo ""
+
+# Skipping Pingdom Check 3 (not yet created in Hyperping)
+echo "Import complete! Imported 1 resources."
+echo "Run 'terraform plan' to verify the state matches your configuration."

--- a/cmd/migrate-pingdom/generator/testdata/monitors.tf.golden
+++ b/cmd/migrate-pingdom/generator/testdata/monitors.tf.golden
@@ -1,0 +1,33 @@
+# Generated from Pingdom export
+# Review and adjust as needed before applying
+
+# Pingdom Check ID: 1
+# Original Name: API Health
+# Type: https
+# Tags: production, api
+resource "hyperping_monitor" "api_apihealth" {
+  name     = "[PROD]-API-ApiHealth"
+  url      = "https://api.example.com/health"
+  protocol = "http"
+  check_frequency = 300
+  regions = ["virginia", "london", "frankfurt", "singapore"]
+}
+
+# Pingdom Check ID: 2
+# Original Name: Database
+# Type: tcp
+# Tags: production, database
+resource "hyperping_monitor" "database_database" {
+  name     = "[PROD]-Database-Database"
+  url      = "db.example.com"
+  protocol = "port"
+  regions = ["virginia", "london", "frankfurt", "singapore"]
+  port = 5432
+}
+
+# Pingdom Check ID: 3
+# Original Name: DNS Lookup
+# Type: dns
+# UNSUPPORTED: dns
+# NOTE: DNS checks not directly supported. Consider using HTTP check to DNS-over-HTTPS service or monitor the service that relies on DNS
+

--- a/cmd/migrate-pingdom/pingdom/client_test.go
+++ b/cmd/migrate-pingdom/pingdom/client_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package pingdom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient("token")
+	if c.apiToken != "token" {
+		t.Errorf("apiToken = %q, want token", c.apiToken)
+	}
+	if c.baseURL != defaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", c.baseURL, defaultBaseURL)
+	}
+	if c.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+	if c.httpClient.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want 30s", c.httpClient.Timeout)
+	}
+}
+
+func TestNewClient_WithOptions(t *testing.T) {
+	custom := &http.Client{Timeout: 5 * time.Second}
+	c := NewClient("token",
+		WithBaseURL("https://example.test/api"),
+		WithHTTPClient(custom),
+	)
+	if c.baseURL != "https://example.test/api" {
+		t.Errorf("baseURL = %q", c.baseURL)
+	}
+	if c.httpClient != custom {
+		t.Error("WithHTTPClient did not set custom client")
+	}
+}
+
+func TestListChecks_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/checks" {
+			t.Errorf("path = %s, want /checks", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer my-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"checks":[{"id":1,"name":"a","type":"http","hostname":"a.example.com"},{"id":2,"name":"b","type":"tcp","hostname":"b.example.com","port":5432}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("my-token", WithBaseURL(srv.URL))
+	checks, err := c.ListChecks(context.Background())
+	if err != nil {
+		t.Fatalf("ListChecks error = %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("got %d checks, want 2", len(checks))
+	}
+	if checks[0].Name != "a" || checks[1].Port != 5432 {
+		t.Errorf("unexpected checks: %#v", checks)
+	}
+}
+
+func TestListChecks_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient("bad", WithBaseURL(srv.URL)).ListChecks(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "API error (status 401)") {
+		t.Errorf("error = %v, want status 401", err)
+	}
+}
+
+func TestListChecks_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient("t", WithBaseURL(srv.URL)).ListChecks(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing response") {
+		t.Errorf("error = %v, want parse error", err)
+	}
+}
+
+func TestListChecks_NetworkError(t *testing.T) {
+	c := NewClient("t", WithBaseURL("http://127.0.0.1:0"))
+	_, err := c.ListChecks(context.Background())
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	if !strings.Contains(err.Error(), "executing request") {
+		t.Errorf("error = %v, want executing request", err)
+	}
+}
+
+func TestListChecks_BadBaseURL(t *testing.T) {
+	c := NewClient("t", WithBaseURL("://invalid"))
+	_, err := c.ListChecks(context.Background())
+	if err == nil {
+		t.Fatal("expected error from invalid URL")
+	}
+	if !strings.Contains(err.Error(), "creating request") {
+		t.Errorf("error = %v, want creating request", err)
+	}
+}
+
+func TestGetCheck_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/checks/42" {
+			t.Errorf("path = %s, want /checks/42", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"check":{"id":42,"name":"detail","type":"http","hostname":"x.example.com"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	check, err := c.GetCheck(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetCheck error = %v", err)
+	}
+	if check.ID != 42 || check.Name != "detail" {
+		t.Errorf("unexpected check: %#v", check)
+	}
+}
+
+func TestGetCheck_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`not found`))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient("t", WithBaseURL(srv.URL)).GetCheck(context.Background(), 1)
+	if err == nil || !strings.Contains(err.Error(), "API error (status 404)") {
+		t.Errorf("error = %v, want 404 error", err)
+	}
+}
+
+func TestGetCheck_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{`))
+	}))
+	defer srv.Close()
+	_, err := NewClient("t", WithBaseURL(srv.URL)).GetCheck(context.Background(), 1)
+	if err == nil || !strings.Contains(err.Error(), "parsing response") {
+		t.Errorf("error = %v, want parsing response error", err)
+	}
+}
+
+func TestGetCheck_BadBaseURL(t *testing.T) {
+	c := NewClient("t", WithBaseURL("://invalid"))
+	_, err := c.GetCheck(context.Background(), 1)
+	if err == nil || !strings.Contains(err.Error(), "creating request") {
+		t.Errorf("error = %v, want creating request", err)
+	}
+}
+
+func TestGetCheck_NetworkError(t *testing.T) {
+	c := NewClient("t", WithBaseURL("http://127.0.0.1:0"))
+	_, err := c.GetCheck(context.Background(), 1)
+	if err == nil || !strings.Contains(err.Error(), "executing request") {
+		t.Errorf("error = %v, want executing request error", err)
+	}
+}

--- a/cmd/migrate-pingdom/pingdom/client_test.go
+++ b/cmd/migrate-pingdom/pingdom/client_test.go
@@ -5,6 +5,7 @@ package pingdom
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -56,6 +57,14 @@ func TestListChecks_Success(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Errorf("Content-Type = %q", got)
 		}
+		// ListChecks is a GET; body must be empty (we pass http.NoBody).
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		if len(body) != 0 {
+			t.Errorf("request body = %q, want empty", body)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"checks":[{"id":1,"name":"a","type":"http","hostname":"a.example.com"},{"id":2,"name":"b","type":"tcp","hostname":"b.example.com","port":5432}]}`))
 	}))
@@ -106,7 +115,14 @@ func TestListChecks_BadJSON(t *testing.T) {
 }
 
 func TestListChecks_NetworkError(t *testing.T) {
-	c := NewClient("t", WithBaseURL("http://127.0.0.1:0"))
+	// Stand up a server, capture its URL, then close it. The URL is now a
+	// well-formed but unreachable address, so http.Do fails at dial time.
+	// This is more portable than relying on port 0 semantics.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := srv.URL
+	srv.Close()
+
+	c := NewClient("t", WithBaseURL(deadURL))
 	_, err := c.ListChecks(context.Background())
 	if err == nil {
 		t.Fatal("expected network error")
@@ -179,7 +195,11 @@ func TestGetCheck_BadBaseURL(t *testing.T) {
 }
 
 func TestGetCheck_NetworkError(t *testing.T) {
-	c := NewClient("t", WithBaseURL("http://127.0.0.1:0"))
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := srv.URL
+	srv.Close()
+
+	c := NewClient("t", WithBaseURL(deadURL))
 	_, err := c.GetCheck(context.Background(), 1)
 	if err == nil || !strings.Contains(err.Error(), "executing request") {
 		t.Errorf("error = %v, want executing request error", err)

--- a/cmd/migrate-pingdom/report/reporter_test.go
+++ b/cmd/migrate-pingdom/report/reporter_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package report
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+func sampleInputs() ([]pingdom.Check, []converter.ConversionResult) {
+	checks := []pingdom.Check{
+		{ID: 1, Name: "API", Type: "http", Hostname: "api.example.com", Tags: []pingdom.Tag{{Name: "production"}, {Name: "api"}}},
+		{ID: 2, Name: "DNS", Type: "dns", Hostname: "example.com"},
+		{ID: 3, Name: "UDP", Type: "udp", Hostname: "u.example.com"},
+		{ID: 4, Name: "TX", Type: "transaction", Hostname: "x.example.com"},
+		{ID: 5, Name: "Mail", Type: "smtp", Hostname: "mail.example.com"},
+		{ID: 6, Name: "Mystery", Type: "weirdo", Hostname: "x"},
+	}
+	conv := converter.NewCheckConverter()
+	results := make([]converter.ConversionResult, len(checks))
+	for i, c := range checks {
+		results[i] = conv.Convert(c)
+	}
+	return checks, results
+}
+
+func TestGenerateReport_Counts(t *testing.T) {
+	checks, results := sampleInputs()
+
+	r := NewReporter().GenerateReport(checks, results)
+
+	if r.TotalChecks != 6 {
+		t.Errorf("TotalChecks = %d, want 6", r.TotalChecks)
+	}
+	if r.SupportedChecks != 2 { // http + smtp
+		t.Errorf("SupportedChecks = %d, want 2", r.SupportedChecks)
+	}
+	if r.UnsupportedChecks != 4 {
+		t.Errorf("UnsupportedChecks = %d, want 4", r.UnsupportedChecks)
+	}
+	if r.ChecksByType["http"] != 1 || r.ChecksByType["dns"] != 1 || r.ChecksByType["smtp"] != 1 {
+		t.Errorf("ChecksByType = %v", r.ChecksByType)
+	}
+	if r.UnsupportedTypes["dns"] != 1 || r.UnsupportedTypes["udp"] != 1 || r.UnsupportedTypes["transaction"] != 1 || r.UnsupportedTypes["weirdo"] != 1 {
+		t.Errorf("UnsupportedTypes = %v", r.UnsupportedTypes)
+	}
+	if len(r.ManualSteps) != 4 {
+		t.Errorf("ManualSteps = %d, want 4", len(r.ManualSteps))
+	}
+	// SMTP supported with notes -> warning expected
+	if len(r.Warnings) == 0 {
+		t.Error("expected at least one warning for SMTP note")
+	}
+}
+
+func TestGenerateManualStep_ByType(t *testing.T) {
+	cases := []struct {
+		checkType    string
+		descContains string
+		actContains  string
+	}{
+		{"dns", "DNS checks are not directly supported", "DNS-over-HTTPS"},
+		{"udp", "UDP checks are not supported", "TCP alternative"},
+		{"transaction", "Transaction/browser checks", "Playwright/Selenium"},
+		{"weirdo", "is not supported", "Manual review"},
+	}
+	r := NewReporter()
+	for _, tt := range cases {
+		t.Run(tt.checkType, func(t *testing.T) {
+			step := r.generateManualStep(
+				pingdom.Check{ID: 1, Name: "x", Type: tt.checkType},
+				converter.ConversionResult{},
+			)
+			if !strings.Contains(step.Description, tt.descContains) {
+				t.Errorf("Description = %q, want substring %q", step.Description, tt.descContains)
+			}
+			if !strings.Contains(step.Action, tt.actContains) {
+				t.Errorf("Action = %q, want substring %q", step.Action, tt.actContains)
+			}
+		})
+	}
+}
+
+func TestGenerateJSONReport_RoundTrip(t *testing.T) {
+	checks, results := sampleInputs()
+	rep := NewReporter()
+	report := rep.GenerateReport(checks, results)
+
+	out, err := rep.GenerateJSONReport(report)
+	if err != nil {
+		t.Fatalf("GenerateJSONReport error: %v", err)
+	}
+
+	var got MigrationReport
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.TotalChecks != report.TotalChecks {
+		t.Errorf("TotalChecks roundtrip: got %d, want %d", got.TotalChecks, report.TotalChecks)
+	}
+	if len(got.ManualSteps) != len(report.ManualSteps) {
+		t.Errorf("ManualSteps roundtrip: got %d, want %d", len(got.ManualSteps), len(report.ManualSteps))
+	}
+}
+
+func TestGenerateTextReport_Sections(t *testing.T) {
+	checks, results := sampleInputs()
+	rep := NewReporter()
+	report := rep.GenerateReport(checks, results)
+
+	out := rep.GenerateTextReport(report)
+	for _, want := range []string{
+		"Pingdom to Hyperping Migration Report",
+		"Total Checks:",
+		"Checks by Type",
+		"Unsupported Check Types",
+		"Warnings",
+		"Manual Steps Required",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text report missing %q", want)
+		}
+	}
+}
+
+func TestGenerateTextReport_NoWarningsNoSteps(t *testing.T) {
+	checks := []pingdom.Check{
+		{ID: 1, Name: "Plain HTTP", Type: "http", Hostname: "h"},
+	}
+	results := []converter.ConversionResult{
+		converter.NewCheckConverter().Convert(checks[0]),
+	}
+	rep := NewReporter()
+	report := rep.GenerateReport(checks, results)
+
+	out := rep.GenerateTextReport(report)
+	if strings.Contains(out, "Warnings\n--------") {
+		t.Error("did not expect Warnings section")
+	}
+	if strings.Contains(out, "Manual Steps Required") {
+		t.Error("did not expect Manual Steps section")
+	}
+}
+
+func TestGenerateManualStepsMarkdown_Empty(t *testing.T) {
+	out := NewReporter().GenerateManualStepsMarkdown(&MigrationReport{})
+	if !strings.Contains(out, "No manual steps required") {
+		t.Errorf("expected empty-state message, got:\n%s", out)
+	}
+}
+
+func TestGenerateManualStepsMarkdown_WithSteps(t *testing.T) {
+	checks, results := sampleInputs()
+	rep := NewReporter()
+	report := rep.GenerateReport(checks, results)
+
+	out := rep.GenerateManualStepsMarkdown(report)
+	for _, want := range []string{
+		"# Manual Migration Steps",
+		"## 1.",
+		"**Type:**",
+		"**Issue:**",
+		"**Action Required:**",
+		"## Additional Resources",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit tests for every non-main subpackage under `cmd/migrate-pingdom`. The package was at 0.0% across the board; this brings every non-main subpackage well above the 70% target laid out in `BACKLOG.md` (TF-02). No production code changes; tests pass against the existing tool behaviour.

## Coverage (verified locally with `go tool cover -func=...`)

| Subpackage                        | Before | After  |
| --------------------------------- | ------ | ------ |
| `cmd/migrate-pingdom/converter`   | 0.0%   | 100.0% |
| `cmd/migrate-pingdom/generator`   | 0.0%   | 100.0% |
| `cmd/migrate-pingdom/pingdom`     | 0.0%   | 95.6%  |
| `cmd/migrate-pingdom/report`      | 0.0%   | 98.9%  |
| `cmd/migrate-pingdom` (main)      | 0.0%   | 0.0%   |

The `main` package itself stays at 0%: it is mostly interactive-wizard orchestration and CLI flag wiring, exercised by the existing `//go:build integration` tests in `cmd/migrate-pingdom/integration_test.go`. Pulling it under unit-test coverage would require introducing prompter/IO seams in production code, which is out of scope for a tests-only PR.

## What's covered

- **`converter`** -- HCL conversion dispatch (http/https/tcp/ping/smtp/pop3/imap/dns/udp/transaction/unknown), HTTP field mapping (POST body, redirects, expected status, keyword), port defaults for SMTP/POP3/IMAP/TCP, frequency mapping to Hyperping's allowed list, region-filter expansion (NA/EU/APAC/LATAM, dedup, fallback), name/tag generation (env, category, customer, tenant, sanitisation, length cap).
- **`generator`** -- HCL emission for supported and unsupported checks, prefix application, every `buildOptional*` helper, `terraformName` edge cases (brackets, leading digits, special chars), `formatStringList`, and the import-script generator (shape, prefix, skip-uncreated, skip-unsupported, count summary).
- **`pingdom`** -- `NewClient` defaults and options, `ListChecks` and `GetCheck` happy path plus error paths (HTTP error, malformed JSON, network error, malformed base URL) using `httptest`.
- **`report`** -- counts/by-type/by-unsupported aggregation, manual-step messages per unsupported type, JSON round-trip, text-report sections (presence and conditional omission), markdown empty state and full output.

## Note for reviewer: pre-existing double-escape in HCL emission

While writing the generator tests I noticed `cmd/migrate-pingdom/generator/terraform.go` formats already-escaped strings with `%q`, e.g.:

    fmt.Fprintf(sb, \"  request_body = %q\\n\", escapeHCL(*monitor.RequestBody))

`escapeHCL` already escapes backslashes and quotes, then `%q` escapes them again. For ASCII-only inputs the output is correct, but a request body or header value containing a `\"` will end up emitted as `\\\\\\\"` in HCL. The same pattern is used for `name`, `url`, `required_keyword`, and request-header `name`/`value`. I did not fix it here because TF-02 is a tests-only PR; one of the new test cases (`buildOptionalRequestBody`/`body emitted`) pins the current behaviour and includes a comment flagging it. Happy to file this separately as a follow-up bug.

## Test plan

- [x] `go test ./cmd/migrate-pingdom/... -race -count=1` passes
- [x] `go test ./cmd/migrate-pingdom/... -coverprofile=cov.out && go tool cover -func=cov.out` shows >=70% for every non-main subpackage
- [x] `go vet ./cmd/migrate-pingdom/...` clean
- [ ] CI green