### PR TITLE
test: raise cmd/migrate-uptimerobot coverage to 70%+

### DIFF
--- a/cmd/migrate-uptimerobot/converter/contacts_test.go
+++ b/cmd/migrate-uptimerobot/converter/contacts_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package converter
+
+import (
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/uptimerobot"
+)
+
+func TestCategorizeAlertContacts(t *testing.T) {
+	contacts := []uptimerobot.AlertContact{
+		{ID: "1", Type: 2, Value: "a@example.com", FriendlyName: "Alice"},
+		{ID: "2", Type: 3, Value: "+15555555555", FriendlyName: "Phone"},
+		{ID: "3", Type: 4, Value: "https://hook.example.com", FriendlyName: "Hook"},
+		{ID: "4", Type: 11, FriendlyName: "Slack #ops"},
+		{ID: "5", Type: 14, FriendlyName: "PagerDuty Primary"},
+		{ID: "6", Type: 99, FriendlyName: "Some Other"},
+	}
+
+	got := CategorizeAlertContacts(contacts)
+
+	if len(got.Emails) != 1 || got.Emails[0] != "a@example.com" {
+		t.Errorf("Emails = %v, want [a@example.com]", got.Emails)
+	}
+	if len(got.SMSPhones) != 1 || got.SMSPhones[0] != "+15555555555" {
+		t.Errorf("SMSPhones = %v", got.SMSPhones)
+	}
+	if len(got.Webhooks) != 1 || got.Webhooks[0] != "https://hook.example.com" {
+		t.Errorf("Webhooks = %v", got.Webhooks)
+	}
+	if len(got.Slack) != 1 || got.Slack[0] != "Slack #ops" {
+		t.Errorf("Slack = %v", got.Slack)
+	}
+	if len(got.PagerDuty) != 1 || got.PagerDuty[0] != "PagerDuty Primary" {
+		t.Errorf("PagerDuty = %v", got.PagerDuty)
+	}
+	if len(got.Other) != 1 || got.Other[0] != "Some Other" {
+		t.Errorf("Other = %v", got.Other)
+	}
+}
+
+func TestCategorizeAlertContacts_Empty(t *testing.T) {
+	got := CategorizeAlertContacts(nil)
+	if got == nil {
+		t.Fatal("got nil, want non-nil empty struct")
+	}
+	if len(got.Emails) != 0 || len(got.SMSPhones) != 0 || len(got.Webhooks) != 0 ||
+		len(got.Slack) != 0 || len(got.PagerDuty) != 0 || len(got.Other) != 0 {
+		t.Errorf("expected all empty slices, got %+v", got)
+	}
+}
+
+func TestGetAlertContactTypeName(t *testing.T) {
+	// Slice rather than map for deterministic subtest order under -shuffle.
+	cases := []struct {
+		typeID int
+		want   string
+	}{
+		{2, "Email"},
+		{3, "SMS"},
+		{4, "Webhook"},
+		{5, "Twitter"},
+		{6, "Boxcar"},
+		{7, "Web-Hook"},
+		{8, "Pushbullet"},
+		{9, "Zapier"},
+		{10, "Pushover"},
+		{11, "Slack"},
+		{12, "HipChat"},
+		{13, "Google Hangouts Chat"},
+		{14, "PagerDuty"},
+		{15, "Opsgenie"},
+		{16, "VictorOps"},
+		{17, "Microsoft Teams"},
+		{0, "Unknown"},
+		{999, "Unknown"},
+	}
+	for _, tc := range cases {
+		if got := GetAlertContactTypeName(tc.typeID); got != tc.want {
+			t.Errorf("GetAlertContactTypeName(%d) = %q, want %q", tc.typeID, got, tc.want)
+		}
+	}
+}

