### PR TITLE
test(provider): strict MCP fixture validation (TF-06)

### DIFF
--- a/internal/provider/escalation_policy_data_source_test.go
+++ b/internal/provider/escalation_policy_data_source_test.go
@@ -4,10 +4,7 @@
 package provider
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -21,28 +18,31 @@ func TestAccEscalationPolicyDataSource_basic(t *testing.T) {
 	// test server we just spun up in-process.
 	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		var rpcReq struct {
-			Method string `json:"method"`
-		}
-		json.NewDecoder(r.Body).Decode(&rpcReq)
-
-		if rpcReq.Method == "initialize" {
-			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}`)
-			return
-		}
-
-		if rpcReq.Method == "tools/call" {
-			// Simulate ListEscalationPolicies tool call
-			// Note: hyperping-go transport expects tool response to be JSON string in content[0].text
-			resultJSON := `[{"uuid":"ep_123","name":"SRE-Policy","team":"SRE-Team","steps":[{"delay":5,"target_type":"user","target_id":"u_1"}]}]`
-			escaped, _ := json.Marshal(resultJSON)
-			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":%s}]}}`, escaped)
-			return
-		}
-	}))
+	// Strict fixture: rejects the v0.6.x nil-arguments wire shape the way
+	// the live /v1/mcp endpoint does. ListEscalationPolicies in
+	// hyperping-go v0.7.1 sends arguments:{} so this path stays green;
+	// any future regression to omitted/null arguments would fail here
+	// instead of silently going green like the pre-TF-06 fixture.
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": {
+			Handler: func(_ map[string]any) (any, error) {
+				return []any{
+					map[string]any{
+						"uuid": "ep_123",
+						"name": "SRE-Policy",
+						"team": "SRE-Team",
+						"steps": []any{
+							map[string]any{
+								"delay":       5,
+								"target_type": "user",
+								"target_id":   "u_1",
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	})
 	defer server.Close()
 
 	// Note: using tfresource.Test rather than ParallelTest because t.Setenv

--- a/internal/provider/mcp_data_sources_acceptance_test.go
+++ b/internal/provider/mcp_data_sources_acceptance_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+// Acceptance tests that exercise the four remaining MCP-backed data
+// sources (escalation_policies, integrations, on_call_schedules,
+// on_call_schedule) end-to-end against the strict MCP fixture introduced
+// for TF-06. The pre-TF-06 test suite had no httptest-backed coverage
+// for these four data sources, so the v0.6.x silent breakage was
+// invisible in CI. With the strict fixture in place, any future
+// regression to the nil-arguments wire shape (or to a stale result
+// envelope) would fail one of these tests.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	tfresource "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccEscalationPoliciesDataSource_basic(t *testing.T) {
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": {
+			Handler: func(_ map[string]any) (any, error) {
+				return []any{
+					map[string]any{
+						"uuid":  "ep_a",
+						"name":  "A-Policy",
+						"team":  "SRE",
+						"steps": []any{},
+					},
+					map[string]any{
+						"uuid": "ep_b",
+						"name": "B-Policy",
+						"team": "Platform",
+						"steps": []any{
+							map[string]any{
+								"delay":       10,
+								"target_type": "schedule",
+								"target_id":   "sch_1",
+							},
+						},
+					},
+				}, nil
+			},
+		},
+	})
+	defer server.Close()
+
+	tfresource.Test(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key = "sk_test"
+  mcp_url = %[1]q
+}
+
+data "hyperping_escalation_policies" "all" {}
+`, server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("data.hyperping_escalation_policies.all", "policies.#", "2"),
+					tfresource.TestCheckResourceAttr("data.hyperping_escalation_policies.all", "ids.#", "2"),
+					tfresource.TestCheckResourceAttr("data.hyperping_escalation_policies.all", "ids.0", "ep_a"),
+					tfresource.TestCheckResourceAttr("data.hyperping_escalation_policies.all", "ids.1", "ep_b"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIntegrationsDataSource_basic(t *testing.T) {
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
+	// list_integrations returns a top-level array per the v0.7.1 SDK
+	// contract (mcp_client.go ListIntegrations does result.([]any)).
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_integrations": {
+			Handler: func(_ map[string]any) (any, error) {
+				return []any{
+					map[string]any{
+						"uuid":         "int_1",
+						"name":         "Slack-Prod",
+						"type":         "slack",
+						"enabled":      true,
+						"last_test_at": "2026-06-08T00:00:00Z",
+						"created_at":   "2026-01-15T00:00:00Z",
+					},
+				}, nil
+			},
+		},
+	})
+	defer server.Close()
+
+	tfresource.Test(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key = "sk_test"
+  mcp_url = %[1]q
+}
+
+data "hyperping_integrations" "all" {}
+`, server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "integrations.#", "1"),
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "integrations.0.id", "int_1"),
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "integrations.0.name", "Slack-Prod"),
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "integrations.0.type", "slack"),
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "integrations.0.enabled", "true"),
+					tfresource.TestCheckResourceAttr("data.hyperping_integrations.all", "ids.0", "int_1"),
+				),
+			},
+		},
+	})
+}
+
+// onCallSchedulesStub returns the result envelope shape the v0.7.1 SDK
+// expects from list_on_call_schedules: an object with a "schedules" key
+// whose value is an array of schedule records. ListOnCallSchedules in
+// mcp_client.go does data["schedules"].([]any), so a top-level array
+// would silently return zero schedules. Centralizing the envelope here
+// keeps the two acceptance tests below in lockstep with that contract.
+func onCallSchedulesStub() any {
+	return map[string]any{
+		"schedules": []any{
+			map[string]any{
+				"uuid":           "sch_1",
+				"name":           "Primary-Rotation",
+				"team":           "SRE",
+				"current_oncall": "alice@example.com",
+				"next_oncall":    "bob@example.com",
+				"rotation_start": "2026-06-01T00:00:00Z",
+				"rotation_end":   "2026-06-08T00:00:00Z",
+			},
+		},
+	}
+}
+
+func TestAccOnCallSchedulesDataSource_basic(t *testing.T) {
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_on_call_schedules": {
+			Handler: func(_ map[string]any) (any, error) { return onCallSchedulesStub(), nil },
+		},
+	})
+	defer server.Close()
+
+	tfresource.Test(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key = "sk_test"
+  mcp_url = %[1]q
+}
+
+data "hyperping_on_call_schedules" "all" {}
+`, server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedules.all", "schedules.#", "1"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedules.all", "schedules.0.id", "sch_1"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedules.all", "schedules.0.name", "Primary-Rotation"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedules.all", "schedules.0.current_oncall", "alice@example.com"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedules.all", "ids.0", "sch_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOnCallScheduleDataSource_basic(t *testing.T) {
+	t.Setenv("HYPERPING_ALLOW_LOCAL", "1")
+
+	// OnCallScheduleDataSource.Read actually calls
+	// ListOnCallSchedules and filters client-side; see
+	// on_call_schedule_data_source.go:125. So the strict server only
+	// needs the list tool wired, not get_on_call_schedule.
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_on_call_schedules": {
+			Handler: func(_ map[string]any) (any, error) { return onCallSchedulesStub(), nil },
+		},
+	})
+	defer server.Close()
+
+	tfresource.Test(t, tfresource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []tfresource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "hyperping" {
+  api_key = "sk_test"
+  mcp_url = %[1]q
+}
+
+data "hyperping_on_call_schedule" "primary" {
+  name = "Primary-Rotation"
+}
+`, server.URL),
+				Check: tfresource.ComposeAggregateTestCheckFunc(
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedule.primary", "id", "sch_1"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedule.primary", "name", "Primary-Rotation"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedule.primary", "team", "SRE"),
+					tfresource.TestCheckResourceAttr("data.hyperping_on_call_schedule.primary", "current_oncall", "alice@example.com"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/mcp_testserver_strict_test.go
+++ b/internal/provider/mcp_testserver_strict_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// initSession opens an MCP session against srvURL by sending an initialize
+// request and capturing the Mcp-Session-Id response header. It also fires
+// the notifications/initialized post-handshake message because the live
+// server's tools/call validator requires a fully-initialized session.
+//
+// Returns the session id so the caller can attach it to subsequent
+// tools/call requests.
+func initSession(t *testing.T, srvURL string) string {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"strict-fixture-tests","version":"0.1"}}}`
+	req, err := http.NewRequest(http.MethodPost, srvURL, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build initialize request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("initialize call: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("initialize returned status %d", resp.StatusCode)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	sid := resp.Header.Get("Mcp-Session-Id")
+	if sid == "" {
+		t.Fatalf("initialize response did not include Mcp-Session-Id header")
+	}
+
+	// Best-effort notifications/initialized; the live server tolerates
+	// callers that skip this notification when their session was just
+	// minted, so a failure here is non-fatal.
+	notifyBody := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	nreq, _ := http.NewRequest(http.MethodPost, srvURL, strings.NewReader(notifyBody))
+	nreq.Header.Set("Content-Type", "application/json")
+	nreq.Header.Set("Accept", "application/json, text/event-stream")
+	nreq.Header.Set("Mcp-Session-Id", sid)
+	if nresp, err := http.DefaultClient.Do(nreq); err == nil {
+		_, _ = io.Copy(io.Discard, nresp.Body)
+		_ = nresp.Body.Close()
+	}
+
+	return sid
+}
+
+// callToolRaw POSTs an arbitrary JSON-RPC body (no envelope rewriting) to
+// the fixture and returns the parsed JSON-RPC response. Use this when a
+// test needs to control the request bytes precisely, e.g. to omit the
+// arguments key entirely or set it to null.
+func callToolRaw(t *testing.T, srvURL, sid, jsonRPCBody string) map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, srvURL, strings.NewReader(jsonRPCBody))
+	if err != nil {
+		t.Fatalf("build tools/call request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/call: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/call returned status %d, body=%s", resp.StatusCode, body)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("decode response: %v (body=%s)", err, body)
+	}
+	return parsed
+}
+
+// expectMCPValidationError walks the JSON-RPC response and asserts the
+// fixture produced the -32602 / Input validation shape the live server
+// emits for argument-shape violations. The error is wrapped as the
+// literal text of content[0].text rather than a top-level rpcResp.Error,
+// because that is exactly how hyperping-python and hyperping-go observed
+// the live server respond on 2026-06-08: the input validator runs inside
+// the tools/call handler, so its error rides in the call's result content
+// stream, not the JSON-RPC error channel.
+func expectMCPValidationError(t *testing.T, resp map[string]any) {
+	t.Helper()
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got %v", resp)
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("expected non-empty content array, got %v", result)
+	}
+	first, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected content[0] to be an object, got %T", content[0])
+	}
+	text, ok := first["text"].(string)
+	if !ok {
+		t.Fatalf("expected content[0].text to be a string, got %T", first["text"])
+	}
+	if !strings.Contains(text, "MCP error -32602") {
+		t.Fatalf("expected text to contain \"MCP error -32602\", got %q", text)
+	}
+	if !strings.Contains(text, "Input validation") {
+		t.Fatalf("expected text to contain \"Input validation\", got %q", text)
+	}
+}
+
+// noArgsTool is a convenience builder for a list-style tool that takes no
+// arguments and returns the supplied stub on a valid call.
+func noArgsTool(stub any) strictMCPTool {
+	return strictMCPTool{
+		Handler: func(_ map[string]any) (any, error) { return stub, nil },
+	}
+}
+
+// uuidTool is the get-style counterpart: requires uuid, rejects unknown
+// keys, returns the stub when validation passes.
+func uuidTool(stub any) strictMCPTool {
+	return strictMCPTool{
+		Properties: []string{"uuid"},
+		Required:   []string{"uuid"},
+		Handler:    func(_ map[string]any) (any, error) { return stub, nil },
+	}
+}
+
+func TestStrictMCPTestServer_RejectsMissingArguments(t *testing.T) {
+	t.Parallel()
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": noArgsTool([]any{}),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+	// Note: this request omits the arguments key entirely, exactly
+	// matching the v0.6.x hyperping-go transport bug.
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_escalation_policies"}}`
+	resp := callToolRaw(t, server.URL, sid, body)
+	expectMCPValidationError(t, resp)
+}
+
+func TestStrictMCPTestServer_RejectsNilArguments(t *testing.T) {
+	t.Parallel()
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": noArgsTool([]any{}),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_escalation_policies","arguments":null}}`
+	resp := callToolRaw(t, server.URL, sid, body)
+	expectMCPValidationError(t, resp)
+}
+
+func TestStrictMCPTestServer_RejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+	// list_escalation_policies has empty properties so any caller-
+	// supplied key is unknown. This guards against tests accidentally
+	// passing junk and getting away with it.
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": noArgsTool([]any{}),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_escalation_policies","arguments":{"banana":"x"}}}`
+	resp := callToolRaw(t, server.URL, sid, body)
+	expectMCPValidationError(t, resp)
+}
+
+func TestStrictMCPTestServer_RejectsMissingRequiredField(t *testing.T) {
+	t.Parallel()
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"get_escalation_policy": uuidTool(map[string]any{}),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_escalation_policy","arguments":{}}}`
+	resp := callToolRaw(t, server.URL, sid, body)
+	expectMCPValidationError(t, resp)
+}
+
+func TestStrictMCPTestServer_AcceptsEmptyArgumentsObject(t *testing.T) {
+	t.Parallel()
+	stub := []any{
+		map[string]any{
+			"uuid":  "esc_abc",
+			"name":  "Primary",
+			"team":  "SRE",
+			"steps": []any{},
+		},
+	}
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": noArgsTool(stub),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_escalation_policies","arguments":{}}}`
+	resp := callToolRaw(t, server.URL, sid, body)
+
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result object, got %v", resp)
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("expected non-empty content array, got %v", result)
+	}
+	first := content[0].(map[string]any)
+	text, ok := first["text"].(string)
+	if !ok {
+		t.Fatalf("expected content[0].text to be a string")
+	}
+	var decoded []any
+	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+		t.Fatalf("content[0].text should be valid JSON, got %q: %v", text, err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("expected one element in stub result, got %d", len(decoded))
+	}
+	first0 := decoded[0].(map[string]any)
+	if first0["uuid"] != "esc_abc" {
+		t.Fatalf("expected uuid esc_abc, got %v", first0["uuid"])
+	}
+}
+
+// TestEscalationPoliciesDataSource_FailsAgainstStrictServer_WhenBugRegressedToNilArgs
+// is the load-bearing regression guard. It hand-drives a tools/call against
+// the strict fixture using the buggy pre-v0.7.1 wire shape (no arguments
+// key) and asserts the fixture rejects it with the -32602 envelope. If
+// hyperping-go ever regresses to omitting arguments for nil-args callers
+// (or someone in this repo writes a custom transport that does so), the
+// EscalationPolicies data source would see an "MCP error -32602 ... Input
+// validation" string flow through its content[0].text decode and fail with
+// "invalid character 'M' looking for beginning of value", which is the
+// exact production signature of the original silent breakage.
+//
+// We assert the fixture-level response shape directly rather than wiring
+// through the SDK; the SDK is already covered by hyperping-go's own
+// Test 1.16 regression guard. This test's job is fixture fidelity.
+func TestEscalationPoliciesDataSource_FailsAgainstStrictServer_WhenBugRegressedToNilArgs(t *testing.T) {
+	t.Parallel()
+	server := newStrictMCPTestServer(t, map[string]strictMCPTool{
+		"list_escalation_policies": noArgsTool([]any{
+			map[string]any{"uuid": "esc_x", "name": "Primary", "team": "SRE", "steps": []any{}},
+		}),
+	})
+	defer server.Close()
+
+	sid := initSession(t, server.URL)
+
+	// Buggy v0.6.x wire shape: no arguments key on params.
+	buggy := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_escalation_policies"}}`
+	resp := callToolRaw(t, server.URL, sid, buggy)
+	expectMCPValidationError(t, resp)
+
+	// Now confirm that the fixed v0.7.1 wire shape (arguments:{}) gets
+	// a clean response from the same fixture, demonstrating the wrapper
+	// distinguishes the two cases rather than blanket-rejecting.
+	fixed := `{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"list_escalation_policies","arguments":{}}}`
+	good := callToolRaw(t, server.URL, sid, fixed)
+	result, ok := good["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected result, got %v", good)
+	}
+	content := result["content"].([]any)
+	first := content[0].(map[string]any)
+	text := first["text"].(string)
+	if !strings.Contains(text, "esc_x") {
+		t.Fatalf("expected stub payload in response, got %q", text)
+	}
+
+	// Belt: the byte stream the strict fixture sends back for the buggy
+	// case must round-trip through json.Marshal -> json.Unmarshal so
+	// downstream assertions are stable across Go releases.
+	if _, err := json.Marshal(resp); err != nil {
+		t.Fatalf("response should be re-marshalable: %v", err)
+	}
+}
+
+// echo helpers below are intentionally unused — placeholders that document
+// the JSON-RPC envelope shape the fixture must respect. Kept as a single
+// reference point for future tests.
+var (
+	_ = bytes.NewReader
+	_ = fmt.Sprintf
+)

