### PR TITLE
chore: release v1.11.1 with hyperping-go v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-05-31
+
 ### Added
 
 - `hyperping_monitor.request_headers` now accepts `Authorization`, `Cookie`, and other previously-rejected auth headers, so probes can authenticate against endpoints behind Bearer/Basic/session auth (closes #132).
@@ -20,10 +22,12 @@ Published releases start from v1.0.3.
 - `ReservedHeaderName` validator updated to block the full set of HTTP framing and connection-control headers: `Host`, `Transfer-Encoding`, `Content-Length`, `Connection`, `Upgrade`, `TE`, `Trailer`, `Expect`. These are unsafe to expose to user configuration on outbound probes (request smuggling, protocol switch, cache poisoning). `Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorize`, `X-Forwarded-*`, `Forwarded`, `X-Real-IP`, and `Range` are allowed.
 - `ReservedHeaderName` now also rejects header names that do not match the RFC 7230 token grammar, including names with leading, trailing, or internal whitespace. This closes a bypass where `"Host "` or `" host"` would be accepted by the lowercased-map lookup.
 - Updated `examples/modules/graphql-monitor`, `docs/guides/validation.md`, `docs/DRY_RUN_GUIDE.md`, and `examples/dry-run-example.md` to reflect the relaxed validator.
+- Bumped `github.com/develeap/hyperping-go` from v0.4.0 to v0.6.1. Brings in server-side outage filtering (`WithStatus` functional option on `ListOutages`) and the broadened error sanitizer that now redacts `Authorization: Basic|Digest|<scheme>`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`, and `X-Api-Key` / `X-Auth-Token` / `X-Access-Token` header values. The `APIClient` interface in `cmd/import-generator` was extended to accept the new variadic option on `ListOutages`; no behavior change for existing callers.
+- Bumped Go toolchain to 1.26.3 and `golang.org/x/net` to v0.55.0 to clear stdlib and module CVEs surfaced by govulncheck (GO-2026-4918, GO-2026-4971, GO-2026-4976, GO-2026-4980, GO-2026-4981, GO-2026-4982, GO-2026-5026).
 
 ### Security
 
-- Pairs with `hyperping-go` PR #32, which extends error sanitization to redact `Authorization: Basic`/`Digest`/custom-scheme values, not only `Bearer`. The provider should consume the resulting `hyperping-go` release once published.
+- Closes a credential-leak path opened by the new `Authorization` / `Cookie` support: the bundled `hyperping-go` v0.6.1 sanitizer now scrubs all common credential-bearing headers from `APIError.Error()` output, not just `Authorization: Bearer`.
 
 ## [1.11.0] - 2026-04-25
 

--- a/cmd/import-generator/generator.go
+++ b/cmd/import-generator/generator.go
@@ -19,7 +19,7 @@ type APIClient interface {
 	ListStatusPages(ctx context.Context, page *int, search *string) (*hyperping.StatusPagePaginatedResponse, error)
 	ListIncidents(ctx context.Context) ([]hyperping.Incident, error)
 	ListMaintenance(ctx context.Context) ([]hyperping.Maintenance, error)
-	ListOutages(ctx context.Context) ([]hyperping.Outage, error)
+	ListOutages(ctx context.Context, opts ...hyperping.OutageListOption) ([]hyperping.Outage, error)
 }
 
 // Generator generates Terraform import commands and HCL from Hyperping resources.

--- a/cmd/import-generator/generator_test.go
+++ b/cmd/import-generator/generator_test.go
@@ -52,7 +52,7 @@ func (m *mockClient) ListMaintenance(_ context.Context) ([]hyperping.Maintenance
 	return m.maintenance, m.maintenanceErr
 }
 
-func (m *mockClient) ListOutages(_ context.Context) ([]hyperping.Outage, error) {
+func (m *mockClient) ListOutages(_ context.Context, _ ...hyperping.OutageListOption) ([]hyperping.Outage, error) {
 	return m.outages, m.outagesErr
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.4.0
+	github.com/develeap/hyperping-go v0.6.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/develeap/hyperping-go v0.4.0 h1:0++CDXxNohxQN803+l6+8ZVamnDL5zIa+JMl6FhHGyg=
-github.com/develeap/hyperping-go v0.4.0/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
+github.com/develeap/hyperping-go v0.6.1 h1:WT/PYrm7zm0Kuz/QEHf2ccqwXNLhvgxx1ch2v+WOnaA=
+github.com/develeap/hyperping-go v0.6.1/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

Cuts \`v1.11.1\` and pulls in the matching \`hyperping-go\` v0.6.1 release.

- \`go.mod\` bumps \`github.com/develeap/hyperping-go\` from v0.4.0 to v0.6.1.
- \`cmd/import-generator/generator.go\` and its test mock are updated so the local \`APIClient\` interface matches v0.6.0's variadic \`ListOutages(ctx, ...OutageListOption)\` signature. No behavior change at the call sites; both existing callers in \`generator.go:208\` and \`validate.go:163\` pass zero options and behave exactly as before.
- \`CHANGELOG.md\` moves the Unreleased section to \`[1.11.1] - 2026-05-31\` and adds entries for the SDK bump (carrying the broadened sanitizer that covers Authorization/Cookie/X-Api-Key family) plus the Go 1.26.3 / x/net v0.55.0 CVE bumps that already shipped on the request_headers branch.

## Why v1.11.1 (patch) and not v1.12.0

Calling judgment: the user-facing change in v1.11.0...HEAD is the request_headers behavior in #136, which the maintainer chose to label a fix-class change. All other diff in this PR is bookkeeping (CHANGELOG section move, SDK bump that carries security hardening, interface signature catching up to the new SDK variadic).

## Test plan

- [x] \`go build ./...\` (was failing on the ListOutages signature before the interface update; clean now).
- [x] \`go test ./...\` — 2105 passed in 25 packages.
- [x] \`go vet ./...\` clean.
- [x] \`govulncheck -scan package ./...\` (v1.1.4, same as CI) — "No vulnerabilities found."

## Release sequence after merge

1. Tag \`v1.11.1\` on \`main\` from the merge commit.
2. \`git push origin v1.11.1\` to trigger the release workflow.
3. Verify the release artifacts land on the Terraform Registry.