--- a/cmd/migrate-uptimerobot/converter/monitor_test.go
+++ b/cmd/migrate-uptimerobot/converter/monitor_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/uptimerobot"
+)
+
+func flexInt(n int) *uptimerobot.FlexibleInt {
+	v := uptimerobot.FlexibleInt(n)
+	return &v
+}
+
+func strPtr(s string) *string { return &s }
+
+// TestConvert_DispatchByType walks every type the switch handles and checks the
+// branch lands in the right output bucket (Monitors vs Healthchecks vs Skipped)
+// with the right protocol where applicable.
+func TestConvert_DispatchByType(t *testing.T) {
+	tests := []struct {
+		name           string
+		monitorType    int
+		wantMonitors   int
+		wantHealthchks int
+		wantSkipped    int
+		wantProtocol   string
+	}{
+		{"http", 1, 1, 0, 0, "http"},
+		{"keyword", 2, 1, 0, 0, "http"},
+		{"ping", 3, 1, 0, 0, "icmp"},
+		{"port", 4, 1, 0, 0, "port"},
+		{"heartbeat", 5, 0, 1, 0, ""},
+		{"unsupported", 99, 0, 0, 1, ""},
+	}
+	c := NewConverter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := c.Convert([]uptimerobot.Monitor{
+				{ID: 1, FriendlyName: "x", URL: "https://x.example.com", Type: tt.monitorType, Interval: 60},
+			}, nil)
+			if got := len(r.Monitors); got != tt.wantMonitors {
+				t.Errorf("Monitors = %d, want %d", got, tt.wantMonitors)
+			}
+			if got := len(r.Healthchecks); got != tt.wantHealthchks {
+				t.Errorf("Healthchecks = %d, want %d", got, tt.wantHealthchks)
+			}
+			if got := len(r.Skipped); got != tt.wantSkipped {
+				t.Errorf("Skipped = %d, want %d", got, tt.wantSkipped)
+			}
+			if tt.wantProtocol != "" && r.Monitors[0].Protocol != tt.wantProtocol {
+				t.Errorf("Protocol = %q, want %q", r.Monitors[0].Protocol, tt.wantProtocol)
+			}
+			if tt.monitorType == 99 {
+				if !strings.Contains(r.Skipped[0].Reason, "unsupported monitor type") {
+					t.Errorf("Skipped reason = %q", r.Skipped[0].Reason)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertHTTPMonitor_Fields(t *testing.T) {
+	c := NewConverter()
+	r := c.Convert([]uptimerobot.Monitor{
+		{
+			ID:           7,
+			FriendlyName: "Health Check",
+			URL:          "https://api.example.com/health",
+			Type:         1,
+			HTTPMethod:   flexInt(2), // POST
+			Interval:     300,
+		},
+	}, nil)
+	if len(r.Monitors) != 1 {
+		t.Fatalf("got %d monitors, want 1", len(r.Monitors))
+	}
+	m := r.Monitors[0]
+	if m.HTTPMethod != "POST" {
+		t.Errorf("HTTPMethod = %q, want POST", m.HTTPMethod)
+	}
+	if m.CheckFrequency != 300 {
+		t.Errorf("CheckFrequency = %d, want 300", m.CheckFrequency)
+	}
+	if m.ExpectedStatusCode != "2xx" {
+		t.Errorf("ExpectedStatusCode = %q, want 2xx", m.ExpectedStatusCode)
+	}
+	if !m.FollowRedirects {
+		t.Error("FollowRedirects = false, want true (default)")
+	}
+	if m.OriginalID != 7 {
+		t.Errorf("OriginalID = %d, want 7", m.OriginalID)
+	}
+	if len(m.Warnings) != 0 {
+		t.Errorf("expected no warnings for matching frequency, got %v", m.Warnings)
+	}
+}
+
+func TestConvertHTTPMonitor_FrequencyAdjustedWarning(t *testing.T) {
+	c := NewConverter()
+	r := c.Convert([]uptimerobot.Monitor{
+		{ID: 1, FriendlyName: "X", URL: "https://x.example.com", Type: 1, Interval: 45},
+	}, nil)
+	if len(r.Monitors) != 1 {
+		t.Fatalf("monitors = %d", len(r.Monitors))
+	}
+	m := r.Monitors[0]
+	// 45s rounds to 30 (closest in AllowedFrequencies). A warning must fire.
+	if len(m.Warnings) == 0 {
+		t.Error("expected frequency-adjusted warning")
+	}
+}
+
+func TestConvertKeywordMonitor_ExistsVsNotExists(t *testing.T) {
+	tests := []struct {
+		name        string
+		keywordType *uptimerobot.FlexibleInt
+		keywordVal  *string
+		wantKeyword string
+		wantWarn    bool
+	}{
+		{
+			name:        "exists supported",
+			keywordType: flexInt(1),
+			keywordVal:  strPtr("ok"),
+			wantKeyword: "ok",
+			wantWarn:    false,
+		},
+		{
+			name:        "not-exists warns and drops keyword",
+			keywordType: flexInt(2),
+			keywordVal:  strPtr("error"),
+			wantKeyword: "",
+			wantWarn:    true,
+		},
+		{
+			name:        "no value, no keyword",
+			keywordType: flexInt(1),
+			keywordVal:  nil,
+			wantKeyword: "",
+			wantWarn:    false,
+		},
+		{
+			name:        "empty value treated as missing",
+			keywordType: flexInt(1),
+			keywordVal:  strPtr(""),
+			wantKeyword: "",
+			wantWarn:    false,
+		},
+	}
+	c := NewConverter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := c.Convert([]uptimerobot.Monitor{
+				{
+					ID: 1, FriendlyName: "K", URL: "https://k.example.com", Type: 2, Interval: 60,
+					KeywordType:  tt.keywordType,
+					KeywordValue: tt.keywordVal,
+				},
+			}, nil)
+			m := r.Monitors[0]
+			if m.RequiredKeyword != tt.wantKeyword {
+				t.Errorf("RequiredKeyword = %q, want %q", m.RequiredKeyword, tt.wantKeyword)
+			}
+			hasWarn := false
+			for _, w := range m.Warnings {
+				if strings.Contains(w, "must not exist") {
+					hasWarn = true
+				}
+			}
+			if hasWarn != tt.wantWarn {
+				t.Errorf("must-not-exist warning = %v, want %v (warnings: %v)", hasWarn, tt.wantWarn, m.Warnings)
+			}
+		})
+	}
+}
+
+func TestConvertPingMonitor_AddsScheme(t *testing.T) {
+	c := NewConverter()
+	r := c.Convert([]uptimerobot.Monitor{
+		{ID: 1, FriendlyName: "P", URL: "host.example.com", Type: 3, Interval: 60},
+	}, nil)
+	m := r.Monitors[0]
+	if m.Protocol != "icmp" {
+		t.Errorf("Protocol = %q, want icmp", m.Protocol)
+	}
+	if !strings.HasPrefix(m.URL, "https://") {
+		t.Errorf("URL = %q, expected scheme prefix", m.URL)
+	}
+}
+
+func TestConvertPortMonitor_PortResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		port     *uptimerobot.FlexibleInt
+		subType  *uptimerobot.FlexibleInt
+		wantPort int
+	}{
+		{"explicit port wins", flexInt(8080), flexInt(3 /* HTTPS */), 8080},
+		{"sub-type HTTPS = 443", nil, flexInt(3), 443},
+		{"sub-type HTTP = 80", nil, flexInt(2), 80},
+		{"sub-type FTP = 21", nil, flexInt(4), 21},
+		{"sub-type SMTP = 25", nil, flexInt(5), 25},
+		{"sub-type POP3 = 110", nil, flexInt(6), 110},
+		{"sub-type IMAP = 143", nil, flexInt(7), 143},
+		{"sub-type unknown = 80", nil, flexInt(99), 80},
+		{"no port no sub-type = 80", nil, nil, 80},
+	}
+	c := NewConverter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := c.Convert([]uptimerobot.Monitor{
+				{
+					ID: 1, FriendlyName: "PortMon", URL: "host.example.com", Type: 4, Interval: 60,
+					Port: tt.port, SubType: tt.subType,
+				},
+			}, nil)
+			if got := r.Monitors[0].Port; got != tt.wantPort {
+				t.Errorf("Port = %d, want %d", got, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestConvertHeartbeatMonitor_PeriodMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		intervalSec int
+		wantValue   int
+		wantType    string
+	}{
+		{"days", 172800, 2, "days"},
+		{"hours", 7200, 2, "hours"},
+		{"minutes", 600, 10, "minutes"},
+		{"seconds fallback", 30, 30, "seconds"},
+		{"exactly 1 day", 86400, 1, "days"},
+		{"exactly 1 hour", 3600, 1, "hours"},
+		{"exactly 1 minute", 60, 1, "minutes"},
+	}
+	c := NewConverter()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := c.Convert([]uptimerobot.Monitor{
+				{ID: 1, FriendlyName: "HB", Type: 5, Interval: tt.intervalSec},
+			}, nil)
+			if len(r.Healthchecks) != 1 {
+				t.Fatalf("Healthchecks = %d", len(r.Healthchecks))
+			}
+			h := r.Healthchecks[0]
+			if h.PeriodValue != tt.wantValue || h.PeriodType != tt.wantType {
+				t.Errorf("Period = %d %s, want %d %s", h.PeriodValue, h.PeriodType, tt.wantValue, tt.wantType)
+			}
+			if h.GracePeriodValue != 1 || h.GracePeriodType != "hours" {
+				t.Errorf("Grace = %d %s, want 1 hours", h.GracePeriodValue, h.GracePeriodType)
+			}
+			if len(h.Warnings) == 0 {
+				t.Error("expected note warning on heartbeat conversion")
+			}
+		})
+	}
+}
+
+func TestConvert_ContactsMapPopulated(t *testing.T) {
+	c := NewConverter()
+	r := c.Convert(nil, []uptimerobot.AlertContact{
+		{ID: "1", Type: 2, Value: "a@example.com"},
+		{ID: "1", Type: 2, Value: "b@example.com"},
+		{ID: "2", Type: 4, Value: "https://hook"},
+	})
+	if got := len(r.ContactsMap["1"]); got != 2 {
+		t.Errorf("ContactsMap[1] len = %d, want 2", got)
+	}
+	if got := len(r.ContactsMap["2"]); got != 1 {
+		t.Errorf("ContactsMap[2] len = %d, want 1", got)
+	}
+}
+
+func TestConvert_ResourceNameDeduplication(t *testing.T) {
+	c := NewConverter()
+	r := c.Convert([]uptimerobot.Monitor{
+		{ID: 1, FriendlyName: "Same Name", URL: "https://a.example.com", Type: 1, Interval: 60},
+		{ID: 2, FriendlyName: "Same Name", URL: "https://b.example.com", Type: 1, Interval: 60},
+		{ID: 3, FriendlyName: "Same Name", URL: "https://c.example.com", Type: 1, Interval: 60},
+	}, nil)
+	if len(r.Monitors) != 3 {
+		t.Fatalf("got %d", len(r.Monitors))
+	}
+	seen := map[string]bool{}
+	for _, m := range r.Monitors {
+		if seen[m.ResourceName] {
+			t.Errorf("duplicate ResourceName: %s", m.ResourceName)
+		}
+		seen[m.ResourceName] = true
+	}
+}
+
+func TestConvertHTTPMethod(t *testing.T) {
+	tests := []struct {
+		method *uptimerobot.FlexibleInt
+		want   string
+	}{
+		{nil, "GET"},
+		{flexInt(1), "GET"},
+		{flexInt(2), "POST"},
+		{flexInt(3), "PUT"},
+		{flexInt(4), "PATCH"},
+		{flexInt(5), "DELETE"},
+		{flexInt(6), "HEAD"},
+		{flexInt(99), "GET"}, // unknown falls back to GET
+	}
+	for _, tt := range tests {
+		got := convertHTTPMethod(tt.method)
+		if got != tt.want {
+			t.Errorf("convertHTTPMethod(%v) = %q, want %q", tt.method, got, tt.want)
+		}
+	}
+}
+
+func TestMapSubTypeToPort(t *testing.T) {
+	cases := map[int]int{1: 80, 2: 80, 3: 443, 4: 21, 5: 25, 6: 110, 7: 143, 999: 80}
+	for in, want := range cases {
+		if got := mapSubTypeToPort(in); got != want {
+			t.Errorf("mapSubTypeToPort(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestTerraformName_DigitPrefix(t *testing.T) {
+	// Property: digit-leading names get the "r_" prefix.
+	got := terraformName("123abc")
+	if !strings.HasPrefix(got, "r_") {
+		t.Errorf("terraformName(\"123abc\") = %q, want r_ prefix", got)
+	}
+}
+
+func TestTerraformName_EmptyFallback(t *testing.T) {
+	got := terraformName("!!!")
+	if got != "monitor" {
+		t.Errorf("terraformName(\"!!!\") = %q, want \"monitor\"", got)
+	}
+}
+
+func TestEnsureURLScheme(t *testing.T) {
+	if got := ensureURLScheme("example.com"); !strings.HasPrefix(got, "https://") {
+		t.Errorf("expected scheme prefix, got %q", got)
+	}
+	if got := ensureURLScheme("http://example.com"); got != "http://example.com" {
+		t.Errorf("scheme should be preserved, got %q", got)
+	}
+}
+
+func TestMapFrequency_DelegatesToPkg(t *testing.T) {
+	// Sanity: 60 is in the allowed list, so this must round-trip exactly.
+	if got := mapFrequency(60); got != 60 {
+		t.Errorf("mapFrequency(60) = %d, want 60", got)
+	}
+}

--- a/cmd/migrate-uptimerobot/generator/helpers_test.go
+++ b/cmd/migrate-uptimerobot/generator/helpers_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var updateGolden = flag.Bool("update-golden", false, "rewrite testdata/*.golden files with current output")
+
+// goldenAssert compares got to the contents of testdata/<name>. With
+// -update-golden, the file is rewritten instead. testdata/ is created on
+// demand so a deleted golden regenerates rather than failing in a confusing way.
+func goldenAssert(t *testing.T, name, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil { //nolint:gosec // testdata only
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (run: go test ./cmd/migrate-uptimerobot/generator -update-golden)", path, err)
+	}
+	if got != string(want) {
+		t.Errorf("output does not match %s\nrun -update-golden after intentional changes\n--- got ---\n%s\n--- want ---\n%s", name, got, string(want))
+	}
+}

--- a/cmd/migrate-uptimerobot/generator/import_test.go
+++ b/cmd/migrate-uptimerobot/generator/import_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+)
+
+func TestGenerateImportScript_Golden(t *testing.T) {
+	got := GenerateImportScript(goldenResult())
+	goldenAssert(t, "import.sh.golden", got)
+}
+
+func TestGenerateImportScript_NoResources(t *testing.T) {
+	got := GenerateImportScript(&converter.ConversionResult{})
+	for _, want := range []string{
+		"#!/bin/bash",
+		"set -e",
+		"Total resources to import: 0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("empty script missing %q", want)
+		}
+	}
+	if strings.Contains(got, "terraform import") {
+		t.Errorf("empty result should not produce import commands, got:\n%s", got)
+	}
+}
+
+func TestGenerateImportScript_OnlyHealthchecks(t *testing.T) {
+	r := &converter.ConversionResult{
+		Healthchecks: []converter.HyperpingHealthcheck{
+			{ResourceName: "hb", Name: "H", OriginalID: 1, PeriodValue: 1, PeriodType: "hours"},
+		},
+	}
+	got := GenerateImportScript(r)
+	if !strings.Contains(got, "terraform import 'hyperping_healthcheck.hb'") {
+		t.Errorf("expected healthcheck import line, got:\n%s", got)
+	}
+	if strings.Contains(got, "hyperping_monitor.") {
+		t.Error("monitor import lines should not appear when no monitors are present")
+	}
+}

--- a/cmd/migrate-uptimerobot/generator/manual_steps_test.go
+++ b/cmd/migrate-uptimerobot/generator/manual_steps_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/uptimerobot"
+)
+
+func TestGenerateManualSteps_FullCoverage(t *testing.T) {
+	contacts := []uptimerobot.AlertContact{
+		{Type: 2, Value: "ops@example.com"},
+		{Type: 3, Value: "+15555555555"},
+		{Type: 4, Value: "https://hook.example.com"},
+		{Type: 11, FriendlyName: "Slack #ops"},
+		{Type: 14, FriendlyName: "PagerDuty Primary"},
+	}
+	got := GenerateManualSteps(goldenResult(), contacts)
+
+	for _, want := range []string{
+		"# Manual Migration Steps",
+		"## Table of Contents",
+		"## Escalation Policy Setup",
+		"### Your UptimeRobot Alert Contacts",
+		"**Email Contacts:**",
+		"ops@example.com",
+		"**SMS Contacts:**",
+		"+15555555555",
+		"**Webhook URLs:**",
+		"https://hook.example.com",
+		"**Slack Integrations:**",
+		"Slack #ops",
+		"**PagerDuty Integrations:**",
+		"PagerDuty Primary",
+		"## Healthcheck Configuration",
+		"## Monitor Warnings",
+		"## Skipped Resources",
+		"Unsupported Foo",
+		"## Testing and Validation",
+		"## Decommissioning UptimeRobot",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing section/text %q", want)
+		}
+	}
+}
+
+func TestGenerateManualSteps_OmitsEmptySections(t *testing.T) {
+	// No healthchecks, no warnings, no skipped → those sections must be absent
+	// from the body and from the table of contents.
+	r := &converter.ConversionResult{
+		Monitors: []converter.HyperpingMonitor{
+			{ResourceName: "m", Name: "M", Protocol: "http", CheckFrequency: 60, Warnings: nil},
+		},
+	}
+	got := GenerateManualSteps(r, nil)
+
+	for _, unwanted := range []string{
+		"## Healthcheck Configuration",
+		"## Monitor Warnings",
+		"## Skipped Resources",
+		"- [Healthcheck Configuration]",
+		"- [Monitor Warnings]",
+		"- [Skipped Resources]",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("did not expect %q in output", unwanted)
+		}
+	}
+	// Sections that always appear.
+	for _, want := range []string{
+		"## Escalation Policy Setup",
+		"## Testing and Validation",
+		"## Decommissioning UptimeRobot",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected always-on section %q", want)
+		}
+	}
+}
+
+func TestGenerateManualSteps_NoAlertContactsSubsection(t *testing.T) {
+	got := GenerateManualSteps(goldenResult(), nil)
+	if strings.Contains(got, "### Your UptimeRobot Alert Contacts") {
+		t.Errorf("alert-contacts subsection should be omitted when contacts list is empty")
+	}
+}
+
+func TestHasWarnings(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *converter.ConversionResult
+		want bool
+	}{
+		{"no warnings", &converter.ConversionResult{}, false},
+		{
+			name: "monitor warning",
+			r: &converter.ConversionResult{
+				Monitors: []converter.HyperpingMonitor{{Warnings: []string{"x"}}},
+			},
+			want: true,
+		},
+		{
+			name: "healthcheck warning",
+			r: &converter.ConversionResult{
+				Healthchecks: []converter.HyperpingHealthcheck{{Warnings: []string{"y"}}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasWarnings(tt.r); got != tt.want {
+				t.Errorf("hasWarnings = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/migrate-uptimerobot/generator/terraform_test.go
+++ b/cmd/migrate-uptimerobot/generator/terraform_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+)
+
+// goldenResult is a deliberately small, deterministic conversion result that
+// touches one of every code path (monitor with warning, healthcheck with
+// warning, skipped resource). No map-iteration paths in the generator so the
+// output is stable.
+func goldenResult() *converter.ConversionResult {
+	return &converter.ConversionResult{
+		Monitors: []converter.HyperpingMonitor{
+			{
+				ResourceName:       "api_health",
+				Name:               "API Health",
+				URL:                "https://api.example.com/health",
+				Protocol:           "http",
+				HTTPMethod:         "GET",
+				CheckFrequency:     300,
+				ExpectedStatusCode: "2xx",
+				FollowRedirects:    true,
+				Regions:            []string{"london", "virginia", "singapore"},
+				OriginalID:         101,
+				Warnings:           []string{"Check frequency adjusted from 250s to 300s (nearest allowed value)"},
+			},
+			{
+				ResourceName:    "db_port",
+				Name:            "Database Port",
+				URL:             "https://db.example.com",
+				Protocol:        "port",
+				CheckFrequency:  60,
+				Port:            5432,
+				FollowRedirects: false,
+				Regions:         []string{"virginia"},
+				OriginalID:      102,
+			},
+		},
+		Healthchecks: []converter.HyperpingHealthcheck{
+			{
+				ResourceName:     "cron_heartbeat",
+				Name:             "Cron Heartbeat",
+				PeriodValue:      1,
+				PeriodType:       "hours",
+				GracePeriodValue: 1,
+				GracePeriodType:  "hours",
+				OriginalID:       201,
+				Warnings:         []string{"Heartbeat monitor converted to healthcheck. Update your script to ping the new URL (see manual-steps.md)"},
+			},
+		},
+		Skipped: []converter.SkippedMonitor{
+			{ID: 999, Name: "Unsupported Foo", Type: 99, Reason: "unsupported monitor type: 99"},
+		},
+		ContactsMap: map[string][]string{},
+	}
+}
+
+func TestGenerateTerraform_Golden(t *testing.T) {
+	got := GenerateTerraform(goldenResult())
+	goldenAssert(t, "hyperping.tf.golden", got)
+}
+
+func TestGenerateTerraform_EmptyResult(t *testing.T) {
+	got := GenerateTerraform(&converter.ConversionResult{ContactsMap: map[string][]string{}})
+
+	// Header + provider block must always be present.
+	for _, want := range []string{
+		"# Terraform configuration generated from UptimeRobot migration",
+		`terraform {`,
+		`provider "hyperping"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("empty result missing %q", want)
+		}
+	}
+	// No resources or skipped section.
+	for _, unwanted := range []string{
+		`resource "hyperping_monitor"`,
+		`resource "hyperping_healthcheck"`,
+		"# Skipped Resources",
+		"# Escalation Policy Configuration",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("empty result should not contain %q", unwanted)
+		}
+	}
+}
+
+func TestGenerateTerraform_HealthcheckOutput(t *testing.T) {
+	r := &converter.ConversionResult{
+		Healthchecks: []converter.HyperpingHealthcheck{
+			{ResourceName: "hb1", Name: "HB", PeriodValue: 1, PeriodType: "hours", GracePeriodValue: 1, GracePeriodType: "hours"},
+		},
+	}
+	got := GenerateTerraform(r)
+	if !strings.Contains(got, `output "hb1_ping_url"`) {
+		t.Errorf("expected ping_url output for healthcheck, got:\n%s", got)
+	}
+	if !strings.Contains(got, "sensitive   = true") {
+		t.Error("expected sensitive flag on ping_url output")
+	}
+}
+
+func TestGenerateTerraform_FollowRedirectsOnlyForHTTP(t *testing.T) {
+	r := &converter.ConversionResult{
+		Monitors: []converter.HyperpingMonitor{
+			{ResourceName: "p", Name: "P", URL: "host", Protocol: "icmp", CheckFrequency: 60, FollowRedirects: true},
+		},
+	}
+	got := GenerateTerraform(r)
+	if strings.Contains(got, "follow_redirects") {
+		t.Errorf("follow_redirects should be omitted for non-HTTP protocols, got:\n%s", got)
+	}
+}

--- a/cmd/migrate-uptimerobot/generator/testdata/hyperping.tf.golden
+++ b/cmd/migrate-uptimerobot/generator/testdata/hyperping.tf.golden
@@ -1,0 +1,100 @@
+# Terraform configuration generated from UptimeRobot migration
+# Review and adjust as needed before applying
+#
+# Total monitors: 2
+# Total healthchecks: 1
+# Skipped resources: 1 (see comments below)
+
+terraform {
+  required_providers {
+    hyperping = {
+      source  = "develeap/hyperping"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "hyperping" {
+  # API key will be read from HYPERPING_API_KEY environment variable
+}
+
+# Escalation Policy Configuration
+# Create escalation policies in Hyperping dashboard first,
+# then set their UUIDs here or via terraform.tfvars
+variable "escalation_policy" {
+  description = "Default escalation policy UUID for alerts"
+  type        = string
+  default     = ""  # Set this to your escalation policy UUID
+}
+
+# ============================================
+# Monitors
+# ============================================
+
+# Original UptimeRobot Monitor ID: 101
+# Warnings:
+#   - Check frequency adjusted from 250s to 300s (nearest allowed value)
+resource "hyperping_monitor" "api_health" {
+  name            = "API Health"
+  url             = "https://api.example.com/health"
+  protocol        = "http"
+  http_method     = "GET"
+  check_frequency = 300
+  expected_status_code = "2xx"
+  follow_redirects = true
+  regions         = ["london", "virginia", "singapore"]
+
+  # Uncomment to enable alerting:
+  # escalation_policy = var.escalation_policy
+}
+
+# Original UptimeRobot Monitor ID: 102
+resource "hyperping_monitor" "db_port" {
+  name            = "Database Port"
+  url             = "https://db.example.com"
+  protocol        = "port"
+  check_frequency = 60
+  port            = 5432
+  regions         = ["virginia"]
+
+  # Uncomment to enable alerting:
+  # escalation_policy = var.escalation_policy
+}
+
+# ============================================
+# Healthchecks (from Heartbeat monitors)
+# ============================================
+
+# Original UptimeRobot Heartbeat Monitor ID: 201
+# Warnings:
+#   - Heartbeat monitor converted to healthcheck. Update your script to ping the new URL (see manual-steps.md)
+resource "hyperping_healthcheck" "cron_heartbeat" {
+  name               = "Cron Heartbeat"
+  period_value       = 1
+  period_type        = "hours"
+  grace_period_value = 1
+  grace_period_type  = "hours"
+
+  # Uncomment to enable alerting:
+  # escalation_policy = var.escalation_policy
+}
+
+# ============================================
+# Skipped Resources
+# ============================================
+# The following monitors could not be migrated:
+#
+# - Unsupported Foo (ID: 999, Type: 99): unsupported monitor type: 99
+
+# ============================================
+# Outputs
+# ============================================
+
+# Healthcheck ping URLs
+# Use these URLs to update your heartbeat scripts
+output "cron_heartbeat_ping_url" {
+  description = "Ping URL for Cron Heartbeat"
+  value       = hyperping_healthcheck.cron_heartbeat.ping_url
+  sensitive   = true
+}
+

--- a/cmd/migrate-uptimerobot/generator/testdata/import.sh.golden
+++ b/cmd/migrate-uptimerobot/generator/testdata/import.sh.golden
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Terraform import script generated from UptimeRobot migration
+#
+# This script is only needed if resources already exist in Hyperping
+# and you want to import them into Terraform state.
+#
+# If you're creating new resources, you don't need this script.
+# Just run: terraform apply
+#
+# Prerequisites:
+#   1. Terraform initialized: terraform init
+#   2. Resources created in Hyperping manually or via API
+#   3. HYPERPING_API_KEY environment variable set
+#
+# Total resources to import: 3
+#
+
+set -e  # Exit on error
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "Starting Terraform import process..."
+echo ""
+
+# Check prerequisites
+if [ -z "$HYPERPING_API_KEY" ]; then
+  echo "${RED}Error: HYPERPING_API_KEY environment variable not set${NC}"
+  exit 1
+fi
+
+if ! command -v terraform &> /dev/null; then
+  echo "${RED}Error: terraform command not found${NC}"
+  exit 1
+fi
+
+if [ ! -f "hyperping.tf" ]; then
+  echo "${YELLOW}Warning: hyperping.tf not found in current directory${NC}"
+  echo "Make sure you're in the correct directory"
+fi
+
+# Track import results
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+SKIPPED_COUNT=0
+
+# ============================================
+# Import Monitors
+# ============================================
+
+echo "Importing monitor: API Health..."
+# Note: You need the actual Hyperping monitor UUID
+# Replace 'mon_PLACEHOLDER' with the actual UUID from Hyperping
+if terraform import 'hyperping_monitor.api_health' 'mon_PLACEHOLDER_101' 2>/dev/null; then
+  echo "${GREEN}✓ Successfully imported${NC}"
+  ((SUCCESS_COUNT++))
+else
+  echo "${YELLOW}⚠ Import failed or resource doesn't exist - will be created on apply${NC}"
+  ((SKIPPED_COUNT++))
+fi
+echo ""
+
+echo "Importing monitor: Database Port..."
+# Note: You need the actual Hyperping monitor UUID
+# Replace 'mon_PLACEHOLDER' with the actual UUID from Hyperping
+if terraform import 'hyperping_monitor.db_port' 'mon_PLACEHOLDER_102' 2>/dev/null; then
+  echo "${GREEN}✓ Successfully imported${NC}"
+  ((SUCCESS_COUNT++))
+else
+  echo "${YELLOW}⚠ Import failed or resource doesn't exist - will be created on apply${NC}"
+  ((SKIPPED_COUNT++))
+fi
+echo ""
+
+# ============================================
+# Import Healthchecks
+# ============================================
+
+echo "Importing healthcheck: Cron Heartbeat..."
+# Note: You need the actual Hyperping healthcheck UUID
+# Replace 'hc_PLACEHOLDER' with the actual UUID from Hyperping
+if terraform import 'hyperping_healthcheck.cron_heartbeat' 'hc_PLACEHOLDER_201' 2>/dev/null; then
+  echo "${GREEN}✓ Successfully imported${NC}"
+  ((SUCCESS_COUNT++))
+else
+  echo "${YELLOW}⚠ Import failed or resource doesn't exist - will be created on apply${NC}"
+  ((SKIPPED_COUNT++))
+fi
+echo ""
+
+# ============================================
+# Summary
+# ============================================
+
+echo ""
+echo "Import process complete!"
+echo "${GREEN}Successfully imported: $SUCCESS_COUNT${NC}"
+echo "${YELLOW}Skipped (will be created): $SKIPPED_COUNT${NC}"
+if [ $FAIL_COUNT -gt 0 ]; then
+  echo "${RED}Failed: $FAIL_COUNT${NC}"
+fi
+echo ""
+echo "Next steps:"
+echo "  1. Run: terraform plan"
+echo "  2. Review the plan"
+echo "  3. Run: terraform apply"

--- a/cmd/migrate-uptimerobot/report/reporter_test.go
+++ b/cmd/migrate-uptimerobot/report/reporter_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package report
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/uptimerobot"
+)
+
+func sampleResult() *converter.ConversionResult {
+	return &converter.ConversionResult{
+		Monitors: []converter.HyperpingMonitor{
+			{OriginalID: 1, Name: "API", ResourceName: "api", Protocol: "http"},
+			{OriginalID: 2, Name: "Keyword", ResourceName: "kw", Protocol: "http", RequiredKeyword: "ok", Warnings: []string{"freq adjusted"}},
+			{OriginalID: 3, Name: "Ping", ResourceName: "ping", Protocol: "icmp"},
+			{OriginalID: 4, Name: "Port", ResourceName: "port", Protocol: "port"},
+		},
+		Healthchecks: []converter.HyperpingHealthcheck{
+			{OriginalID: 5, Name: "HB", ResourceName: "hb", Warnings: []string{"check script"}},
+		},
+		Skipped: []converter.SkippedMonitor{
+			{ID: 6, Name: "Bad", Type: 99, Reason: "unsupported monitor type: 99"},
+		},
+		ContactsMap: map[string][]string{},
+	}
+}
+
+func TestGenerate_Counts(t *testing.T) {
+	monitors := []uptimerobot.Monitor{
+		{ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}, {ID: 5}, {ID: 6},
+	}
+	r := Generate(monitors, nil, sampleResult())
+
+	if r.Summary.TotalMonitors != 6 {
+		t.Errorf("TotalMonitors = %d, want 6", r.Summary.TotalMonitors)
+	}
+	if r.Summary.MigratedMonitors != 4 {
+		t.Errorf("MigratedMonitors = %d, want 4", r.Summary.MigratedMonitors)
+	}
+	if r.Summary.MigratedHealthchecks != 1 {
+		t.Errorf("MigratedHealthchecks = %d, want 1", r.Summary.MigratedHealthchecks)
+	}
+	if r.Summary.SkippedMonitors != 1 {
+		t.Errorf("SkippedMonitors = %d, want 1", r.Summary.SkippedMonitors)
+	}
+	if r.Summary.MonitorsWithWarnings != 2 { // keyword monitor + healthcheck
+		t.Errorf("MonitorsWithWarnings = %d, want 2", r.Summary.MonitorsWithWarnings)
+	}
+}
+
+func TestGenerate_OriginalTypeInference(t *testing.T) {
+	r := Generate(nil, nil, sampleResult())
+
+	byName := map[string]int{}
+	for _, m := range r.Monitors {
+		byName[m.OriginalName] = m.OriginalType
+	}
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"API", 1},     // http no keyword → HTTP
+		{"Keyword", 2}, // http with required_keyword → Keyword
+		{"Ping", 3},    // icmp → Ping
+		{"Port", 4},    // port → Port
+		{"HB", 5},      // healthcheck → Heartbeat
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := byName[tt.name]; got != tt.want {
+				t.Errorf("OriginalType for %s = %d, want %d", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerate_SkippedRecordedAsErrorAndMonitor(t *testing.T) {
+	r := Generate(nil, nil, sampleResult())
+
+	if len(r.Errors) != 1 {
+		t.Fatalf("Errors = %d, want 1", len(r.Errors))
+	}
+	if r.Errors[0].Resource != "Bad" {
+		t.Errorf("Errors[0].Resource = %q, want Bad", r.Errors[0].Resource)
+	}
+
+	var skipped *MonitorReport
+	for i := range r.Monitors {
+		if r.Monitors[i].MigrationStatus == "skipped" {
+			skipped = &r.Monitors[i]
+			break
+		}
+	}
+	if skipped == nil {
+		t.Fatal("expected one skipped MonitorReport")
+	}
+	if skipped.ResourceType != "" || skipped.ResourceName != "" {
+		t.Errorf("skipped report should leave Resource{Type,Name} empty, got %+v", skipped)
+	}
+	if len(skipped.Warnings) == 0 || skipped.Warnings[0] != "unsupported monitor type: 99" {
+		t.Errorf("skipped Warnings = %v", skipped.Warnings)
+	}
+}
+
+func TestGenerate_TimestampFormat(t *testing.T) {
+	r := Generate(nil, nil, &converter.ConversionResult{ContactsMap: map[string][]string{}})
+	if _, err := time.Parse(time.RFC3339, r.Timestamp); err != nil {
+		t.Errorf("Timestamp = %q is not RFC3339: %v", r.Timestamp, err)
+	}
+}
+
+func TestGenerate_JSONRoundTrip(t *testing.T) {
+	r := Generate(nil, nil, sampleResult())
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back Report
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Summary.MigratedMonitors != r.Summary.MigratedMonitors {
+		t.Errorf("MigratedMonitors roundtrip: got %d, want %d", back.Summary.MigratedMonitors, r.Summary.MigratedMonitors)
+	}
+	if len(back.Monitors) != len(r.Monitors) {
+		t.Errorf("Monitors length roundtrip: got %d, want %d", len(back.Monitors), len(r.Monitors))
+	}
+}
+
+func TestGenerate_WarningsCollected(t *testing.T) {
+	r := Generate(nil, nil, sampleResult())
+
+	var seenKW, seenHB bool
+	for _, w := range r.Warnings {
+		if w.Resource == "Keyword" && w.Message == "freq adjusted" {
+			seenKW = true
+		}
+		if w.Resource == "HB" && w.Message == "check script" {
+			seenHB = true
+		}
+	}
+	if !seenKW || !seenHB {
+		t.Errorf("expected both keyword and healthcheck warnings, got: %+v", r.Warnings)
+	}
+}

--- a/cmd/migrate-uptimerobot/uptimerobot/client_test.go
+++ b/cmd/migrate-uptimerobot/uptimerobot/client_test.go
@@ -4,12 +4,38 @@
 package uptimerobot
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// roundTripFunc is an http.RoundTripper backed by a function. Letting tests
+// inject a transport keeps the production NewClient surface unchanged while
+// still allowing full request/response control.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newClientWithTransport(rt http.RoundTripper) *Client {
+	c := NewClient("test-api-key")
+	c.httpClient.Transport = rt
+	return c
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
 
 func TestFlexibleInt_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
@@ -128,4 +154,120 @@ func TestFlexibleInt_InStruct(t *testing.T) {
 func flexIntPtr(n int) *FlexibleInt {
 	fi := FlexibleInt(n)
 	return &fi
+}
+
+// =============================================================================
+// Client tests
+// =============================================================================
+
+func TestNewClient_Defaults(t *testing.T) {
+	c := NewClient("k")
+	assert.Equal(t, "k", c.apiKey)
+	require.NotNil(t, c.httpClient)
+	assert.NotZero(t, c.httpClient.Timeout, "expected a non-zero default timeout")
+}
+
+func TestGetMonitors_Success(t *testing.T) {
+	var captured *http.Request
+	var capturedBody []byte
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		captured = r
+		capturedBody, _ = io.ReadAll(r.Body)
+		return jsonResponse(200, `{"stat":"ok","monitors":[{"id":1,"friendly_name":"A","url":"https://a.example.com","type":1,"interval":60,"status":2}]}`), nil
+	})
+	c := newClientWithTransport(rt)
+
+	got, err := c.GetMonitors(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "A", got[0].FriendlyName)
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "POST", captured.Method)
+	assert.Contains(t, captured.URL.String(), "/getMonitors")
+	assert.Equal(t, "application/json", captured.Header.Get("Content-Type"))
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(capturedBody, &payload))
+	assert.Equal(t, "test-api-key", payload["api_key"])
+	assert.Equal(t, "json", payload["format"])
+}
+
+func TestGetMonitors_APIErrorStruct(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{"stat":"fail","error":{"type":"invalid_parameter","message":"bad key"}}`), nil
+	})
+	_, err := newClientWithTransport(rt).GetMonitors(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_parameter")
+	assert.Contains(t, err.Error(), "bad key")
+}
+
+func TestGetMonitors_StatNotOK_NoErrorStruct(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{"stat":"fail"}`), nil
+	})
+	_, err := newClientWithTransport(rt).GetMonitors(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API returned status")
+}
+
+func TestGetMonitors_NonOKHTTPStatus(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusUnauthorized, `unauthorized`), nil
+	})
+	_, err := newClientWithTransport(rt).GetMonitors(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code: 401")
+}
+
+func TestGetMonitors_NetworkError(t *testing.T) {
+	netErr := errors.New("dial tcp: refused")
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, netErr
+	})
+	_, err := newClientWithTransport(rt).GetMonitors(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "executing request")
+}
+
+func TestGetMonitors_BadJSON(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(200, `not json`), nil
+	})
+	_, err := newClientWithTransport(rt).GetMonitors(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding response")
+}
+
+func TestGetAlertContacts_Success(t *testing.T) {
+	var captured *http.Request
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		captured = r
+		return jsonResponse(200, `{"stat":"ok","alert_contacts":[{"id":"1","friendly_name":"Ops","type":2,"value":"ops@example.com","status":2}]}`), nil
+	})
+	got, err := newClientWithTransport(rt).GetAlertContacts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Ops", got[0].FriendlyName)
+	assert.Equal(t, 2, got[0].Type)
+	assert.Contains(t, captured.URL.String(), "/getAlertContacts")
+}
+
+func TestGetAlertContacts_StatFail(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{"stat":"fail","error":{"type":"forbidden","message":"nope"}}`), nil
+	})
+	_, err := newClientWithTransport(rt).GetAlertContacts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestGetAlertContacts_BadJSON(t *testing.T) {
+	rt := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(200, `{`), nil
+	})
+	_, err := newClientWithTransport(rt).GetAlertContacts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding response")
 }


