### PR TITLE
sec: address audit findings (HCL injection, VCR masker, log redaction, mcp_url scope)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,30 +209,30 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
-      # Run acceptance tests with parallel execution (only if API key available)
+      # Run acceptance tests with parallel execution (only if API key available).
+      # The skip gate lives inside the step body because the job-level `env`
+      # context does not see step-scoped secrets, so the previous
+      # `if: env.HYPERPING_API_KEY != ''` always evaluated to false and the
+      # acceptance suite never ran on push or PR.
       - name: Run acceptance tests (E2E)
-        if: env.HYPERPING_API_KEY != ''
         env:
           TF_ACC: "1"
           HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
           # Optimize parallel execution for acceptance tests
           GOMAXPROCS: "4"
         run: |
+          if [ -z "$HYPERPING_API_KEY" ]; then
+            echo "WARN: Acceptance tests skipped - HYPERPING_API_KEY not available"
+            echo "This is expected for:"
+            echo "  - Pull requests from forks"
+            echo "  - First-time contributors"
+            echo ""
+            echo "Unit and contract tests have passed. Maintainers will run acceptance tests."
+            exit 0
+          fi
           # Run with parallelism: -p 2 packages (limit API load), -parallel 10 tests per package
           # Timeout: 30m for comprehensive E2E testing
           go test -v -p 2 -parallel 10 -timeout 30m ./internal/provider/
         continue-on-error: false
-
-      - name: Acceptance tests skipped (no API key)
-        if: env.HYPERPING_API_KEY == ''
-        env:
-          HYPERPING_API_KEY: ${{ secrets.HYPERPING_API_KEY }}
-        run: |
-          echo "WARN: Acceptance tests skipped - HYPERPING_API_KEY not available"
-          echo "This is expected for:"
-          echo "  - Pull requests from forks"
-          echo "  - First-time contributors"
-          echo ""
-          echo "Unit and contract tests have passed. Maintainers will run acceptance tests."
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+### Security
+
+- HCL template-interpolation injection closed across all generator paths (`cmd/migrate-uptimerobot`, `cmd/migrate-pingdom`, `cmd/import-generator`). Untrusted string fields (monitor names, URLs, header values) now flow through `pkg/migrate.QuoteHCL`, which doubles the leading sigil on `${...}` and `%{...}` sequences so Terraform treats them as literal text rather than evaluating them at plan time.
+- VCR cassette masker rewritten: previously only the parameter name was rewritten, leaving the secret value plaintext on disk. The masker now URL-parses the request, replaces the value of every sensitive query parameter with `[MASKED]`, and re-serialises the URL. Lookup is case-insensitive so `Api_Key`, `API_KEY`, `Token`, and `aPi_KeY` are all caught.
+- `TFLogAdapter` now applies per-call redaction inside its `Debug` path, so any message containing API-key-shaped values is sanitised before tflog writes it to disk.
+- `mcp_url` localhost default-deny: `http://localhost`, `http://127.0.0.1`, and `http://[::1]` are rejected unless the operator opts in with `HYPERPING_ALLOW_LOCAL=1`. This closes an SSRF vector where a malicious value could otherwise reach a metadata service.
+- Defense-in-depth quoting for resource UUIDs in generated shell scripts (`cmd/import-generator/{generator,script}.go`, `cmd/migrate-pingdom/generator/import.go`): UUIDs now flow through `pkg/migrate.QuoteShellUUID`, which whitelists `[A-Za-z0-9_-]` and replaces non-conforming values with a sentinel before quoting. The Hyperping API remains the source of truth for these identifiers; this is a guardrail against a future backend or partner-API regression smuggling command substitution into the script.
+
+### Changed
+
+- `mcp_url` set to a localhost address now requires `HYPERPING_ALLOW_LOCAL=1`. **Breaking** for any configuration that pointed `mcp_url` at `http://localhost`, `http://127.0.0.1`, or `http://[::1]` without setting the env var. The `base_url` provider attribute retains the localhost exemption to avoid breaking acceptance-test setups.
+
+### Added
+
+- `HYPERPING_ALLOW_LOCAL` environment variable. Set to `1` to re-enable the localhost exemption for `mcp_url` (intended for local integration testing against a development MCP server).
+- Case-insensitive masking of API-key-shaped query parameters (`api_key`, `apikey`, `token`, `access_token`) in VCR cassettes regardless of source URL casing.
+- `pkg/migrate.SafeUUID` and `pkg/migrate.QuoteShellUUID` helpers for validating and quoting server-issued identifiers before interpolating them into generated shell scripts.
+
 ## [1.11.1] - 2026-05-31
 
 ### Added

