### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-05-31
+
 ### Security
 
 - HCL template-interpolation injection closed across all generator paths (`cmd/migrate-uptimerobot`, `cmd/migrate-pingdom`, `cmd/import-generator`). Untrusted string fields (monitor names, URLs, header values) now flow through `pkg/migrate.QuoteHCL`, which doubles the leading sigil on `${...}` and `%{...}` sequences so Terraform treats them as literal text rather than evaluating them at plan time.
@@ -21,12 +23,31 @@ Published releases start from v1.0.3.
 ### Changed
 
 - `mcp_url` set to a localhost address now requires `HYPERPING_ALLOW_LOCAL=1`. **Breaking** for any configuration that pointed `mcp_url` at `http://localhost`, `http://127.0.0.1`, or `http://[::1]` without setting the env var. The `base_url` provider attribute retains the localhost exemption to avoid breaking acceptance-test setups.
+- Bumped `github.com/develeap/hyperping-go` from v0.6.1 to v0.6.2. Pulls in the MCP transport 10 MB response-body cap, `WithMCPHTTPClient` transport rewrap so caller-supplied clients no longer bypass the TLS 1.2+ floor or drop the Bearer auth wrapper, RFC 6750 challenge-parameter preservation in the Bearer redactor (`realm=`, `scope=`, `error=`, `error_description=`, `error_uri=` no longer over-redacted), `Retry-After` clamping against hostile `86400`-second values, atomic publish of `(sessionID, initialized)` on initialize, and `enforceTLS` cloning caller transports instead of mutating them. `WithBaseURL` and `NewMcpTransport` now reject base URLs that embed userinfo (`https://user:pass@host`); the provider does not construct such URLs, so no provider-side call sites required adaptation.
 
 ### Added
 
 - `HYPERPING_ALLOW_LOCAL` environment variable. Set to `1` to re-enable the localhost exemption for `mcp_url` (intended for local integration testing against a development MCP server).
 - Case-insensitive masking of API-key-shaped query parameters (`api_key`, `apikey`, `token`, `access_token`) in VCR cassettes regardless of source URL casing.
 - `pkg/migrate.SafeUUID` and `pkg/migrate.QuoteShellUUID` helpers for validating and quoting server-issued identifiers before interpolating them into generated shell scripts.
+
+### Upgrade Notes
+
+If a previous configuration pointed `mcp_url` at a localhost address, the provider will now reject it at configure time. Either drop the override (the provider defaults to the public MCP endpoint) or opt in explicitly:
+
+```hcl
+provider "hyperping" {
+  api_key = var.hyperping_api_key
+  mcp_url = "http://localhost:8080"
+}
+```
+
+```bash
+export HYPERPING_ALLOW_LOCAL=1
+terraform plan
+```
+
+`HYPERPING_ALLOW_LOCAL` is intended for local integration testing only. Leave it unset in CI and production.
 
 ## [1.11.1] - 2026-05-31
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.6.1
+	github.com/develeap/hyperping-go v0.6.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/develeap/hyperping-go v0.6.1 h1:WT/PYrm7zm0Kuz/QEHf2ccqwXNLhvgxx1ch2v+WOnaA=
-github.com/develeap/hyperping-go v0.6.1/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
+github.com/develeap/hyperping-go v0.6.2 h1:OQmWfYKPTu6qR1ChGrFGJQ+1oTkqyS1Cz4q5tc1h5CU=
+github.com/develeap/hyperping-go v0.6.2/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

- Releases v1.12.0 with the security audit work that landed on `main` (PR #138).
- Bumps `github.com/develeap/hyperping-go` from v0.6.1 to v0.6.2 to pick up the MCP transport response-body cap, `WithMCPHTTPClient` rewrap, RFC 6750 challenge-parameter preservation in the Bearer redactor, and `Retry-After` clamping.
- Consolidates the previously-drafted `[Unreleased]` security entries into a `[1.12.0]` section dated 2026-05-31.

## Breaking change

`mcp_url` set to a localhost address (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) now requires `HYPERPING_ALLOW_LOCAL=1`. Local-dev configurations that override `mcp_url` to localhost without setting the env var will fail at provider configure time. The CHANGELOG carries the migration snippet under `Upgrade Notes`.

`WithBaseURL` and `NewMcpTransport` in hyperping-go v0.6.2 reject base URLs that embed userinfo, but the provider does not construct such URLs in any call site or test, so no provider-side adaptation was required.

## What changed

- `go.mod` / `go.sum`: hyperping-go v0.6.1 -> v0.6.2.
- `CHANGELOG.md`: new `[1.12.0]` section listing Security, Changed, Added, and Upgrade Notes.

## Release sequence after merge

1. CI green, then squash-merge with `--admin`.
2. Tag `v1.12.0` on the merge commit.
3. Wait for the tag-triggered release workflow to publish the draft GitHub release.
4. Replace the default draft body with notes covering the security work, the breaking `mcp_url` change, and the SDK bump, then publish.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -race` (2153 tests across 25 packages, all green)
- [ ] CI green on this PR
- [ ] Release workflow produces draft after tag push
- [ ] Final release notes published with migration snippet visible