### PR DESCRIPTION
## Summary

Adds unit tests for every non-main subpackage under `cmd/migrate-uptimerobot`. Patterns reuse what landed in #128 (migrate-pingdom): table-driven converter tests, golden-file snapshots for HCL and import-script generators, full request/response control on the REST client via an injected `http.RoundTripper`. No production-code changes; tests pass against existing tool behaviour.

## Coverage (verified locally with `go tool cover -func=...`)

| Subpackage                          | Before | After  |
| ----------------------------------- | ------ | ------ |
| `cmd/migrate-uptimerobot/converter` |  0.0%  |  96.9% |
| `cmd/migrate-uptimerobot/generator` |  0.0%  |  99.7% |
| `cmd/migrate-uptimerobot/report`    |  0.0%  | 100.0% |
| `cmd/migrate-uptimerobot/uptimerobot` | 23.4% |  90.6% |
| `cmd/migrate-uptimerobot` (main)    |  0.0%  |   0.0% |

The `main` package itself stays at 0% for the same reason as in #128: it is interactive-wizard orchestration plus CLI flag wiring, exercised by the existing `//go:build integration` tests in `cmd/migrate-uptimerobot/integration_test.go`. Pulling it under unit-test coverage would require introducing prompter/IO seams in production code, out of scope for a tests-only PR.

