### PR TITLE
chore: bump hyperping-go v0.6.2 → v0.6.3 (HTTP/2 ALPN fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump `github.com/develeap/hyperping-go` v0.6.2 to v0.6.3. v0.6.2 had a critical HTTP/2 ALPN regression that broke all HTTPS API calls to non-localhost servers (manifested as `Unsolicited response received on idle HTTP channel` errors with `\x00\x00\x12\x04` byte patterns, i.e. HTTP/2 SETTINGS frames being misread by Go's HTTP/1 parser). Affects both REST and MCP paths. Upstream fix: https://github.com/develeap/hyperping-go/pull/37.
+
 ## [1.12.0] - 2026-05-31
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Published releases start from v1.0.3.
 
 - Bump `github.com/develeap/hyperping-go` v0.6.2 to v0.6.3. v0.6.2 had a critical HTTP/2 ALPN regression that broke all HTTPS API calls to non-localhost servers (manifested as `Unsolicited response received on idle HTTP channel` errors with `\x00\x00\x12\x04` byte patterns, i.e. HTTP/2 SETTINGS frames being misread by Go's HTTP/1 parser). Affects both REST and MCP paths. Upstream fix: https://github.com/develeap/hyperping-go/pull/37.
 
+### Security
+
+- Bump Go toolchain `1.26.3` to `1.26.4`. Resolves two newly-disclosed stdlib CVEs: `GO-2026-5039` (arbitrary inputs unescaped in `net/textproto` errors) and `GO-2026-5037` / `CVE-2026-42504` (inefficient candidate hostname parsing in `crypto/x509`). Both fixed in stdlib 1.26.4. CI picks up the new version automatically via `go-version-file: 'go.mod'`.
+
 ## [1.12.0] - 2026-05-31
 
 ### Security

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/briandowns/spinner v1.23.2
-	github.com/develeap/hyperping-go v0.6.2
+	github.com/develeap/hyperping-go v0.6.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/develeap/terraform-provider-hyperping
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/develeap/hyperping-go v0.6.2 h1:OQmWfYKPTu6qR1ChGrFGJQ+1oTkqyS1Cz4q5tc1h5CU=
-github.com/develeap/hyperping-go v0.6.2/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
+github.com/develeap/hyperping-go v0.6.3 h1:cELYa3s4NsSePCNozxWqMebRrImG+OCqYt/EzmzXQg0=
+github.com/develeap/hyperping-go v0.6.3/go.mod h1:LReXmCFW1WF/KKJ6Qa+uJe8HgyihFMd4fEDYGQ0wPII=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
## Summary

Bumps `github.com/develeap/hyperping-go` from v0.6.2 to v0.6.3. v0.6.2 shipped a critical HTTP/2 ALPN regression that broke all HTTPS API calls to non-localhost servers: a `RoundTripper` was constructed without HTTP/2 ALPN negotiation enabled, so when `api.hyperping.io` (and any TLS endpoint speaking h2) responded with an HTTP/2 SETTINGS frame, Go's HTTP/1 parser misread the binary frame bytes and surfaced them as `Unsolicited response received on idle HTTP channel` errors containing the `\x00\x00\x12\x04` SETTINGS-frame signature. Both REST and MCP paths in this provider were affected, making v1.12.0 unusable against production Hyperping. v0.6.3 restores the prior transport configuration so ALPN advertises both `h2` and `http/1.1` again.

Full root-cause analysis and patch: https://github.com/develeap/hyperping-go/pull/37.

This brings the provider back to a known-good SDK version.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes (2153 tests across 25 packages, no behavior change in the provider, fix is upstream)
- [x] `go mod tidy` produced only the v0.6.2 to v0.6.3 hash swap in `go.sum`; no transitive dep movement
- [ ] Reviewer-side: acceptance tests against a real Hyperping account (not run here)