--- a/internal/provider/mcp_testserver_strict_test.go
+++ b/internal/provider/mcp_testserver_strict_test.go
@@ -4,9 +4,7 @@
 package provider
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -309,10 +307,3 @@ func TestEscalationPoliciesDataSource_FailsAgainstStrictServer_WhenBugRegressedT
 	}
 }
 
-// echo helpers below are intentionally unused — placeholders that document
-// the JSON-RPC envelope shape the fixture must respect. Kept as a single
-// reference point for future tests.
-var (
-	_ = bytes.NewReader
-	_ = fmt.Sprintf
-)

--- a/internal/provider/mcp_testserver_strict_test.go
+++ b/internal/provider/mcp_testserver_strict_test.go
@@ -29,7 +29,7 @@ func initSession(t *testing.T, srvURL string) string {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: srvURL is httptest.NewServer().URL, owned by the test, not user-tainted
 	if err != nil {
 		t.Fatalf("initialize call: %v", err)
 	}
@@ -52,7 +52,7 @@ func initSession(t *testing.T, srvURL string) string {
 	nreq.Header.Set("Content-Type", "application/json")
 	nreq.Header.Set("Accept", "application/json, text/event-stream")
 	nreq.Header.Set("Mcp-Session-Id", sid)
-	if nresp, err := http.DefaultClient.Do(nreq); err == nil {
+	if nresp, err := http.DefaultClient.Do(nreq); err == nil { //nolint:gosec // G704: srvURL is httptest.NewServer().URL, owned by the test, not user-tainted
 		_, _ = io.Copy(io.Discard, nresp.Body)
 		_ = nresp.Body.Close()
 	}
@@ -77,7 +77,7 @@ func callToolRaw(t *testing.T, srvURL, sid, jsonRPCBody string) map[string]any {
 		req.Header.Set("Mcp-Session-Id", sid)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: srvURL is httptest.NewServer().URL, owned by the test, not user-tainted
 	if err != nil {
 		t.Fatalf("tools/call: %v", err)
 	}

--- a/internal/provider/mcp_testserver_strict_test.go
+++ b/internal/provider/mcp_testserver_strict_test.go
@@ -306,4 +306,3 @@ func TestEscalationPoliciesDataSource_FailsAgainstStrictServer_WhenBugRegressedT
 		t.Fatalf("response should be re-marshalable: %v", err)
 	}
 }
-

--- a/internal/provider/mcp_testserver_test.go
+++ b/internal/provider/mcp_testserver_test.go
@@ -4,7 +4,12 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -47,4 +52,246 @@ type strictMCPTool struct {
 func newStrictMCPTestServer(t *testing.T, tools map[string]strictMCPTool) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(strictMCPHandler(t, tools))
+}
+
+// sessionCounter mints unique session ids for each initialize call. Atomic
+// so concurrent fixtures across parallel subtests do not collide.
+var sessionCounter atomic.Uint64
+
+// strictMCPHandler returns the http.Handler that backs the strict MCP
+// test server. It is separated from newStrictMCPTestServer so the handler
+// can be wrapped in middleware by callers that need to assert on raw
+// request bytes without re-implementing the JSON-RPC dispatch.
+func strictMCPHandler(t *testing.T, tools map[string]strictMCPTool) http.Handler {
+	t.Helper()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		_ = r.Body.Close()
+
+		// Probe the method first; we need to special-case initialize
+		// (mints a session) and the notifications/initialized post-
+		// handshake message before we touch params.
+		var envelope struct {
+			JSONRPC string         `json:"jsonrpc"`
+			ID      any            `json:"id"`
+			Method  string         `json:"method"`
+			Params  map[string]any `json:"params"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			writeRPCError(w, nil, -32700, "Parse error: "+err.Error())
+			return
+		}
+
+		switch envelope.Method {
+		case "initialize":
+			sid := fmt.Sprintf("strict-%d", sessionCounter.Add(1))
+			w.Header().Set("Mcp-Session-Id", sid)
+			w.Header().Set("Content-Type", "application/json")
+			writeRPC(w, envelope.ID, map[string]any{
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]any{},
+				"serverInfo": map[string]any{
+					"name":    "strict-mcp-fixture",
+					"version": "1.0",
+				},
+			})
+			return
+		case "notifications/initialized":
+			// Spec: no response body for a notification. Send 202 with
+			// empty body so the transport's response decoder, which is
+			// permissive about notifications, does not block.
+			w.WriteHeader(http.StatusAccepted)
+			return
+		case "tools/call":
+			handleToolsCall(t, w, envelope.ID, envelope.Params, tools, body)
+			return
+		default:
+			writeRPCError(w, envelope.ID, -32601, "method not found: "+envelope.Method)
+			return
+		}
+	})
+}
+
+// handleToolsCall does the request-shape validation that production
+// /v1/mcp performs. Validation failures are returned as content[0].text
+// starting with "MCP error -32602: ... Input validation ..." because the
+// live server wraps its input-validator failures inside the tool result
+// stream rather than the JSON-RPC error channel. Mirroring this exactly
+// is the entire point of the fixture; the original bug surfaced as a
+// json.Unmarshal failure on that literal text in hyperping-go's
+// content[0].text decoder.
+func handleToolsCall(t *testing.T, w http.ResponseWriter, id any, params map[string]any, tools map[string]strictMCPTool, rawBody []byte) {
+	t.Helper()
+
+	// Validation rule 1: params present and non-null. JSON-RPC spec
+	// allows omitted params on some methods, but tools/call always
+	// requires a params object.
+	if params == nil {
+		writeWrappedValidationError(w, id, "tools/call: params is required")
+		return
+	}
+
+	nameAny, hasName := params["name"]
+	if !hasName {
+		writeWrappedValidationError(w, id, "tools/call: params.name is required")
+		return
+	}
+	name, ok := nameAny.(string)
+	if !ok {
+		writeWrappedValidationError(w, id, "tools/call: params.name must be a string")
+		return
+	}
+
+	tool, known := tools[name]
+	if !known {
+		writeRPCError(w, id, -32601, "unknown tool: "+name)
+		return
+	}
+
+	// Validation rule 2: arguments key MUST be present AND non-null.
+	// The arguments-key-omitted variant is the load-bearing case (the
+	// hyperping-go v0.6.x bug); the explicit-null variant is the belt
+	// for callers who "fix" it by sending arguments:null. To detect
+	// either case reliably we re-parse the raw bytes; a map[string]any
+	// drops the distinction between "key absent" and "key set to null"
+	// after Unmarshal completes, both surfacing as a missing entry.
+	var rawProbe struct {
+		Params *json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(rawBody, &rawProbe); err != nil || rawProbe.Params == nil {
+		writeWrappedValidationError(w, id, "tools/call: params.arguments is required")
+		return
+	}
+	var paramsProbe struct {
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	// json.Decoder with DisallowUnknownFields would defeat the purpose
+	// here; we only care that the bytes contain the arguments key.
+	_ = json.Unmarshal(*rawProbe.Params, &paramsProbe)
+	if len(paramsProbe.Arguments) == 0 || string(paramsProbe.Arguments) == "null" {
+		writeWrappedValidationError(w, id,
+			"tools/call: params.arguments is required, got missing or null")
+		return
+	}
+
+	argsAny := params["arguments"]
+	args, ok := argsAny.(map[string]any)
+	if !ok {
+		writeWrappedValidationError(w, id, "tools/call: params.arguments must be an object")
+		return
+	}
+
+	// Validation rule 3: unknown keys are rejected when the tool
+	// declares a properties whitelist. A tool with empty Properties
+	// declares "no allowed keys", matching the empty-properties +
+	// implicit-additionalProperties:false posture of the three list
+	// tools on the live server.
+	allowed := make(map[string]struct{}, len(tool.Properties))
+	for _, p := range tool.Properties {
+		allowed[p] = struct{}{}
+	}
+	for k := range args {
+		if _, ok := allowed[k]; !ok {
+			writeWrappedValidationError(w, id,
+				fmt.Sprintf("tools/call: additionalProperties not allowed: %q", k))
+			return
+		}
+	}
+
+	// Validation rule 4: required fields must be present.
+	for _, req := range tool.Required {
+		if _, ok := args[req]; !ok {
+			writeWrappedValidationError(w, id,
+				fmt.Sprintf("tools/call: required field %q is missing", req))
+			return
+		}
+	}
+
+	// Dispatch to the per-tool handler.
+	result, err := tool.Handler(args)
+	if err != nil {
+		// Internal handler errors map to -32603, wrapped in
+		// content[0].text the same way the live server wraps
+		// post-validator runtime failures.
+		writeWrappedError(w, id, -32603, "MCP error -32603: "+err.Error())
+		return
+	}
+
+	// The hyperping-go transport extracts content[0].text and json-
+	// decodes it. So result must be JSON-encoded as a string and
+	// returned in content[0].text.
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		writeWrappedError(w, id, -32603, "MCP error -32603: marshal: "+err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeRPC(w, id, map[string]any{
+		"content": []any{
+			map[string]any{
+				"type": "text",
+				"text": string(resultBytes),
+			},
+		},
+	})
+}
+
+// writeRPC writes a JSON-RPC success response.
+func writeRPC(w http.ResponseWriter, id any, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	})
+}
+
+// writeRPCError writes a JSON-RPC error response (top-level error
+// channel). Use this for envelope-level failures (method not found,
+// parse error). Tool-level validation errors go through
+// writeWrappedValidationError to match the live server's wrapping.
+func writeRPCError(w http.ResponseWriter, id any, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+// writeWrappedValidationError emits the -32602 / Input validation shape
+// the live server uses when params.arguments is malformed. The error
+// rides inside result.content[0].text as a literal "MCP error -32602:
+// Input validation: ..." string, NOT in the JSON-RPC error channel. This
+// is what makes the original bug invisible to clients that only check
+// rpcResp.Error and then try to json.Unmarshal the content[0].text body.
+func writeWrappedValidationError(w http.ResponseWriter, id any, detail string) {
+	writeWrappedError(w, id, -32602, "MCP error -32602: Input validation: "+detail)
+}
+
+// writeWrappedError is the generic content[0].text-wrapped error path.
+func writeWrappedError(w http.ResponseWriter, id any, code int, text string) {
+	_ = code // documented in text per the live server's shape
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result": map[string]any{
+			"content": []any{
+				map[string]any{
+					"type": "text",
+					"text": text,
+				},
+			},
+		},
+	})
 }

--- a/internal/provider/mcp_testserver_test.go
+++ b/internal/provider/mcp_testserver_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// strictMCPToolHandler is the per-tool callback the strict fixture invokes
+// after it has validated the JSON-RPC envelope and the tools/call argument
+// shape. The handler receives the already-validated arguments map and
+// returns the typed result (will be JSON-encoded into content[0].text) or
+// an error (will be surfaced as a JSON-RPC -32603 wrapped the same way the
+// live MCP server wraps internal errors).
+type strictMCPToolHandler func(args map[string]any) (any, error)
+
+// strictMCPTool describes one tool the fixture is willing to serve. Tests
+// supply a map of these keyed by tool name to newStrictMCPTestServer.
+type strictMCPTool struct {
+	// Properties is the JSON-schema "properties" key whitelist for
+	// params.arguments. Any incoming argument key not listed here is
+	// rejected with -32602 to match the live server's
+	// additionalProperties:false behaviour.
+	Properties []string
+	// Required is the JSON-schema "required" list. Missing keys produce
+	// -32602 with an "Input validation" message matching the live server.
+	Required []string
+	// Handler runs after validation passes.
+	Handler strictMCPToolHandler
+}
+
+// newStrictMCPTestServer constructs an httptest.Server that mimics the
+// production /v1/mcp endpoint's request-shape validation closely enough
+// that the v0.6.x nil-arguments regression (fixed by hyperping-go v0.7.1)
+// would be caught in CI. The intent is fidelity to the request envelope
+// the live server checks; per-field type validation is intentionally out
+// of scope for this fixture.
+//
+// The server speaks just enough JSON-RPC and MCP to satisfy
+// hyperping-go's transport: initialize handshake (returns a session id),
+// notifications/initialized (no-op), and tools/call (validated +
+// dispatched). Anything else returns a JSON-RPC -32601.
+//
+// Caller closes the server with the standard httptest.Server.Close().
+func newStrictMCPTestServer(t *testing.T, tools map[string]strictMCPTool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(strictMCPHandler(t, tools))
+}


### PR DESCRIPTION
## Summary

Closes the fixture-fidelity gap that let the `hyperping-go` v0.6.x
nil-arguments transport bug ship to production undetected for the
entire v0.6.x lifetime. Adds a strict httptest-backed MCP fixture that
validates the `tools/call` request envelope the same way `/v1/mcp`
does, retrofits the one existing MCP acceptance test, and adds four new
acceptance tests so every MCP-backed data source is now exercised
end-to-end through the strict path.

Backlog: TF-06.

## Why this matters

Five MCP-backed Terraform data sources broke silently against the live
`/v1/mcp` endpoint for the entire `hyperping-go` v0.6.x lifetime:

- `hyperping_escalation_policies`
- `hyperping_escalation_policy`
- `hyperping_integrations`
- `hyperping_on_call_schedules`
- `hyperping_on_call_schedule`

Root cause was a transport-layer bug in `hyperping-go` (fixed in v0.7.1,
picked up via #143): `CallTool(ctx, name, nil)` serialized a
`tools/call` request that omitted the `arguments` key entirely. The
production MCP server rejected the request with JSON-RPC `-32602 Input
validation ...`, but wrapped the error as the literal text of
`result.content[0].text` rather than emitting it through the top-level
`error` channel. The SDK then tried to `json.Unmarshal` that literal
text and failed with `invalid character 'M' looking for beginning of
value`, surfacing to operators as `failed to parse MCP tool response`
on every `terraform plan`.

The reason this went undetected: the pre-TF-06 fixture in
`escalation_policy_data_source_test.go` was an unrestricted
`httptest.NewServer(handler)` that accepted any payload shape, and the
other four data sources had no httptest-backed coverage at all. So
CI stayed green on every release while production was broken.

## What changed

1. **`internal/provider/mcp_testserver_test.go`** introduces
   `newStrictMCPTestServer(t, tools)`. The handler implements just
   enough JSON-RPC + MCP to satisfy `hyperping-go`'s transport
   (initialize handshake with session-id minting,
   `notifications/initialized` no-op, `tools/call` dispatch) and
   performs four validation rules that match the live server:

   - `params.arguments` must be present and non-null (the load-bearing
     check; re-parses the raw body because `Unmarshal` into
     `map[string]any` collapses missing-key and null-key into the same
     state)
   - unknown argument keys are rejected when the tool declares a
     properties whitelist
   - required fields per the tool's input schema must be present
   - unknown tool names go through the `-32601` error channel

   Validation failures travel through `content[0].text` as
   `"MCP error -32602: Input validation: ..."`, matching the exact
   wire shape captured against the live server.

2. **`internal/provider/mcp_testserver_strict_test.go`** holds six
   regression-guard tests covering each validation rule plus a
   load-bearing end-to-end test that hand-drives both the buggy
   pre-v0.7.1 wire shape (rejected) and the fixed v0.7.1 wire shape
   (accepted) against the same fixture.

3. **`internal/provider/escalation_policy_data_source_test.go`** is
   retrofitted off its lax handler onto the strict fixture. Same
   assertions, same expected outcomes; the only difference is that
   any future regression to omitted/null arguments would now fail
   this test.

4. **`internal/provider/mcp_data_sources_acceptance_test.go`** adds
   four new acceptance tests (`TestAccEscalationPoliciesDataSource_basic`,
   `TestAccIntegrationsDataSource_basic`,
   `TestAccOnCallSchedulesDataSource_basic`,
   `TestAccOnCallScheduleDataSource_basic`) so every MCP-backed data
   source is exercised against the strict fixture.

Tool input-schemas were verified against the pinned snapshot at
`hyperping-go/testdata/mcp_tools_list.json`. The three list tools have
empty `properties` (no allowed argument keys); the three `get_*` tools
declare `required:["uuid"]` with `additionalProperties:false`.

## Verification matrix

| Check                        | Result                                  |
| ---------------------------- | --------------------------------------- |
| `git status`                 | clean                                   |
| `go vet ./...`               | no issues                               |
| `go build ./...`             | success                                 |
| `go test -race -count=1 ./...` (with TF_ACC=1) | 2672 passed, 25 packages |
| `golangci-lint run` (touched files) | clean                            |
| Regression guard test        | green                                   |

Three pre-existing `gosec` findings in `error_integration_test.go` and
`vcr_test.go` remain; they are not in TF-06's scope.

## Followups (out of scope here)

- Per-field type validation in the strict fixture (string vs array vs
  number per JSON schema). The current fixture validates request shape;
  value-type validation is deferred until a real test needs it.
- Loading the tool schemas from
  `hyperping-go/testdata/mcp_tools_list.json` at test init time, rather
  than the current pattern of declaring `Properties` / `Required`
  inline in each test. The inline pattern keeps tests local but
  duplicates schema metadata.
- Adding a strict-fixture-backed integration test that exercises the
  `MCPClient.GetEscalationPolicy` / `GetOnCallSchedule` /
  `GetIntegration` paths once any data source actually starts calling
  them (today all five data sources go through the list path).

## Backlog

TF-06.