## What's covered

- **`converter`** -- per-type dispatch (HTTP / Keyword / Ping / Port / Heartbeat / unsupported), HTTP method mapping (every code 1-6 plus default), keyword exists vs not-exists handling (warning emitted, keyword dropped), port resolution (explicit > sub-type > default), heartbeat period mapping (days/hours/minutes/seconds boundaries), check-frequency adjustment warning, alert-contact map population, resource-name deduplication, URL scheme prepending, all sub-type-to-port mappings, terraformName edge cases.
- **`generator`** -- full HCL output (golden file), full import-script output (golden file), empty-result smoke paths, healthcheck `output` block + `sensitive` flag, follow_redirects suppression for non-HTTP protocols, manual-steps section presence/absence per condition, `hasWarnings` truth table.
- **`uptimerobot`** -- existing `FlexibleInt` tests retained; new tests for `GetMonitors` and `GetAlertContacts` covering the success path (with payload + headers + URL inspection), API error struct, stat-not-ok with no error struct, non-200 HTTP status, network failure, malformed JSON.
- **`report`** -- summary counts, original-type inference (HTTP vs Keyword vs ICMP vs Port vs Heartbeat), skipped-resource recording (both as `Errors[]` entry and as a skipped `MonitorReport`), RFC3339 timestamp format, JSON round-trip, warning collection from monitors and healthchecks.