--- a/cmd/import-generator/generator.go
+++ b/cmd/import-generator/generator.go
@@ -224,24 +224,28 @@ func (g *Generator) fetchOutages(ctx context.Context, data *ResourceData, progre
 }
 
 func (g *Generator) generateImports(sb *strings.Builder, data *ResourceData) {
+	// UUIDs flow through migrate.QuoteShellUUID for defense in depth: the API
+	// is the source of truth for these identifiers, but %q does not escape
+	// bash metacharacters ($, `, ;), so an attacker-influenced UUID-shaped
+	// value would otherwise smuggle command substitution into the script.
 	for _, m := range data.Monitors {
 		name := g.terraformName(m.Name)
-		fmt.Fprintf(sb, "terraform import hyperping_monitor.%s %q\n", name, m.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_monitor.%s %s\n", name, migrate.QuoteShellUUID(m.UUID))
 	}
 
 	for _, h := range data.Healthchecks {
 		name := g.terraformName(h.Name)
-		fmt.Fprintf(sb, "terraform import hyperping_healthcheck.%s %q\n", name, h.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_healthcheck.%s %s\n", name, migrate.QuoteShellUUID(h.UUID))
 	}
 
 	for _, sp := range data.StatusPages {
 		name := g.terraformName(sp.Name)
-		fmt.Fprintf(sb, "terraform import hyperping_statuspage.%s %q\n", name, sp.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_statuspage.%s %s\n", name, migrate.QuoteShellUUID(sp.UUID))
 	}
 
 	for _, i := range data.Incidents {
 		name := g.terraformName(i.Title.En)
-		fmt.Fprintf(sb, "terraform import hyperping_incident.%s %q\n", name, i.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_incident.%s %s\n", name, migrate.QuoteShellUUID(i.UUID))
 	}
 
 	for _, m := range data.Maintenance {
@@ -250,12 +254,12 @@ func (g *Generator) generateImports(sb *strings.Builder, data *ResourceData) {
 			titleText = m.Name
 		}
 		name := g.terraformName(titleText)
-		fmt.Fprintf(sb, "terraform import hyperping_maintenance.%s %q\n", name, m.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_maintenance.%s %s\n", name, migrate.QuoteShellUUID(m.UUID))
 	}
 
 	for _, o := range data.Outages {
 		name := g.terraformName(o.Monitor.Name)
-		fmt.Fprintf(sb, "terraform import hyperping_outage.%s %q\n", name, o.UUID)
+		fmt.Fprintf(sb, "terraform import hyperping_outage.%s %s\n", name, migrate.QuoteShellUUID(o.UUID))
 	}
 }
 

--- a/cmd/import-generator/generator.go
+++ b/cmd/import-generator/generator.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	hyperping "github.com/develeap/hyperping-go"
+
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // APIClient defines the interface for fetching Hyperping resources.
@@ -325,22 +327,22 @@ func (g *Generator) terraformName(name string) string {
 	return tfName
 }
 
-// escapeHCL escapes a string for HCL output.
+// escapeHCL escapes a string for HCL output. Delegates to migrate.EscapeHCL
+// so HCL template-interpolation sequences are neutralized in addition to
+// backslashes/quotes/newlines.
 func escapeHCL(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
+	return migrate.EscapeHCL(s)
 }
 
-// formatStringList formats a Go string slice as an HCL list.
+// formatStringList formats a Go string slice as an HCL list, with each item
+// safely quoted via migrate.QuoteHCL (template-interpolation safe).
 func formatStringList(items []string) string {
 	if len(items) == 0 {
 		return "[]"
 	}
 	quoted := make([]string, len(items))
 	for i, item := range items {
-		quoted[i] = fmt.Sprintf("%q", item)
+		quoted[i] = migrate.QuoteHCL(item)
 	}
 	return "[" + strings.Join(quoted, ", ") + "]"
 }

--- a/cmd/import-generator/generator_injection_test.go
+++ b/cmd/import-generator/generator_injection_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	hyperping "github.com/develeap/hyperping-go"
+)
+
+// TestGenerateHCL_TemplateInjection verifies that attacker-controlled string
+// fields in a Hyperping resource cannot inject HCL template-interpolation
+// sequences (${...} and %{...}) into the generated Terraform configuration.
+//
+// If the API ever returns a monitor name like `${file("/etc/passwd")}` (or if
+// an operator has crafted such a name via the UI), the generated .tf must
+// neutralize the sigil so Terraform does not evaluate it at plan time. This
+// test locks in the use of migrate.QuoteHCL in hcl.go; swapping in fmt's %q
+// verb would silently regress and this test would catch it.
+func TestGenerateHCL_TemplateInjection(t *testing.T) {
+	g := &Generator{}
+	keyword := `%{for x in y}`
+	policy := hyperping.EscalationPolicyRef{UUID: "esc_safe_123"}
+	data := &ResourceData{
+		Monitors: []hyperping.Monitor{
+			{
+				UUID:             "mon_evil",
+				Name:             `${file("/etc/passwd")}`,
+				URL:              `https://example.com/${file("/etc/hosts")}`,
+				Protocol:         "http",
+				HTTPMethod:       "POST",
+				CheckFrequency:   30,
+				Regions:          []string{`virginia-${env.LEAK}`},
+				FollowRedirects:  true,
+				RequiredKeyword:  &keyword,
+				EscalationPolicy: &policy,
+				RequestHeaders: []hyperping.RequestHeader{
+					{Name: `X-${env.SECRET}`, Value: `%{for x in y}`},
+				},
+				RequestBody: `${env.SECRET}`,
+			},
+		},
+		Healthchecks: []hyperping.Healthcheck{
+			{
+				UUID: "hc_evil",
+				Name: `${env.SECRET}`,
+			},
+		},
+	}
+
+	var sb strings.Builder
+	g.generateHCL(&sb, data)
+	out := sb.String()
+
+	expected := []string{
+		`$${file(`,
+		`$${env.LEAK}`,
+		`$${env.SECRET}`,
+		`%%{for x in y}`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(out, e) {
+			t.Errorf("generated HCL missing escaped sequence %q\n---\n%s\n---", e, out)
+		}
+	}
+
+	if hasUnescapedTemplateInQuotedHCL(out, "${", '$') {
+		t.Errorf("generated HCL contains unescaped ${ template start in a quoted string\n---\n%s\n---", out)
+	}
+	if hasUnescapedTemplateInQuotedHCL(out, "%{", '%') {
+		t.Errorf("generated HCL contains unescaped %%{ template start in a quoted string\n---\n%s\n---", out)
+	}
+}
+
+// TestGenerateScript_TemplateInjectionInHCLPath is a defensive check that the
+// HCL output (via generateHCL) keeps escaped sigils for malicious monitor
+// names. The shell script path uses %q for UUIDs only (validated separately);
+// names flow through terraformName() which strips non-identifier characters,
+// so they cannot leak template sigils into the script.
+func TestGenerateScript_NameSanitization(t *testing.T) {
+	g := &Generator{}
+	data := &ResourceData{
+		Monitors: []hyperping.Monitor{
+			{
+				UUID: "mon_safe_123",
+				Name: `${file("/etc/passwd")}`,
+			},
+		},
+	}
+	out := g.generateScript(data)
+	// terraformName must have stripped the template sigil from the resource
+	// address; the UUID is plain alphanumeric, so the script must not
+	// contain any unescaped template sequences.
+	if strings.Contains(out, "${file(") {
+		t.Errorf("script leaked unescaped template sigil from monitor name:\n%s", out)
+	}
+}
+
+// hasUnescapedTemplateInQuotedHCL reports true when needle ("${" or "%{")
+// appears inside a double-quoted HCL literal in s without being preceded by
+// the matching escape byte. Comments (`# ...`) are not scanned because they
+// do not undergo HCL template evaluation.
+func hasUnescapedTemplateInQuotedHCL(s, needle string, escape byte) bool {
+	inQuote := false
+	prevByteEscape := byte(0)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '"' && prevByteEscape != '\\' {
+			inQuote = !inQuote
+		}
+		if inQuote && i+len(needle) <= len(s) && s[i:i+len(needle)] == needle {
+			if i == 0 || s[i-1] != escape {
+				return true
+			}
+		}
+		prevByteEscape = c
+	}
+	return false
+}

--- a/cmd/import-generator/hcl.go
+++ b/cmd/import-generator/hcl.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	hyperping "github.com/develeap/hyperping-go"
+
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // buildOptionalStringField returns an HCL line for a string field only when
@@ -17,7 +19,7 @@ func buildOptionalStringField(name, value, skipValue string) string {
 	if value == "" || value == skipValue {
 		return ""
 	}
-	return fmt.Sprintf("  %s = %q\n", name, value)
+	return fmt.Sprintf("  %s = %s\n", name, migrate.QuoteHCL(value))
 }
 
 // buildOptionalIntField returns an HCL line for an int field only when
@@ -32,10 +34,11 @@ func buildOptionalIntField(name string, value, skipValue int) string {
 func (g *Generator) generateMonitorHCL(sb *strings.Builder, m hyperping.Monitor) {
 	name := g.terraformName(m.Name)
 
+	// name is sanitized to identifier-safe characters by terraformName; safe for %q.
 	fmt.Fprintf(sb, "resource \"hyperping_monitor\" %q {\n", name)
-	fmt.Fprintf(sb, "  name     = %q\n", m.Name)
-	fmt.Fprintf(sb, "  url      = %q\n", m.URL)
-	fmt.Fprintf(sb, "  protocol = %q\n", m.Protocol)
+	fmt.Fprintf(sb, "  name     = %s\n", migrate.QuoteHCL(m.Name))
+	fmt.Fprintf(sb, "  url      = %s\n", migrate.QuoteHCL(m.URL))
+	fmt.Fprintf(sb, "  protocol = %s\n", migrate.QuoteHCL(m.Protocol))
 
 	sb.WriteString(buildOptionalStringField("http_method", m.HTTPMethod, "GET"))
 	sb.WriteString(buildOptionalIntField("check_frequency", m.CheckFrequency, 60))
@@ -53,11 +56,11 @@ func (g *Generator) generateMonitorHCL(sb *strings.Builder, m hyperping.Monitor)
 	}
 
 	if m.ExpectedStatusCode.String() != "" && m.ExpectedStatusCode.String() != "200" {
-		fmt.Fprintf(sb, "  expected_status_code = %q\n", m.ExpectedStatusCode.String())
+		fmt.Fprintf(sb, "  expected_status_code = %s\n", migrate.QuoteHCL(m.ExpectedStatusCode.String()))
 	}
 
 	if m.RequiredKeyword != nil && *m.RequiredKeyword != "" {
-		fmt.Fprintf(sb, "  required_keyword = %q\n", *m.RequiredKeyword)
+		fmt.Fprintf(sb, "  required_keyword = %s\n", migrate.QuoteHCL(*m.RequiredKeyword))
 	}
 
 	if m.Paused {
@@ -67,15 +70,15 @@ func (g *Generator) generateMonitorHCL(sb *strings.Builder, m hyperping.Monitor)
 	sb.WriteString(buildOptionalIntField("alerts_wait", m.AlertsWait, 0))
 
 	if m.EscalationPolicy != nil && m.EscalationPolicy.UUID != "" {
-		fmt.Fprintf(sb, "  escalation_policy = %q\n", m.EscalationPolicy.UUID)
+		fmt.Fprintf(sb, "  escalation_policy = %s\n", migrate.QuoteHCL(m.EscalationPolicy.UUID))
 	}
 
 	if len(m.RequestHeaders) > 0 {
 		sb.WriteString("  request_headers = [\n")
 		for _, h := range m.RequestHeaders {
 			sb.WriteString("    {\n")
-			fmt.Fprintf(sb, "      name  = %q\n", h.Name)
-			fmt.Fprintf(sb, "      value = %q\n", h.Value)
+			fmt.Fprintf(sb, "      name  = %s\n", migrate.QuoteHCL(h.Name))
+			fmt.Fprintf(sb, "      value = %s\n", migrate.QuoteHCL(h.Value))
 			sb.WriteString("    },\n")
 		}
 		sb.WriteString("  ]\n")
@@ -90,16 +93,16 @@ func (g *Generator) generateHealthcheckHCL(sb *strings.Builder, h hyperping.Heal
 	name := g.terraformName(h.Name)
 
 	fmt.Fprintf(sb, "resource \"hyperping_healthcheck\" %q {\n", name)
-	fmt.Fprintf(sb, "  name = %q\n", h.Name)
+	fmt.Fprintf(sb, "  name = %s\n", migrate.QuoteHCL(h.Name))
 
 	if h.Cron != "" {
-		fmt.Fprintf(sb, "  cron = %q\n", h.Cron)
+		fmt.Fprintf(sb, "  cron = %s\n", migrate.QuoteHCL(h.Cron))
 		if h.Timezone != "" {
-			fmt.Fprintf(sb, "  timezone = %q\n", h.Timezone)
+			fmt.Fprintf(sb, "  timezone = %s\n", migrate.QuoteHCL(h.Timezone))
 		}
 	} else if h.PeriodValue != nil && *h.PeriodValue > 0 {
 		fmt.Fprintf(sb, "  period_value = %d\n", *h.PeriodValue)
-		fmt.Fprintf(sb, "  period_type = %q\n", h.PeriodType)
+		fmt.Fprintf(sb, "  period_type = %s\n", migrate.QuoteHCL(h.PeriodType))
 	}
 
 	if h.GracePeriod > 0 {
@@ -117,16 +120,16 @@ func (g *Generator) generateStatusPageHCL(sb *strings.Builder, sp hyperping.Stat
 	name := g.terraformName(sp.Name)
 
 	fmt.Fprintf(sb, "resource \"hyperping_statuspage\" %q {\n", name)
-	fmt.Fprintf(sb, "  name             = %q\n", sp.Name)
-	fmt.Fprintf(sb, "  hosted_subdomain = %q\n", sp.HostedSubdomain)
+	fmt.Fprintf(sb, "  name             = %s\n", migrate.QuoteHCL(sp.Name))
+	fmt.Fprintf(sb, "  hosted_subdomain = %s\n", migrate.QuoteHCL(sp.HostedSubdomain))
 
 	if sp.Hostname != nil && *sp.Hostname != "" {
-		fmt.Fprintf(sb, "  hostname = %q\n", *sp.Hostname)
+		fmt.Fprintf(sb, "  hostname = %s\n", migrate.QuoteHCL(*sp.Hostname))
 	}
 
 	// Settings block
 	sb.WriteString("\n  settings = {\n")
-	fmt.Fprintf(sb, "    name      = %q\n", sp.Name)
+	fmt.Fprintf(sb, "    name      = %s\n", migrate.QuoteHCL(sp.Name))
 
 	if len(sp.Settings.Languages) > 0 {
 		fmt.Fprintf(sb, "    languages = %s\n", formatStringList(sp.Settings.Languages))
@@ -153,7 +156,7 @@ func (g *Generator) generateIncidentHCL(sb *strings.Builder, i hyperping.Inciden
 	name := g.terraformName(i.Title.En)
 
 	fmt.Fprintf(sb, "resource \"hyperping_incident\" %q {\n", name)
-	fmt.Fprintf(sb, "  title = %q\n", i.Title.En)
+	fmt.Fprintf(sb, "  title = %s\n", migrate.QuoteHCL(i.Title.En))
 
 	sb.WriteString(buildOptionalStringField("text", i.Text.En, ""))
 	sb.WriteString(buildOptionalStringField("type", i.Type, "incident"))
@@ -178,15 +181,15 @@ func (g *Generator) generateMaintenanceHCL(sb *strings.Builder, m hyperping.Main
 	name := g.terraformName(titleText)
 
 	fmt.Fprintf(sb, "resource \"hyperping_maintenance\" %q {\n", name)
-	fmt.Fprintf(sb, "  title = %q\n", titleText)
+	fmt.Fprintf(sb, "  title = %s\n", migrate.QuoteHCL(titleText))
 
 	sb.WriteString(buildOptionalStringField("text", m.Text.En, ""))
 
 	if m.StartDate != nil {
-		fmt.Fprintf(sb, "  start_date = %q\n", *m.StartDate)
+		fmt.Fprintf(sb, "  start_date = %s\n", migrate.QuoteHCL(*m.StartDate))
 	}
 	if m.EndDate != nil {
-		fmt.Fprintf(sb, "  end_date   = %q\n", *m.EndDate)
+		fmt.Fprintf(sb, "  end_date   = %s\n", migrate.QuoteHCL(*m.EndDate))
 	}
 
 	if len(m.StatusPages) > 0 {
@@ -200,10 +203,11 @@ func (g *Generator) generateOutageHCL(sb *strings.Builder, o hyperping.Outage) {
 	name := g.terraformName(o.Monitor.Name)
 
 	fmt.Fprintf(sb, "resource \"hyperping_outage\" %q {\n", name)
-	fmt.Fprintf(sb, "  monitor_uuid = %q\n", o.Monitor.UUID)
+	fmt.Fprintf(sb, "  monitor_uuid = %s\n", migrate.QuoteHCL(o.Monitor.UUID))
 
 	if o.Description != "" {
-		fmt.Fprintf(sb, "  # description = %q\n", o.Description)
+		// Emitted as a comment so any embedded newline is sanitized via EscapeHCL.
+		fmt.Fprintf(sb, "  # description = %s\n", migrate.QuoteHCL(o.Description))
 	}
 
 	// Note: Most outage fields are read-only/computed

--- a/cmd/import-generator/script.go
+++ b/cmd/import-generator/script.go
@@ -6,6 +6,8 @@ package main
 import (
 	"fmt"
 	"strings"
+
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // generateScript generates an executable bash script for importing resources.
@@ -70,13 +72,16 @@ func (g *Generator) generateScript(data *ResourceData) string {
 	sb.WriteString("echo\n")
 	sb.WriteString("\n")
 
-	// Generate import commands
+	// Generate import commands. UUIDs flow through migrate.QuoteShellUUID so
+	// an attacker-influenced UUID-shaped value cannot smuggle command
+	// substitution ($(...), ``...``) or statement chaining (;) into the
+	// generated script.
 	if len(data.Monitors) > 0 {
 		sb.WriteString("# Monitors\n")
 		for _, m := range data.Monitors {
 			name := g.terraformName(m.Name)
 			addr := fmt.Sprintf("hyperping_monitor.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, m.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(m.UUID))
 		}
 		sb.WriteString("\n")
 	}
@@ -86,7 +91,7 @@ func (g *Generator) generateScript(data *ResourceData) string {
 		for _, h := range data.Healthchecks {
 			name := g.terraformName(h.Name)
 			addr := fmt.Sprintf("hyperping_healthcheck.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, h.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(h.UUID))
 		}
 		sb.WriteString("\n")
 	}
@@ -96,7 +101,7 @@ func (g *Generator) generateScript(data *ResourceData) string {
 		for _, sp := range data.StatusPages {
 			name := g.terraformName(sp.Name)
 			addr := fmt.Sprintf("hyperping_statuspage.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, sp.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(sp.UUID))
 		}
 		sb.WriteString("\n")
 	}
@@ -106,7 +111,7 @@ func (g *Generator) generateScript(data *ResourceData) string {
 		for _, i := range data.Incidents {
 			name := g.terraformName(i.Title.En)
 			addr := fmt.Sprintf("hyperping_incident.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, i.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(i.UUID))
 		}
 		sb.WriteString("\n")
 	}
@@ -120,7 +125,7 @@ func (g *Generator) generateScript(data *ResourceData) string {
 			}
 			name := g.terraformName(titleText)
 			addr := fmt.Sprintf("hyperping_maintenance.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, m.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(m.UUID))
 		}
 		sb.WriteString("\n")
 	}
@@ -130,7 +135,7 @@ func (g *Generator) generateScript(data *ResourceData) string {
 		for _, o := range data.Outages {
 			name := g.terraformName(o.Monitor.Name)
 			addr := fmt.Sprintf("hyperping_outage.%s", name)
-			fmt.Fprintf(&sb, "import_resource %q %q\n", addr, o.UUID)
+			fmt.Fprintf(&sb, "import_resource %q %s\n", addr, migrate.QuoteShellUUID(o.UUID))
 		}
 		sb.WriteString("\n")
 	}

--- a/cmd/import-generator/uuid_injection_test.go
+++ b/cmd/import-generator/uuid_injection_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	hyperping "github.com/develeap/hyperping-go"
+)
+
+// TestGenerateScript_RejectsMaliciousUUID is defense-in-depth: the Hyperping
+// API is the source of truth for resource UUIDs, but if a future regression
+// (or partner-API forwarding) ever surfaces an attacker-influenced value, the
+// generated shell script must refuse to interpolate it. The previous
+// implementation emitted UUIDs through fmt's %q verb, which does NOT escape
+// bash metacharacters ($, `, ;), so a UUID-shaped string like
+// `'; rm -rf $HOME; '` would survive into the script and execute when run.
+func TestGenerateScript_RejectsMaliciousUUID(t *testing.T) {
+	g := &Generator{}
+	data := &ResourceData{
+		Monitors: []hyperping.Monitor{
+			{UUID: `$(rm -rf $HOME)`, Name: "evil_one"},
+			{UUID: "`whoami`", Name: "evil_two"},
+			{UUID: "'; rm -rf $HOME; '", Name: "evil_three"},
+			{UUID: "mon_safe_123", Name: "good"},
+		},
+	}
+	out := g.generateScript(data)
+
+	// Malicious payloads must NOT survive into the script.
+	forbidden := []string{
+		"$(rm",
+		"`whoami`",
+		"'; rm",
+	}
+	for _, f := range forbidden {
+		if strings.Contains(out, f) {
+			t.Errorf("script contains forbidden substring %q\n---\n%s\n---", f, out)
+		}
+	}
+
+	// The safe UUID must round-trip unchanged.
+	if !strings.Contains(out, "mon_safe_123") {
+		t.Errorf("safe UUID was rejected; script:\n%s", out)
+	}
+}
+
+// TestGenerateImports_RejectsMaliciousUUID exercises the same defense for the
+// terraform-import-command output path (Generator.generateImports). HCL would
+// reject these strings on parse, but operators sometimes pipe the output into
+// other tooling, so defense in depth applies.
+func TestGenerateImports_RejectsMaliciousUUID(t *testing.T) {
+	g := &Generator{}
+	data := &ResourceData{
+		Healthchecks: []hyperping.Healthcheck{
+			{UUID: "$(rm -rf /)", Name: "evil"},
+			{UUID: "hc_safe_123", Name: "good"},
+		},
+	}
+	var sb strings.Builder
+	g.generateImports(&sb, data)
+	out := sb.String()
+
+	if strings.Contains(out, "$(rm") {
+		t.Errorf("imports output contains malicious substitution\n---\n%s\n---", out)
+	}
+	if !strings.Contains(out, "hc_safe_123") {
+		t.Errorf("safe UUID was rejected; output:\n%s", out)
+	}
+}

--- a/cmd/migrate-pingdom/generator/import.go
+++ b/cmd/migrate-pingdom/generator/import.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
 	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+	"github.com/develeap/terraform-provider-hyperping/pkg/migrate"
 )
 
 // ImportGenerator generates Terraform import scripts.
@@ -53,7 +54,9 @@ func (g *ImportGenerator) GenerateImportScript(checks []pingdom.Check, results [
 			tfName := g.terraformName(result.Monitor.Name)
 			fmt.Fprintf(&sb, "# Pingdom Check %d: %s\n", check.ID, check.Name)
 			fmt.Fprintf(&sb, "echo \"Importing hyperping_monitor.%s...\"\n", tfName)
-			fmt.Fprintf(&sb, "terraform import hyperping_monitor.%s %q || echo \"Warning: Import failed for %s\"\n", tfName, uuid, tfName)
+			// UUID flows through migrate.QuoteShellUUID for defense in depth;
+			// %q does not escape bash metacharacters.
+			fmt.Fprintf(&sb, "terraform import hyperping_monitor.%s %s || echo \"Warning: Import failed for %s\"\n", tfName, migrate.QuoteShellUUID(uuid), tfName)
 			sb.WriteString("echo \"\"\n\n")
 			importCount++
 		}
@@ -87,7 +90,7 @@ func (g *ImportGenerator) GenerateImportCommands(checks []pingdom.Check, results
 		if result.Monitor != nil {
 			tfName := g.terraformName(result.Monitor.Name)
 			fmt.Fprintf(&sb, "# Pingdom Check %d: %s\n", check.ID, check.Name)
-			fmt.Fprintf(&sb, "terraform import hyperping_monitor.%s %q\n\n", tfName, uuid)
+			fmt.Fprintf(&sb, "terraform import hyperping_monitor.%s %s\n\n", tfName, migrate.QuoteShellUUID(uuid))
 		}
 	}
 

--- a/cmd/migrate-pingdom/generator/import_injection_test.go
+++ b/cmd/migrate-pingdom/generator/import_injection_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	hyperping "github.com/develeap/hyperping-go"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+// TestGenerateImportScript_RejectsMaliciousUUID is defense in depth for the
+// pingdom migration import-script emitter. The createdResources map carries
+// UUIDs returned by the Hyperping API; if those values were ever
+// attacker-influenced, the previous use of fmt.Sprintf("%q", uuid) would not
+// neutralize bash metacharacters and the malicious payload would execute when
+// the script ran.
+func TestGenerateImportScript_RejectsMaliciousUUID(t *testing.T) {
+	checks := []pingdom.Check{
+		{ID: 1, Name: "evil-one", Type: "http"},
+		{ID: 2, Name: "evil-two", Type: "http"},
+		{ID: 3, Name: "good", Type: "http"},
+	}
+	results := []converter.ConversionResult{
+		{Supported: true, Monitor: &hyperping.CreateMonitorRequest{Name: "evil-one", URL: "https://e1.example.com", Protocol: "http"}},
+		{Supported: true, Monitor: &hyperping.CreateMonitorRequest{Name: "evil-two", URL: "https://e2.example.com", Protocol: "http"}},
+		{Supported: true, Monitor: &hyperping.CreateMonitorRequest{Name: "good", URL: "https://g.example.com", Protocol: "http"}},
+	}
+	createdResources := map[int]string{
+		1: "$(rm -rf $HOME)",
+		2: "'; rm -rf $HOME; '",
+		3: "mon_safe_123",
+	}
+
+	g := NewImportGenerator("")
+	out := g.GenerateImportScript(checks, results, createdResources)
+
+	forbidden := []string{"$(rm", "'; rm"}
+	for _, f := range forbidden {
+		if strings.Contains(out, f) {
+			t.Errorf("script contains forbidden substring %q\n---\n%s\n---", f, out)
+		}
+	}
+	if !strings.Contains(out, "mon_safe_123") {
+		t.Errorf("safe UUID was rejected; script:\n%s", out)
+	}
+
+	// Same defense for the GenerateImportCommands path.
+	out2 := g.GenerateImportCommands(checks, results, createdResources)
+	for _, f := range forbidden {
+		if strings.Contains(out2, f) {
+			t.Errorf("commands output contains forbidden substring %q\n---\n%s\n---", f, out2)
+		}
+	}
+}

--- a/cmd/migrate-pingdom/generator/terraform.go
+++ b/cmd/migrate-pingdom/generator/terraform.go
@@ -71,10 +71,11 @@ func (g *TerraformGenerator) GenerateHCL(checks []pingdom.Check, results []conve
 func (g *TerraformGenerator) generateMonitorHCL(sb *strings.Builder, _ pingdom.Check, monitor *hyperping.CreateMonitorRequest) {
 	tfName := g.terraformName(monitor.Name)
 
+	// tfName is derived from terraformName() and only contains [a-z0-9_]; safe for %q.
 	fmt.Fprintf(sb, "resource \"hyperping_monitor\" %q {\n", tfName)
-	fmt.Fprintf(sb, "  name     = %q\n", escapeHCL(monitor.Name))
-	fmt.Fprintf(sb, "  url      = %q\n", escapeHCL(monitor.URL))
-	fmt.Fprintf(sb, "  protocol = %q\n", monitor.Protocol)
+	fmt.Fprintf(sb, "  name     = %s\n", migrate.QuoteHCL(monitor.Name))
+	fmt.Fprintf(sb, "  url      = %s\n", migrate.QuoteHCL(monitor.URL))
+	fmt.Fprintf(sb, "  protocol = %s\n", migrate.QuoteHCL(monitor.Protocol))
 
 	sb.WriteString(buildOptionalHTTPMethod(monitor))
 	sb.WriteString(buildOptionalCheckFrequency(monitor))
@@ -95,7 +96,7 @@ func buildOptionalHTTPMethod(monitor *hyperping.CreateMonitorRequest) string {
 	if monitor.HTTPMethod == "" || monitor.HTTPMethod == "GET" {
 		return ""
 	}
-	return fmt.Sprintf("  http_method = %q\n", monitor.HTTPMethod)
+	return fmt.Sprintf("  http_method = %s\n", migrate.QuoteHCL(monitor.HTTPMethod))
 }
 
 // buildOptionalCheckFrequency returns the check_frequency line if non-default.
@@ -135,7 +136,7 @@ func buildOptionalExpectedStatus(monitor *hyperping.CreateMonitorRequest) string
 	if monitor.ExpectedStatusCode == "" || monitor.ExpectedStatusCode == "200" {
 		return ""
 	}
-	return fmt.Sprintf("  expected_status_code = %q\n", monitor.ExpectedStatusCode)
+	return fmt.Sprintf("  expected_status_code = %s\n", migrate.QuoteHCL(monitor.ExpectedStatusCode))
 }
 
 // buildOptionalRequiredKeyword returns the required_keyword line if set.
@@ -143,7 +144,7 @@ func buildOptionalRequiredKeyword(monitor *hyperping.CreateMonitorRequest) strin
 	if monitor.RequiredKeyword == nil || *monitor.RequiredKeyword == "" {
 		return ""
 	}
-	return fmt.Sprintf("  required_keyword = %q\n", escapeHCL(*monitor.RequiredKeyword))
+	return fmt.Sprintf("  required_keyword = %s\n", migrate.QuoteHCL(*monitor.RequiredKeyword))
 }
 
 // buildOptionalRequestHeaders returns the request_headers list if non-empty.
@@ -155,8 +156,8 @@ func buildOptionalRequestHeaders(monitor *hyperping.CreateMonitorRequest) string
 	sb.WriteString("  request_headers = [\n")
 	for _, h := range monitor.RequestHeaders {
 		sb.WriteString("    {\n")
-		fmt.Fprintf(&sb, "      name  = %q\n", escapeHCL(h.Name))
-		fmt.Fprintf(&sb, "      value = %q\n", escapeHCL(h.Value))
+		fmt.Fprintf(&sb, "      name  = %s\n", migrate.QuoteHCL(h.Name))
+		fmt.Fprintf(&sb, "      value = %s\n", migrate.QuoteHCL(h.Value))
 		sb.WriteString("    },\n")
 	}
 	sb.WriteString("  ]\n")
@@ -168,7 +169,7 @@ func buildOptionalRequestBody(monitor *hyperping.CreateMonitorRequest) string {
 	if monitor.RequestBody == nil || *monitor.RequestBody == "" {
 		return ""
 	}
-	return fmt.Sprintf("  request_body = %q\n", escapeHCL(*monitor.RequestBody))
+	return fmt.Sprintf("  request_body = %s\n", migrate.QuoteHCL(*monitor.RequestBody))
 }
 
 // buildOptionalPaused returns the paused line if true.
@@ -213,12 +214,8 @@ func (g *TerraformGenerator) terraformName(name string) string {
 	return tfName
 }
 
-// escapeHCL escapes a string for HCL output.
-func escapeHCL(s string) string {
-	return migrate.EscapeHCL(s)
-}
-
-// formatStringList formats a Go string slice as an HCL list.
+// formatStringList formats a Go string slice as an HCL list, with each item
+// safely quoted via migrate.QuoteHCL (template-interpolation safe).
 func formatStringList(items []string) string {
 	if len(items) == 0 {
 		return "[]"
@@ -226,7 +223,7 @@ func formatStringList(items []string) string {
 
 	quoted := make([]string, len(items))
 	for i, item := range items {
-		quoted[i] = fmt.Sprintf("%q", item)
+		quoted[i] = migrate.QuoteHCL(item)
 	}
 
 	return "[" + strings.Join(quoted, ", ") + "]"

--- a/cmd/migrate-pingdom/generator/terraform_injection_test.go
+++ b/cmd/migrate-pingdom/generator/terraform_injection_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	hyperping "github.com/develeap/hyperping-go"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/converter"
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-pingdom/pingdom"
+)
+
+// TestGenerateHCL_TemplateInjection verifies that attacker-controlled string
+// fields in a Pingdom check cannot inject HCL template-interpolation sequences
+// (${...} and %{...}) into the generated Terraform configuration.
+//
+// A malicious Pingdom check whose name contains `${file("/etc/passwd")}` must
+// be emitted with the leading dollar/percent doubled so Terraform treats it
+// as literal text rather than evaluating it during plan/apply. This locks in
+// the use of migrate.QuoteHCL inside generator/terraform.go; replacing those
+// calls with fmt's %q verb (which does not escape template sigils) would
+// regress and this test would catch it.
+func TestGenerateHCL_TemplateInjection(t *testing.T) {
+	checks := []pingdom.Check{
+		{
+			ID:   42,
+			Name: `${file("/etc/passwd")}`,
+			Type: "http",
+			URL:  `https://example.com/${file("/etc/hosts")}`,
+		},
+	}
+
+	requiredKeyword := `%{for x in y}`
+	requestBody := `${env.SECRET}`
+	followRedirects := false
+	results := []converter.ConversionResult{
+		{
+			Supported: true,
+			Monitor: &hyperping.CreateMonitorRequest{
+				Name:            `${file("/etc/passwd")}`,
+				URL:             `https://example.com/${file("/etc/hosts")}`,
+				Protocol:        "http",
+				HTTPMethod:      "POST",
+				CheckFrequency:  60,
+				Regions:         []string{`virginia-${env.LEAK}`},
+				FollowRedirects: &followRedirects,
+				RequiredKeyword: &requiredKeyword,
+				RequestBody:     &requestBody,
+				RequestHeaders: []hyperping.RequestHeader{
+					{Name: `X-${env.SECRET}`, Value: `%{for x in y}`},
+				},
+			},
+		},
+	}
+
+	g := NewTerraformGenerator("")
+	out := g.GenerateHCL(checks, results)
+
+	// Escaped forms MUST appear.
+	expected := []string{
+		`$${file(`,
+		`$${env.LEAK}`,
+		`$${env.SECRET}`,
+		`%%{for x in y}`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(out, e) {
+			t.Errorf("generated HCL missing escaped sequence %q\n---\n%s\n---", e, out)
+		}
+	}
+
+	// No unescaped template starts inside attribute string literals may remain.
+	if hasUnescapedTemplateInQuotes(out, "${", '$') {
+		t.Errorf("generated HCL contains unescaped ${ template start in a quoted string\n---\n%s\n---", out)
+	}
+	if hasUnescapedTemplateInQuotes(out, "%{", '%') {
+		t.Errorf("generated HCL contains unescaped %%{ template start in a quoted string\n---\n%s\n---", out)
+	}
+}
+
+// hasUnescapedTemplateInQuotes reports true when needle ("${" or "%{") appears
+// inside a double-quoted HCL literal in s without being preceded by the
+// matching escape byte. We restrict the search to double-quoted spans because
+// the generator legitimately emits `# Original Name: ${...}` comments with the
+// raw user-supplied name (comments do not undergo HCL template evaluation).
+func hasUnescapedTemplateInQuotes(s, needle string, escape byte) bool {
+	inQuote := false
+	prevByteEscape := byte(0)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		// Track double-quote spans, but only toggle on quotes that are not
+		// themselves escaped by a backslash (so `\"` inside the literal does
+		// not flip the inQuote state).
+		if c == '"' && prevByteEscape != '\\' {
+			inQuote = !inQuote
+		}
+		if inQuote && i+len(needle) <= len(s) && s[i:i+len(needle)] == needle {
+			if i == 0 || s[i-1] != escape {
+				return true
+			}
+		}
+		prevByteEscape = c
+	}
+	return false
+}

--- a/cmd/migrate-uptimerobot/generator/terraform.go
+++ b/cmd/migrate-uptimerobot/generator/terraform.go
@@ -117,22 +117,22 @@ func generateMonitorResource(sb *strings.Builder, m converter.HyperpingMonitor) 
 		}
 	}
 	fmt.Fprintf(sb, "resource \"hyperping_monitor\" \"%s\" {\n", m.ResourceName)
-	fmt.Fprintf(sb, "  name            = %q\n", m.Name)
-	fmt.Fprintf(sb, "  url             = %q\n", m.URL)
-	fmt.Fprintf(sb, "  protocol        = %q\n", m.Protocol)
+	fmt.Fprintf(sb, "  name            = %s\n", migrate.QuoteHCL(m.Name))
+	fmt.Fprintf(sb, "  url             = %s\n", migrate.QuoteHCL(m.URL))
+	fmt.Fprintf(sb, "  protocol        = %s\n", migrate.QuoteHCL(m.Protocol))
 
 	if m.HTTPMethod != "" {
-		fmt.Fprintf(sb, "  http_method     = %q\n", m.HTTPMethod)
+		fmt.Fprintf(sb, "  http_method     = %s\n", migrate.QuoteHCL(m.HTTPMethod))
 	}
 
 	fmt.Fprintf(sb, "  check_frequency = %d\n", m.CheckFrequency)
 
 	if m.ExpectedStatusCode != "" {
-		fmt.Fprintf(sb, "  expected_status_code = %q\n", m.ExpectedStatusCode)
+		fmt.Fprintf(sb, "  expected_status_code = %s\n", migrate.QuoteHCL(m.ExpectedStatusCode))
 	}
 
 	if m.RequiredKeyword != "" {
-		fmt.Fprintf(sb, "  required_keyword     = %q\n", m.RequiredKeyword)
+		fmt.Fprintf(sb, "  required_keyword     = %s\n", migrate.QuoteHCL(m.RequiredKeyword))
 	}
 
 	if m.Port > 0 {
@@ -149,7 +149,7 @@ func generateMonitorResource(sb *strings.Builder, m converter.HyperpingMonitor) 
 			if i > 0 {
 				sb.WriteString(", ")
 			}
-			fmt.Fprintf(sb, "%q", r)
+			sb.WriteString(migrate.QuoteHCL(r))
 		}
 		sb.WriteString("]\n")
 	}
@@ -170,11 +170,11 @@ func generateHealthcheckResource(sb *strings.Builder, h converter.HyperpingHealt
 		}
 	}
 	fmt.Fprintf(sb, "resource \"hyperping_healthcheck\" \"%s\" {\n", h.ResourceName)
-	fmt.Fprintf(sb, "  name               = %q\n", h.Name)
+	fmt.Fprintf(sb, "  name               = %s\n", migrate.QuoteHCL(h.Name))
 	fmt.Fprintf(sb, "  period_value       = %d\n", h.PeriodValue)
-	fmt.Fprintf(sb, "  period_type        = %q\n", h.PeriodType)
+	fmt.Fprintf(sb, "  period_type        = %s\n", migrate.QuoteHCL(h.PeriodType))
 	fmt.Fprintf(sb, "  grace_period_value = %d\n", h.GracePeriodValue)
-	fmt.Fprintf(sb, "  grace_period_type  = %q\n", h.GracePeriodType)
+	fmt.Fprintf(sb, "  grace_period_type  = %s\n", migrate.QuoteHCL(h.GracePeriodType))
 	sb.WriteString("\n")
 	sb.WriteString("  # Uncomment to enable alerting:\n")
 	sb.WriteString("  # escalation_policy = var.escalation_policy\n")

--- a/cmd/migrate-uptimerobot/generator/terraform_injection_test.go
+++ b/cmd/migrate-uptimerobot/generator/terraform_injection_test.go
@@ -45,19 +45,8 @@ func TestGenerateTerraform_HCLTemplateInjection(t *testing.T) {
 
 	out := GenerateTerraform(result)
 
-	// Raw template sequences must NOT appear unescaped anywhere in the output.
-	forbidden := []string{
-		`${file(`,
-		`${env.SECRET}`,
-		`%{for x in y}`,
-	}
-	for _, f := range forbidden {
-		if strings.Contains(out, f) {
-			t.Errorf("generated HCL contains unescaped template sequence %q\n---\n%s\n---", f, out)
-		}
-	}
-
-	// The escaped forms MUST appear.
+	// The escaped forms MUST appear: ${...} must become $${...} and %{...}
+	// must become %%{...} so HCL treats them as literal text.
 	expected := []string{
 		`$${file(`,
 		`$${env.SECRET}`,
@@ -67,5 +56,34 @@ func TestGenerateTerraform_HCLTemplateInjection(t *testing.T) {
 		if !strings.Contains(out, e) {
 			t.Errorf("generated HCL missing escaped sequence %q\n---\n%s\n---", e, out)
 		}
+	}
+
+	// No unescaped template start ("${" or "%{") may appear. We detect this by
+	// scanning for the literal two-byte starts that lack the leading sigil
+	// double. An unescaped ${...} appears as "${" not preceded by "$"; an
+	// unescaped %{...} appears as "%{" not preceded by "%".
+	if hasUnescapedTemplate(out, "${", '$') {
+		t.Errorf("generated HCL contains unescaped ${ template start\n---\n%s\n---", out)
+	}
+	if hasUnescapedTemplate(out, "%{", '%') {
+		t.Errorf("generated HCL contains unescaped %%{ template start\n---\n%s\n---", out)
+	}
+}
+
+// hasUnescapedTemplate returns true when needle ("${" or "%{") appears in s
+// without the leading escape byte (a duplicate of the sigil) directly in front
+// of it. This is the same check Terraform's template lexer effectively does.
+func hasUnescapedTemplate(s, needle string, escape byte) bool {
+	from := 0
+	for {
+		idx := strings.Index(s[from:], needle)
+		if idx < 0 {
+			return false
+		}
+		abs := from + idx
+		if abs == 0 || s[abs-1] != escape {
+			return true
+		}
+		from = abs + len(needle)
 	}
 }

--- a/cmd/migrate-uptimerobot/generator/terraform_injection_test.go
+++ b/cmd/migrate-uptimerobot/generator/terraform_injection_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/develeap/terraform-provider-hyperping/cmd/migrate-uptimerobot/converter"
+)
+
+// TestGenerateTerraform_HCLTemplateInjection verifies that attacker-controlled
+// string fields in the source monitor cannot inject HCL template-interpolation
+// sequences (${...} and %{...}) into the generated Terraform configuration.
+//
+// A malicious UptimeRobot monitor name such as `${file("/etc/passwd")}` must be
+// emitted with the leading dollar/percent doubled so Terraform treats it as a
+// literal rather than evaluating it during plan/apply.
+func TestGenerateTerraform_HCLTemplateInjection(t *testing.T) {
+	result := &converter.ConversionResult{
+		Monitors: []converter.HyperpingMonitor{
+			{
+				ResourceName:    "evil",
+				Name:            `${file("/etc/passwd")}`,
+				URL:             `https://example.com/${file("/etc/hosts")}`,
+				Protocol:        "http",
+				HTTPMethod:      "GET",
+				CheckFrequency:  60,
+				RequiredKeyword: `%{for x in y}`,
+				FollowRedirects: true,
+			},
+		},
+		Healthchecks: []converter.HyperpingHealthcheck{
+			{
+				ResourceName:     "evil_hc",
+				Name:             `${env.SECRET}`,
+				PeriodValue:      5,
+				PeriodType:       "minutes",
+				GracePeriodValue: 1,
+				GracePeriodType:  "minutes",
+			},
+		},
+	}
+
+	out := GenerateTerraform(result)
+
+	// Raw template sequences must NOT appear unescaped anywhere in the output.
+	forbidden := []string{
+		`${file(`,
+		`${env.SECRET}`,
+		`%{for x in y}`,
+	}
+	for _, f := range forbidden {
+		if strings.Contains(out, f) {
+			t.Errorf("generated HCL contains unescaped template sequence %q\n---\n%s\n---", f, out)
+		}
+	}
+
+	// The escaped forms MUST appear.
+	expected := []string{
+		`$${file(`,
+		`$${env.SECRET}`,
+		`%%{for x in y}`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(out, e) {
+			t.Errorf("generated HCL missing escaped sequence %q\n---\n%s\n---", e, out)
+		}
+	}
+}

--- a/internal/provider/escalation_policy_data_source_test.go
+++ b/internal/provider/escalation_policy_data_source_test.go
@@ -14,6 +14,13 @@ import (
 )
 
 func TestAccEscalationPolicyDataSource_basic(t *testing.T) {
+	// This fixture points mcp_url at an httptest server on 127.0.0.1, which the
+	// provider rejects by default. The opt-in env var is scoped to this test so
+	// the production gate (default-deny localhost for mcp_url) remains intact
+	// for real users; it is only relaxed here, where the loopback target is the
+	// test server we just spun up in-process.
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -38,7 +45,9 @@ func TestAccEscalationPolicyDataSource_basic(t *testing.T) {
 	}))
 	defer server.Close()
 
-	tfresource.ParallelTest(t, tfresource.TestCase{
+	// Note: using tfresource.Test rather than ParallelTest because t.Setenv
+	// above is incompatible with t.Parallel (the Go testing runtime panics).
+	tfresource.Test(t, tfresource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []tfresource.TestStep{
 			{

--- a/internal/provider/logging.go
+++ b/internal/provider/logging.go
@@ -11,7 +11,32 @@ import (
 	hyperping "github.com/develeap/hyperping-go"
 )
 
-// TFLogAdapter adapts the Terraform plugin logging framework to the hyperping.Logger interface.
+// sensitiveLogFieldKeys are structured-log field names whose values are
+// always redacted regardless of content.
+var sensitiveLogFieldKeys = []string{
+	"api_key",
+	"apikey",
+	"Authorization",
+	"authorization",
+	"token",
+	"access_token",
+	"X-Api-Key",
+	"x-api-key",
+}
+
+// TFLogAdapter adapts the Terraform plugin logging framework to the
+// hyperping.Logger interface.
+//
+// Every Debug call applies tflog masking before emitting:
+//   - any field whose key matches a known sensitive header/parameter name is
+//     replaced with [REDACTED];
+//   - any value matching hyperping.APIKeyPattern (sk_...) is replaced with
+//     [REDACTED] regardless of field name, catching cases where a secret is
+//     logged under an unexpected key.
+//
+// This per-call masking is the runtime guarantee: a derived context built in
+// provider.Configure does not survive into the per-operation contexts that
+// the Terraform framework creates, so masking must be applied here.
 type TFLogAdapter struct{}
 
 // NewTFLogAdapter creates a new TFLogAdapter.
@@ -19,8 +44,10 @@ func NewTFLogAdapter() *TFLogAdapter {
 	return &TFLogAdapter{}
 }
 
-// Debug logs a debug-level message using tflog.
+// Debug logs a debug-level message using tflog, redacting sensitive fields.
 func (l *TFLogAdapter) Debug(ctx context.Context, msg string, fields map[string]interface{}) {
+	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, sensitiveLogFieldKeys...)
+	ctx = tflog.MaskAllFieldValuesRegexes(ctx, hyperping.APIKeyPattern)
 	tflog.Debug(ctx, msg, fields)
 }
 

--- a/internal/provider/logging_test.go
+++ b/internal/provider/logging_test.go
@@ -4,8 +4,12 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 
 	hyperping "github.com/develeap/hyperping-go"
 )
@@ -31,4 +35,41 @@ func TestTFLogAdapter_Debug(t *testing.T) {
 
 func TestTFLogAdapter_ImplementsLogger(t *testing.T) {
 	var _ hyperping.Logger = (*TFLogAdapter)(nil)
+}
+
+// TestTFLogAdapter_MasksAPIKey verifies that secrets emitted through the
+// adapter as structured fields are redacted before reaching Terraform's log
+// sink. This is the runtime safety net that justifies removing the dead
+// MaskAllFieldValuesRegexes calls in provider.Configure: the masking is
+// applied at every Debug call rather than relying on the framework to
+// propagate a derived context that it does not actually propagate.
+func TestTFLogAdapter_MasksAPIKey(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+
+	adapter := NewTFLogAdapter()
+	adapter.Debug(ctx, "outgoing request", map[string]interface{}{
+		"api_key":       "sk_real_secret_value_should_never_leak",
+		"Authorization": "Bearer sk_another_secret",
+		"method":        "GET",
+	})
+
+	logged := buf.String()
+	for _, secret := range []string{
+		"sk_real_secret_value_should_never_leak",
+		"sk_another_secret",
+	} {
+		if strings.Contains(logged, secret) {
+			t.Errorf("secret leaked to log output:\n%s", logged)
+		}
+	}
+	// A redaction marker must be present so the operator can confirm masking
+	// is engaged.
+	if !strings.Contains(logged, "[REDACTED]") && !strings.Contains(logged, "[MASKED]") {
+		t.Errorf("expected redaction marker in log output:\n%s", logged)
+	}
+	// Non-sensitive fields are still emitted normally.
+	if !strings.Contains(logged, "GET") {
+		t.Errorf("expected non-sensitive field 'GET' to remain in log output:\n%s", logged)
+	}
 }

--- a/internal/provider/logging_test.go
+++ b/internal/provider/logging_test.go
@@ -64,8 +64,8 @@ func TestTFLogAdapter_MasksAPIKey(t *testing.T) {
 		}
 	}
 	// A redaction marker must be present so the operator can confirm masking
-	// is engaged.
-	if !strings.Contains(logged, "[REDACTED]") && !strings.Contains(logged, "[MASKED]") {
+	// is engaged. tflog renders its default marker as "***".
+	if !strings.Contains(logged, "***") && !strings.Contains(logged, "[REDACTED]") && !strings.Contains(logged, "[MASKED]") {
 		t.Errorf("expected redaction marker in log output:\n%s", logged)
 	}
 	// Non-sensitive fields are still emitted normally.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	hyperping "github.com/develeap/hyperping-go"
 )
@@ -137,12 +136,11 @@ func (p *HyperpingProvider) Configure(ctx context.Context, req provider.Configur
 		return
 	}
 
-	// Mask sensitive fields in logs to prevent API key leaks in debug output
-	// Note: Context masking applies to logs in this Configure function only
-	_ = tflog.MaskAllFieldValuesRegexes(
-		tflog.MaskFieldValuesWithFieldKeys(ctx, "api_key"),
-		hyperping.APIKeyPattern,
-	)
+	// Note: sensitive-field masking is applied per Debug call inside
+	// TFLogAdapter (see internal/provider/logging.go). A masked context built
+	// here would not survive into the per-operation contexts the Terraform
+	// framework creates for resources and data sources, so we cannot rely on
+	// Configure-time masking alone.
 
 	// Create REST client
 	restClient := hyperping.NewClient(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -96,9 +96,10 @@ func (p *HyperpingProvider) Configure(ctx context.Context, req provider.Configur
 		baseURL = config.BaseURL.ValueString()
 
 		// SECURITY: Enforce domain allowlist AND HTTPS requirement to prevent credential theft.
-		// isAllowedBaseURL checks both the domain (*.hyperping.io only) and protocol (HTTPS required,
-		// except for localhost which is exempt for testing).
-		if !isAllowedBaseURL(baseURL) {
+		// isAllowedBaseURL checks both the domain (*.hyperping.io only) and protocol (HTTPS required).
+		// base_url retains a localhost exemption so httptest-driven unit and
+		// acceptance tests can continue to work out of the box.
+		if !isAllowedBaseURL(baseURL, true /* allowLocal */) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("base_url"),
 				"Invalid Base URL",
@@ -112,12 +113,18 @@ func (p *HyperpingProvider) Configure(ctx context.Context, req provider.Configur
 
 	if !config.MCPURL.IsNull() {
 		mcpURL = config.MCPURL.ValueString()
-		// Re-use same security check for MCP URL if it's not localhost
-		if !isAllowedBaseURL(mcpURL) {
+		// SECURITY: For mcp_url, the localhost exemption is gated behind an
+		// explicit opt-in (HYPERPING_ALLOW_LOCAL=1). Otherwise a malicious
+		// example or typo-squatted variable pointing mcp_url at
+		// http://localhost:8080 would ship the bearer token to whatever is
+		// listening on loopback.
+		allowLocalMCP := os.Getenv("HYPERPING_ALLOW_LOCAL") == "1"
+		if !isAllowedBaseURL(mcpURL, allowLocalMCP) {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("mcp_url"),
 				"Invalid MCP URL",
 				"The mcp_url must be an HTTPS URL pointing to a Hyperping API domain (*.hyperping.io). "+
+					"Localhost URLs are only accepted when HYPERPING_ALLOW_LOCAL=1 is set in the environment. "+
 					fmt.Sprintf("Provided: %s.", mcpURL),
 			)
 			return
@@ -213,25 +220,27 @@ func (p *HyperpingProvider) DataSources(_ context.Context) []func() datasource.D
 	}
 }
 
-// isAllowedBaseURL validates that a base URL points to an allowed Hyperping domain
-// and uses HTTPS (VULN-016: reject http:// to prevent credential leakage in cleartext).
-// Only *.hyperping.io and localhost (for testing) are permitted to prevent
+// isAllowedBaseURL validates that a URL points to an allowed Hyperping domain
+// and uses HTTPS (VULN-016: reject http:// to prevent credential leakage in
+// cleartext). Only *.hyperping.io is permitted by default, to prevent
 // credential theft via SSRF attacks.
-func isAllowedBaseURL(baseURL string) bool {
+//
+// When allowLocal is true, loopback hosts (localhost, 127.0.0.1, ::1) are
+// also accepted regardless of scheme, so httptest-driven tests and explicit
+// local-MCP development setups (gated by HYPERPING_ALLOW_LOCAL=1) can work.
+func isAllowedBaseURL(baseURL string, allowLocal bool) bool {
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
 		return false
 	}
 
-	// Require a scheme to avoid ambiguous parsing
 	host := parsed.Hostname()
 
-	// Allow localhost for local testing (127.0.0.1, ::1, localhost)
-	// Localhost is exempt from HTTPS requirement (httptest uses HTTP)
-	isLocalhost := host == "localhost" || host == "127.0.0.1" || host == "::1"
-
-	if isLocalhost {
-		return true
+	if allowLocal {
+		isLocalhost := host == "localhost" || host == "127.0.0.1" || host == "::1"
+		if isLocalhost {
+			return true
+		}
 	}
 
 	// Non-localhost targets MUST use HTTPS to prevent credential leakage (VULN-016)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -85,6 +85,73 @@ func TestProvider_DataSources(t *testing.T) {
 	}
 }
 
+// TestAccProvider_LocalMCPURLDeniedByDefault asserts that a localhost mcp_url
+// is rejected unless the operator explicitly opts in via the HYPERPING_ALLOW_LOCAL
+// environment variable. Without the gate, a malicious example or typo-squatted
+// module variable could redirect the bearer token to any process listening on
+// loopback.
+func TestAccProvider_LocalMCPURLDeniedByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hyperping.HeaderContentType, hyperping.ContentTypeJSON)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	// Ensure the opt-in env var is unset.
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key  = "hp_test_key"
+  base_url = %q
+  mcp_url  = "http://localhost:8080"
+}
+
+data "hyperping_monitors" "all" {}
+`, server.URL),
+				ExpectError: regexp.MustCompile("Invalid MCP URL"),
+			},
+		},
+	})
+}
+
+// TestAccProvider_LocalMCPURLAllowedWithOptIn asserts that setting
+// HYPERPING_ALLOW_LOCAL=1 re-enables the localhost exemption for mcp_url so
+// integration testing against a local MCP server remains possible.
+func TestAccProvider_LocalMCPURLAllowedWithOptIn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hyperping.HeaderContentType, hyperping.ContentTypeJSON)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key  = "hp_test_key"
+  base_url = %q
+  mcp_url  = "http://localhost:9"
+}
+
+data "hyperping_monitors" "all" {}
+`, server.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hyperping_monitors.all", "monitors.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccProvider_MissingAPIKey(t *testing.T) {
 	// Save and unset the env var to test missing API key scenario
 	originalKey := os.Getenv("HYPERPING_API_KEY")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -365,9 +365,32 @@ func TestIsAllowedBaseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isAllowedBaseURL(tt.baseURL)
+			// Historic cases were written against the base_url path, which
+			// retains the localhost exemption (allowLocal=true).
+			got := isAllowedBaseURL(tt.baseURL, true)
 			if got != tt.want {
-				t.Errorf("isAllowedBaseURL(%q) = %v, want %v", tt.baseURL, got, tt.want)
+				t.Errorf("isAllowedBaseURL(%q, true) = %v, want %v", tt.baseURL, got, tt.want)
+			}
+		})
+	}
+
+	// Additional cases for the no-local-exemption path (mcp_url default).
+	denyLocalCases := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{"local http denied without allowLocal", "http://localhost:8080", false},
+		{"local 127.0.0.1 denied without allowLocal", "http://127.0.0.1:8080", false},
+		{"local ipv6 denied without allowLocal", "http://[::1]", false},
+		{"local https denied without allowLocal (not a hyperping host)", "https://localhost", false},
+		{"hyperping.io still allowed without allowLocal", "https://api.hyperping.io", true},
+	}
+	for _, tt := range denyLocalCases {
+		t.Run("noLocal/"+tt.name, func(t *testing.T) {
+			got := isAllowedBaseURL(tt.baseURL, false)
+			if got != tt.want {
+				t.Errorf("isAllowedBaseURL(%q, false) = %v, want %v", tt.baseURL, got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -383,7 +383,7 @@ func TestIsAllowedBaseURL(t *testing.T) {
 		{"local http denied without allowLocal", "http://localhost:8080", false},
 		{"local 127.0.0.1 denied without allowLocal", "http://127.0.0.1:8080", false},
 		{"local ipv6 denied without allowLocal", "http://[::1]", false},
-		{"local https denied without allowLocal (not a hyperping host)", "https://localhost", false},
+		{"https://localhost rejected by hyperping-host allowlist when allowLocal off", "https://localhost", false},
 		{"hyperping.io still allowed without allowLocal", "https://api.hyperping.io", true},
 	}
 	for _, tt := range denyLocalCases {

--- a/internal/provider/statuspage_mapping_coverage_test.go
+++ b/internal/provider/statuspage_mapping_coverage_test.go
@@ -1299,7 +1299,7 @@ func TestMapSettingsToTFWithFilter_WithOptionalValues(t *testing.T) {
 }
 
 // =============================================================================
-// isAllowedBaseURL edge case — port in domain
+// isAllowedBaseURL edge case (port in domain)
 // =============================================================================
 
 func TestIsAllowedBaseURL_PortVariants(t *testing.T) {
@@ -1316,9 +1316,9 @@ func TestIsAllowedBaseURL_PortVariants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isAllowedBaseURL(tt.baseURL)
+			got := isAllowedBaseURL(tt.baseURL, true)
 			if got != tt.want {
-				t.Errorf("isAllowedBaseURL(%q) = %v, want %v", tt.baseURL, got, tt.want)
+				t.Errorf("isAllowedBaseURL(%q, true) = %v, want %v", tt.baseURL, got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/testutil/vcr.go
+++ b/internal/provider/testutil/vcr.go
@@ -38,6 +38,7 @@ package testutil
 
 import (
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,15 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
+
+// sensitiveQueryParams lists URL query parameter names whose VALUES must be
+// stripped before a cassette is written to disk.
+var sensitiveQueryParams = map[string]struct{}{
+	"api_key":      {},
+	"apikey":       {},
+	"token":        {},
+	"access_token": {},
+}
 
 // VCRMode determines how VCR handles HTTP requests.
 type VCRMode int
@@ -130,15 +140,57 @@ func maskSensitiveHeaders(i *cassette.Interaction) {
 		i.Request.Headers.Set("Authorization", "Bearer [MASKED]")
 	}
 
-	// Mask any API keys in URL query params (shouldn't happen but be safe)
-	if strings.Contains(i.Request.URL, "api_key=") {
-		i.Request.URL = strings.ReplaceAll(i.Request.URL, "api_key=", "api_key=[MASKED]")
-	}
+	// Mask sensitive query-parameter VALUES (api_key, token, ...) in the URL.
+	// The previous implementation only rewrote the parameter NAME, which left
+	// the value plaintext on disk; see security audit finding HIGH-2.
+	i.Request.URL = maskSensitiveQueryValues(i.Request.URL)
 
 	// Mask Set-Cookie headers
 	if cookie := i.Response.Headers.Get("Set-Cookie"); cookie != "" {
 		i.Response.Headers.Set("Set-Cookie", "[MASKED]")
 	}
+}
+
+// maskSensitiveQueryValues parses the URL, replaces every value of any
+// parameter in sensitiveQueryParams with "[MASKED]", and re-serializes the
+// URL. If the URL fails to parse, it is returned untouched (the underlying
+// string is opaque to us, so we cannot safely mutate substrings without
+// risking leaving secrets behind).
+//
+// We rebuild RawQuery by hand rather than calling url.Values.Encode() so the
+// "[MASKED]" sentinel is not percent-encoded into "%5BMASKED%5D", which would
+// hide the substring test cassette reviewers look for.
+func maskSensitiveQueryValues(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.RawQuery == "" {
+		return raw
+	}
+	pairs := strings.Split(u.RawQuery, "&")
+	mutated := false
+	for idx, pair := range pairs {
+		key, _, hasEq := strings.Cut(pair, "=")
+		decodedKey, derr := url.QueryUnescape(key)
+		if derr != nil {
+			decodedKey = key
+		}
+		if _, sensitive := sensitiveQueryParams[decodedKey]; !sensitive {
+			continue
+		}
+		if hasEq {
+			pairs[idx] = key + "=[MASKED]"
+		} else {
+			pairs[idx] = key + "=[MASKED]"
+		}
+		mutated = true
+	}
+	if !mutated {
+		return raw
+	}
+	u.RawQuery = strings.Join(pairs, "&")
+	return u.String()
 }
 
 // GetRecordMode returns the VCR mode based on environment variables.

--- a/internal/provider/testutil/vcr.go
+++ b/internal/provider/testutil/vcr.go
@@ -171,7 +171,7 @@ func maskSensitiveQueryValues(raw string) string {
 	pairs := strings.Split(u.RawQuery, "&")
 	mutated := false
 	for idx, pair := range pairs {
-		key, _, hasEq := strings.Cut(pair, "=")
+		key, _, _ := strings.Cut(pair, "=")
 		decodedKey, derr := url.QueryUnescape(key)
 		if derr != nil {
 			decodedKey = key
@@ -179,11 +179,10 @@ func maskSensitiveQueryValues(raw string) string {
 		if _, sensitive := sensitiveQueryParams[decodedKey]; !sensitive {
 			continue
 		}
-		if hasEq {
-			pairs[idx] = key + "=[MASKED]"
-		} else {
-			pairs[idx] = key + "=[MASKED]"
-		}
+		// Always emit "<key>=[MASKED]" regardless of whether the original pair
+		// contained an equals sign: if a sensitive parameter appears without a
+		// value, we still want the value position explicitly masked.
+		pairs[idx] = key + "=[MASKED]"
 		mutated = true
 	}
 	if !mutated {

--- a/internal/provider/testutil/vcr.go
+++ b/internal/provider/testutil/vcr.go
@@ -49,7 +49,9 @@ import (
 )
 
 // sensitiveQueryParams lists URL query parameter names whose VALUES must be
-// stripped before a cassette is written to disk.
+// stripped before a cassette is written to disk. Keys are stored lowercase;
+// lookups must lowercase the decoded parameter name first so variations such
+// as "Api_Key", "API_KEY", "Token", and "aPi_KeY" are all caught.
 var sensitiveQueryParams = map[string]struct{}{
 	"api_key":      {},
 	"apikey":       {},
@@ -176,7 +178,9 @@ func maskSensitiveQueryValues(raw string) string {
 		if derr != nil {
 			decodedKey = key
 		}
-		if _, sensitive := sensitiveQueryParams[decodedKey]; !sensitive {
+		// Look up case-insensitively but preserve the original key casing
+		// in the rewritten pair so cassette diffs remain human-readable.
+		if _, sensitive := sensitiveQueryParams[strings.ToLower(decodedKey)]; !sensitive {
 			continue
 		}
 		// Always emit "<key>=[MASKED]" regardless of whether the original pair

--- a/internal/provider/testutil/vcr_test.go
+++ b/internal/provider/testutil/vcr_test.go
@@ -123,11 +123,11 @@ func TestMaskSensitiveHeaders(t *testing.T) {
 		}
 	})
 
-	t.Run("masks api_key in URL", func(t *testing.T) {
+	t.Run("masks api_key value in URL", func(t *testing.T) {
 		interaction := &cassette.Interaction{
 			Request: cassette.Request{
 				Headers: http.Header{},
-				URL:     "https://api.example.com/v1/test?api_key=secret123",
+				URL:     "https://api.example.com/v1/test?api_key=sk_real_secret_value&page=2",
 			},
 			Response: cassette.Response{
 				Headers: http.Header{},
@@ -136,9 +136,43 @@ func TestMaskSensitiveHeaders(t *testing.T) {
 
 		maskSensitiveHeaders(interaction)
 
-		// The masking replaces "api_key=" with "api_key=[MASKED]"
+		// The masker must replace the VALUE of api_key, not just the parameter name.
 		if !strings.Contains(interaction.Request.URL, "api_key=[MASKED]") {
 			t.Errorf("expected api_key=[MASKED] in URL, got: %s", interaction.Request.URL)
+		}
+		if strings.Contains(interaction.Request.URL, "sk_real_secret_value") {
+			t.Errorf("secret value leaked into cassette URL: %s", interaction.Request.URL)
+		}
+		// Other query parameters must survive unchanged.
+		if !strings.Contains(interaction.Request.URL, "page=2") {
+			t.Errorf("non-sensitive query param dropped: %s", interaction.Request.URL)
+		}
+	})
+
+	t.Run("masks token and apikey and access_token query params", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			url    string
+			secret string
+		}{
+			{"token", "https://api.example.com/v1/x?token=sk_alpha_secret", "sk_alpha_secret"},
+			{"apikey", "https://api.example.com/v1/x?apikey=sk_beta_secret", "sk_beta_secret"},
+			{"access_token", "https://api.example.com/v1/x?access_token=sk_gamma_secret", "sk_gamma_secret"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				i := &cassette.Interaction{
+					Request:  cassette.Request{Headers: http.Header{}, URL: tc.url},
+					Response: cassette.Response{Headers: http.Header{}},
+				}
+				maskSensitiveHeaders(i)
+				if strings.Contains(i.Request.URL, tc.secret) {
+					t.Errorf("secret leaked: %s", i.Request.URL)
+				}
+				if !strings.Contains(i.Request.URL, "[MASKED]") {
+					t.Errorf("expected [MASKED] in URL, got: %s", i.Request.URL)
+				}
+			})
 		}
 	})
 

--- a/internal/provider/testutil/vcr_test.go
+++ b/internal/provider/testutil/vcr_test.go
@@ -149,6 +149,42 @@ func TestMaskSensitiveHeaders(t *testing.T) {
 		}
 	})
 
+	t.Run("masks sensitive query params case-insensitively", func(t *testing.T) {
+		// Real-world APIs (and operator-crafted URLs) use varying capitalisations
+		// for the same parameter name. The masker must treat the parameter name
+		// case-insensitively while preserving the original casing in the output
+		// (so cassette diffs remain readable). Locking this in here: a future
+		// change that reverts to a case-sensitive map lookup would let secrets
+		// hit disk under `Api_Key=...`, `API_KEY=...`, or `Token=...`.
+		cases := []struct {
+			name     string
+			url      string
+			secret   string
+			wantPair string // pair that must appear verbatim in the masked URL
+		}{
+			{"PascalCase Api_Key", "https://api.example.com/v1/x?Api_Key=sk_real_value", "sk_real_value", "Api_Key=[MASKED]"},
+			{"upper API_KEY", "https://api.example.com/v1/x?API_KEY=sk_real_value", "sk_real_value", "API_KEY=[MASKED]"},
+			{"title Token", "https://api.example.com/v1/x?Token=secret_value", "secret_value", "Token=[MASKED]"},
+			{"jagged aPi_KeY", "https://api.example.com/v1/x?aPi_KeY=sk_xxx", "sk_xxx", "aPi_KeY=[MASKED]"},
+			{"upper Access_Token", "https://api.example.com/v1/x?Access_Token=tk_yyy", "tk_yyy", "Access_Token=[MASKED]"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				i := &cassette.Interaction{
+					Request:  cassette.Request{Headers: http.Header{}, URL: tc.url},
+					Response: cassette.Response{Headers: http.Header{}},
+				}
+				maskSensitiveHeaders(i)
+				if strings.Contains(i.Request.URL, tc.secret) {
+					t.Errorf("secret leaked under non-lowercase key: %s", i.Request.URL)
+				}
+				if !strings.Contains(i.Request.URL, tc.wantPair) {
+					t.Errorf("expected %q in URL, got: %s", tc.wantPair, i.Request.URL)
+				}
+			})
+		}
+	})
+
 	t.Run("masks token and apikey and access_token query params", func(t *testing.T) {
 		cases := []struct {
 			name   string

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -564,7 +564,7 @@ func (v statusCodePatternValidator) ValidateString(_ context.Context, req valida
 			resp.Diagnostics.AddAttributeError(
 				req.Path,
 				"Invalid Status Code Range",
-				fmt.Sprintf("The range %q is inverted — the start class (%cxx) must be "+
+				fmt.Sprintf("The range %q is inverted: the start class (%cxx) must be "+
 					"less than or equal to the end class (%cxx).", value, value[0], value[4]),
 			)
 		}

--- a/pkg/migrate/escape.go
+++ b/pkg/migrate/escape.go
@@ -6,27 +6,48 @@ package migrate
 import "strings"
 
 // EscapeHCL escapes a string for safe inclusion in Terraform HCL.
-// It handles backslashes, double quotes, and newlines.
+//
+// In addition to backslashes, quotes, and control characters, this function
+// neutralizes HCL template-interpolation sequences (${...} and %{...}) by
+// doubling their leading sigil. This is critical when emitting untrusted
+// strings (monitor names, URLs, header values, etc.) into a generated .tf
+// file: without it, a value such as `${file("/etc/passwd")}` would be
+// evaluated by Terraform at plan time, enabling local-file exfiltration or
+// arbitrary HCL function execution against the operator's machine.
+//
+// The template-escape replacements MUST run after the backslash/quote
+// escaping (so we never accidentally double a sigil we just produced) and
+// before the result is wrapped in quotes by QuoteHCL.
 func EscapeHCL(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	s = strings.ReplaceAll(s, "\n", `\n`)
 	s = strings.ReplaceAll(s, "\r", `\r`)
 	s = strings.ReplaceAll(s, "\t", `\t`)
+	// Neutralize HCL template-interpolation sequences.
+	s = strings.ReplaceAll(s, "${", "$${")
+	s = strings.ReplaceAll(s, "%{", "%%{")
 	return s
 }
 
 // EscapeShell escapes a string for safe inclusion in a bash script.
-// It handles backslashes, double quotes, dollar signs, and backticks.
+// It handles backslashes, double quotes, dollar signs, backticks, and
+// embedded newlines/carriage returns (which would otherwise break out of
+// a single shell argument).
 func EscapeShell(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	s = strings.ReplaceAll(s, "$", `\$`)
 	s = strings.ReplaceAll(s, "`", "\\`")
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
 	return s
 }
 
 // QuoteHCL wraps a string in double quotes after escaping it for HCL.
+// Prefer this over fmt's %q verb when emitting untrusted data into
+// generated Terraform configuration: %q does not escape HCL template
+// sequences (${...} and %{...}).
 func QuoteHCL(s string) string {
 	return `"` + EscapeHCL(s) + `"`
 }

--- a/pkg/migrate/escape_test.go
+++ b/pkg/migrate/escape_test.go
@@ -29,6 +29,11 @@ func TestEscapeHCL(t *testing.T) {
 		{"interp env var", `${env.SECRET}`, `$${env.SECRET}`},
 		{"interp mixed", `${env.SECRET}_%{ "x" }`, `$${env.SECRET}_%%{ \"x\" }`},
 		{"interp dollar then template", `$${literal}`, `$$${literal}`},
+		// Pathological backslash + template start. The backslash must be doubled
+		// first; then ${ must be neutralized. Order matters: if the template
+		// escape ran before the backslash escape, we could end up doubling the
+		// sigil we just produced. Locking the ordering in with a regression case.
+		{"interp backslash then template", `\${x}`, `\\$${x}`},
 	}
 
 	for _, tt := range tests {

--- a/pkg/migrate/escape_test.go
+++ b/pkg/migrate/escape_test.go
@@ -23,6 +23,12 @@ func TestEscapeHCL(t *testing.T) {
 		{"tab", "col1\tcol2", `col1\tcol2`},
 		{"mixed", "say \"hello\"\nnext line", `say \"hello\"\nnext line`},
 		{"empty", "", ""},
+		// Template-interpolation injection prevention (HCL ${...} and %{...} sequences).
+		{"interp file()", `${file("/etc/passwd")}`, `$${file(\"/etc/passwd\")}`},
+		{"interp for", `%{for x in y}`, `%%{for x in y}`},
+		{"interp env var", `${env.SECRET}`, `$${env.SECRET}`},
+		{"interp mixed", `${env.SECRET}_%{ "x" }`, `$${env.SECRET}_%%{ \"x\" }`},
+		{"interp dollar then template", `$${literal}`, `$$${literal}`},
 	}
 
 	for _, tt := range tests {
@@ -46,6 +52,8 @@ func TestEscapeShell(t *testing.T) {
 		{"backtick", "run `ls`", "run \\`ls\\`"},
 		{"mixed", `var="$HOME"`, `var=\"\$HOME\"`},
 		{"empty", "", ""},
+		{"newline", "line1\nline2", `line1\nline2`},
+		{"carriage return", "line1\rline2", `line1\rline2`},
 	}
 
 	for _, tt := range tests {
@@ -60,4 +68,7 @@ func TestQuoteHCL(t *testing.T) {
 	assert.Equal(t, `"hello"`, QuoteHCL("hello"))
 	assert.Equal(t, `"say \"hi\""`, QuoteHCL(`say "hi"`))
 	assert.Equal(t, `""`, QuoteHCL(""))
+	// QuoteHCL must neutralize HCL template interpolation in the value.
+	assert.Equal(t, `"$${file(\"/etc/passwd\")}"`, QuoteHCL(`${file("/etc/passwd")}`))
+	assert.Equal(t, `"%%{for x in y}"`, QuoteHCL(`%{for x in y}`))
 }

--- a/pkg/migrate/uuid.go
+++ b/pkg/migrate/uuid.go
@@ -34,7 +34,7 @@ func SafeUUID(s string) (string, bool) {
 // bash double-quote-safe) literal. Inputs that do not match the safe UUID
 // pattern are replaced with the sentinel "INVALID_UUID_<hex>" before quoting,
 // so a malformed server response cannot smuggle command substitution
-// ($(...), ``...``), variable expansion ($VAR), or statement chaining (;) into
+// ($(...), “...“), variable expansion ($VAR), or statement chaining (;) into
 // the generated shell script.
 //
 // The sentinel preserves the script's structure (Terraform will fail the

--- a/pkg/migrate/uuid.go
+++ b/pkg/migrate/uuid.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// safeUUIDPattern matches identifiers we are willing to interpolate into
+// generated shell scripts. The Hyperping backend currently emits resource
+// UUIDs as hex with optional hyphens or short prefixed identifiers
+// (e.g. "mon_abc123"). This pattern is intentionally narrow: a single
+// non-conforming byte rejects the entire value rather than attempt partial
+// sanitisation.
+var safeUUIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// SafeUUID returns (value, true) when the input is a plausibly server-issued
+// UUID-shaped identifier (alphanumerics, underscores, hyphens). Otherwise it
+// returns ("", false). This is defense-in-depth: the API is the source of
+// truth for these identifiers, but if a future regression or partner-API
+// forwarding ever surfaces an attacker-influenced value, we want callers to
+// have an explicit boolean signal to refuse interpolating it into a shell
+// script or HCL document.
+func SafeUUID(s string) (string, bool) {
+	if s == "" || !safeUUIDPattern.MatchString(s) {
+		return "", false
+	}
+	return s, true
+}
+
+// QuoteShellUUID emits a UUID-shaped identifier as a Go-quoted (and thus
+// bash double-quote-safe) literal. Inputs that do not match the safe UUID
+// pattern are replaced with the sentinel "INVALID_UUID_<hex>" before quoting,
+// so a malformed server response cannot smuggle command substitution
+// ($(...), ``...``), variable expansion ($VAR), or statement chaining (;) into
+// the generated shell script.
+//
+// The sentinel preserves the script's structure (Terraform will fail the
+// import with a clear "resource not found" error), which is preferable to
+// silently emitting a corrupted value.
+func QuoteShellUUID(s string) string {
+	if _, ok := SafeUUID(s); !ok {
+		return fmt.Sprintf("%q", "INVALID_UUID_REJECTED_BY_SANITIZER")
+	}
+	// %q is safe here because the input is restricted to [A-Za-z0-9_-], which
+	// contains no Go-string-escape characters and no bash metacharacters.
+	return fmt.Sprintf("%q", s)
+}

--- a/pkg/migrate/uuid_test.go
+++ b/pkg/migrate/uuid_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestSafeUUID(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    string
-		wantOK  bool
+		name   string
+		input  string
+		want   string
+		wantOK bool
 	}{
 		{"empty", "", "", false},
 		{"plain uuid hex", "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000", true},

--- a/pkg/migrate/uuid_test.go
+++ b/pkg/migrate/uuid_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeUUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantOK  bool
+	}{
+		{"empty", "", "", false},
+		{"plain uuid hex", "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000", true},
+		{"prefixed safe id", "mon_abc123", "mon_abc123", true},
+		{"alphanumeric", "abcDEF0123", "abcDEF0123", true},
+		{"underscore", "mon_safe_123", "mon_safe_123", true},
+		{"hyphen", "mon-safe-123", "mon-safe-123", true},
+		// Adversarial inputs the server should never produce, but which we
+		// defend against in case of a backend bug or partner-API forwarding.
+		{"command sub", "$(rm -rf /)", "", false},
+		{"backtick", "`whoami`", "", false},
+		{"semicolon chain", "abc; rm -rf $HOME", "", false},
+		{"single quote escape", "'; rm -rf $HOME; '", "", false},
+		{"shell var", "$HOME", "", false},
+		{"space", "abc 123", "", false},
+		{"slash", "../etc/passwd", "", false},
+		{"newline", "abc\nrm", "", false},
+		{"hcl template", `${file("/etc/passwd")}`, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := SafeUUID(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestQuoteShellUUID(t *testing.T) {
+	// Whitelisted UUID -> Go-quoted form unchanged.
+	assert.Equal(t, `"mon_abc123"`, QuoteShellUUID("mon_abc123"))
+	assert.Equal(t, `"550e8400-e29b-41d4-a716-446655440000"`, QuoteShellUUID("550e8400-e29b-41d4-a716-446655440000"))
+
+	// Adversarial values must be replaced with the sentinel so they cannot
+	// expand in a bash double-quoted string.
+	bad := QuoteShellUUID("$(rm -rf /)")
+	assert.NotContains(t, bad, "$(")
+	assert.Contains(t, bad, "INVALID_UUID")
+
+	bad2 := QuoteShellUUID("`whoami`")
+	assert.NotContains(t, bad2, "`")
+	assert.Contains(t, bad2, "INVALID_UUID")
+
+	bad3 := QuoteShellUUID("abc; rm -rf $HOME")
+	assert.NotContains(t, bad3, ";")
+	assert.NotContains(t, bad3, "$HOME")
+	assert.Contains(t, bad3, "INVALID_UUID")
+}


### PR DESCRIPTION
## Summary

Lands the security fixes from the recent audit. TDD throughout where the
finding is testable; the CI-workflow and cosmetic items are called out as
non-TDD.

## Commits to findings

- `ebc80d7` test(migrate) + `0783599` fix(security): **CRITICAL-1** HCL
  template-interpolation injection. `EscapeHCL`/`QuoteHCL` now neutralize
  `${...}` and `%{...}`; every `%q` in HCL-emitting code switched to
  `migrate.QuoteHCL`. Includes an integration test that drives the
  UptimeRobot generator with `\${file("/etc/passwd")}` as the monitor name
  and asserts the output has no unescaped template start. `EscapeShell`
  also gained newline/CR escaping (**LOW-6**).
- `c7f4cdd` test(testutil) + `eb6cbf2` fix(security): **HIGH-2** VCR
  cassette masker. The old `ReplaceAll("api_key=", "api_key=[MASKED]")`
  rewrote the parameter NAME and left the VALUE plaintext; replaced with
  a `url.Parse`-based walker that masks `api_key`/`apikey`/`token`/
  `access_token` values.
- `7014967` test(provider) + `556a5d0` fix(security): **HIGH-3** provider
  log redaction. The old `_ = tflog.MaskAllFieldValuesRegexes(...)` was
  dead code; the masked context never reached operations downstream of
  `Configure`. Moved masking into `TFLogAdapter.Debug` so every log call
  is redacted at emit time. Test uses `tflogtest.RootLogger` to capture
  output and assert that secrets do not leak.
- `1b5f1bf` test(provider) + `ff4addd` fix(security): **MEDIUM-4**
  `mcp_url` localhost allowlist bypass. `isAllowedBaseURL` now takes an
  `allowLocal` flag. `base_url` keeps its localhost exemption for
  `httptest`-driven tests, but `mcp_url` requires
  `HYPERPING_ALLOW_LOCAL=1` to accept loopback targets.
- `e4d2d5c` fix(ci,style): **MEDIUM-5** acceptance-test gate (job-level
  `env.HYPERPING_API_KEY != ''` always evaluated to false because the
  secret is only attached inside the step's env block) plus **NIT-7**
  em-dash in the status-code-range validator diagnostic. Both are
  non-TDD: CI fix verifies on the next workflow run, diagnostic edit is
  a cosmetic string change.
- `9dd2119` fix(testutil): collapse identical if/else branches in the
  new query-mask helper flagged by gocritic `dupBranchBody`.

## Out of scope (intentionally deferred)

- `hyperping-go` bump: SDK fixes land in a parallel branch on the SDK
  repo; do not couple them.
- Unused mock-server setters in `healthcheck_resource_acceptance_test.go`
  and `outage_resource_acceptance_test.go`: separate hygiene PR.
- Provider doc regeneration: no schema changes affect docs.

## Test plan

- [x] `go test ./... -race -count=1` (2123 passed)
- [x] `go vet ./...` (clean)
- [x] `golangci-lint run ./internal/provider/... ./pkg/... ./cmd/...`
      (one pre-existing G115 in `error_integration_test.go`; no new
      findings)
- [x] `govulncheck ./...` (no vulnerabilities found)
- [ ] Confirm the unskipped acceptance-test step runs on this branch's
      CI (the skip-with-reason branch is the expected path on PRs from
      forks).