### PR TITLE
chore(ci): bump govulncheck to v1.3.0, drop scan-package workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,14 +91,10 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - name: Run govulncheck
-        # -scan package avoids a govulncheck v1.1.4 internal error triggered by
-        # golang.org/x/sys/unix v0.35+ using //go:linkname in auxv.go, which causes
-        # go/packages to fail type-checking in symbol scan mode (-scan symbol is default).
-        # Package-level scanning still catches all imported vulnerable packages.
         run: |
-          govulncheck -scan package ./... 2>&1 | tee /tmp/govulncheck.txt
+          govulncheck ./... 2>&1 | tee /tmp/govulncheck.txt
           echo "## govulncheck Results" >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/govulncheck.txt >> "$GITHUB_STEP_SUMMARY"
         shell: bash


### PR DESCRIPTION
## Summary

Bumps the `govulncheck` install pin from `v1.1.4` to `v1.3.0` and drops the `-scan package` workaround in the `Security` job of `.github/workflows/test.yml`. Pattern mirrors hyperping-go's [PR #22](https://github.com/develeap/hyperping-go/pull/22), which originated this workaround.

## Why

`govulncheck` v1.1.4 crashed in symbol-scan (default) mode whenever `golang.org/x/sys/unix` v0.35+ entered the dependency graph: a `//go:linkname` in `auxv.go` made `go/packages` fail type-checking. The Security job worked around this by passing `-scan package`, which is robust but less precise — it reports every imported vulnerable package, not just the ones reachable from this repo's call graph.

The upstream crash was fixed in v1.3.0. Bumping the pin and dropping `-scan package` restores the default symbol-mode scan, which only flags reachable vulnerabilities. The four-line explanatory comment about the v1.1.4 workaround is also removed since it no longer describes anything in the file.

The `tee /tmp/govulncheck.txt` plus `$GITHUB_STEP_SUMMARY` plumbing is preserved — that is a UX feature, not part of the workaround.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML valid
- [x] Local rehearsal: `go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && govulncheck ./...` runs to completion without crashing on this repo (`No vulnerabilities found.`)
- [ ] CI green