## Notes for reviewer

- **REST client testability.** The uptimerobot client's `NewClient` exposes no `WithBaseURL` / `WithHTTPClient` option, so redirecting requests via `httptest.Server` would require a production-code change. Tests instead inject an `http.RoundTripper` into the client's existing `http.Client` (same in-package access pattern used by the existing `FlexibleInt` tests). Production paths are unchanged. If you'd prefer a `WithHTTPClient` option in production, happy to follow up in a separate PR.
- **Goldens are deterministic.** Inputs avoid map-iteration paths in the generator (`Regions` is set as a slice, no probe-filter expansion), and were verified stable under `go test -shuffle=on -count=2`. Regenerate after intentional output changes with `go test ./cmd/migrate-uptimerobot/generator -update-golden`.
- **Pre-existing double-escape bug from #128 does not apply here.** This generator uses `%q` directly on raw strings (no pre-escape), so HCL escaping is correct on its own. No follow-up needed.

## Test plan

- [x] `go test ./cmd/migrate-uptimerobot/... -race -count=1` passes
- [x] `go test ./cmd/migrate-uptimerobot/... -shuffle=on -count=2` passes (deterministic)
- [x] `go test ./cmd/migrate-uptimerobot/... -coverprofile=cov.out && go tool cover -func=cov.out` shows >=70% for every non-main subpackage
- [x] `go vet ./cmd/migrate-uptimerobot/...` clean
- [x] `golangci-lint run ./cmd/migrate-uptimerobot/...` clean
- [ ] CI green