### PR TITLE
chore(provider): track WriteOnly support for api_key (TF-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Published releases start from v1.0.3.
 
 ## [Unreleased]
 
+### Chore
+
+- Added a tracking `TODO(TF-10)` comment on the `api_key` provider attribute noting that `WriteOnly: true` cannot be set until `terraform-plugin-framework` supports write-only attributes on provider schemas. As of v1.19.0, `IsWriteOnly()` always returns false for provider attributes. The attribute remains protected by `Sensitive: true` and the `HYPERPING_API_KEY` environment variable pattern in the meantime.
+
 ### Changed
 
 - Bumped `github.com/develeap/hyperping-go` from v0.6.3 to v0.7.1. The bump pulls in the v0.7.0 MCP client correctness work (canonical windowed signatures on `GetMonitorMtta`, `GetMonitorMttr`, `GetMonitorResponseTime`, `GetMonitorUptime`; response types renamed and rewritten to match the live `https://api.hyperping.io/v1/mcp` wire shape) and the v0.7.1 nil-args MCP transport fix that unblocked the six argument-less `tools/call` requests. The provider only consumes `*MCPClient` methods that were not affected by the type renames (`ListEscalationPolicies`, `ListOnCallSchedules`, `ListIntegrations`, plus the single-resource lookups), so no source-level migration is required for provider users. Upstream releases: v0.7.0 (https://github.com/develeap/hyperping-go/releases/tag/v0.7.0), v0.7.1 (https://github.com/develeap/hyperping-go/releases/tag/v0.7.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Published releases start from v1.0.3.
 
 ### Chore
 
-- Added a tracking `TODO(TF-10)` comment on the `api_key` provider attribute noting that `WriteOnly: true` cannot be set until `terraform-plugin-framework` supports write-only attributes on provider schemas. As of v1.19.0, `IsWriteOnly()` always returns false for provider attributes. The attribute remains protected by `Sensitive: true` and the `HYPERPING_API_KEY` environment variable pattern in the meantime.
+- Added a tracking `TODO(TF-10)` comment on the `api_key` provider attribute noting that `WriteOnly: true` cannot be set until `terraform-plugin-framework` supports write-only attributes on provider schemas. As of v1.19.0, `IsWriteOnly()` always returns false for provider attributes. The attribute remains protected by `Sensitive: true` and the `HYPERPING_API_KEY` environment variable pattern in the meantime. Upstream feature request: hashicorp/terraform-plugin-framework#1305.
 
 ### Changed
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -63,8 +63,9 @@ func (p *HyperpingProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				// TODO(TF-10): add WriteOnly: true once terraform-plugin-framework supports
 				// WriteOnly on provider schema attributes. As of v1.19.0, IsWriteOnly()
 				// always returns false for provider attributes ("write-only attributes are
-				// not relevant to provider schemas"). Track:
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/1118
+				// not relevant to provider schemas"). WriteOnly was added for resource
+				// schemas in hashicorp/terraform-plugin-framework#1044; no upstream issue
+				// yet tracks provider-schema support.
 			},
 			"base_url": schema.StringAttribute{
 				MarkdownDescription: "Hyperping API base URL. Defaults to `https://api.hyperping.io`.",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,6 +60,11 @@ func (p *HyperpingProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				MarkdownDescription: "Hyperping API key (starts with `sk_`). Can also be set via `HYPERPING_API_KEY` environment variable.",
 				Optional:            true,
 				Sensitive:           true,
+				// TODO(TF-10): add WriteOnly: true once terraform-plugin-framework supports
+				// WriteOnly on provider schema attributes. As of v1.19.0, IsWriteOnly()
+				// always returns false for provider attributes ("write-only attributes are
+				// not relevant to provider schemas"). Track:
+				// https://github.com/hashicorp/terraform-plugin-framework/issues/1118
 			},
 			"base_url": schema.StringAttribute{
 				MarkdownDescription: "Hyperping API base URL. Defaults to `https://api.hyperping.io`.",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,8 +64,8 @@ func (p *HyperpingProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 				// WriteOnly on provider schema attributes. As of v1.19.0, IsWriteOnly()
 				// always returns false for provider attributes ("write-only attributes are
 				// not relevant to provider schemas"). WriteOnly was added for resource
-				// schemas in hashicorp/terraform-plugin-framework#1044; no upstream issue
-				// yet tracks provider-schema support.
+				// schemas in hashicorp/terraform-plugin-framework#1044; provider-schema
+				// support is tracked upstream at hashicorp/terraform-plugin-framework#1305.
 			},
 			"base_url": schema.StringAttribute{
 				MarkdownDescription: "Hyperping API base URL. Defaults to `https://api.hyperping.io`.",

--- a/internal/provider/provider_api_key_write_only_test.go
+++ b/internal/provider/provider_api_key_write_only_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Develeap
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+)
+
+// TestProviderSchema_APIKeyNotWriteOnly documents the framework limitation:
+// terraform-plugin-framework v1.19.0 does not support WriteOnly on provider schema
+// attributes (IsWriteOnly() is hard-coded to return false). Tracked as TF-10.
+func TestProviderSchema_APIKeyNotWriteOnly(t *testing.T) {
+	p := &HyperpingProvider{}
+	resp := &provider.SchemaResponse{}
+	p.Schema(context.Background(), provider.SchemaRequest{}, resp)
+
+	attrRaw, ok := resp.Schema.Attributes["api_key"]
+	if !ok {
+		t.Fatal("api_key attribute not found in provider schema")
+	}
+
+	attr, ok := attrRaw.(providerschema.StringAttribute)
+	if !ok {
+		t.Fatalf("api_key is not a provider StringAttribute, got %T", attrRaw)
+	}
+
+	if attr.IsWriteOnly() {
+		t.Error("api_key should not be write-only: framework does not support WriteOnly on provider schemas (track TF-10)")
+	}
+}


### PR DESCRIPTION
## Summary

Tracks terraform-plugin-framework's lack of `WriteOnly` support on provider schema attributes. The framework's `IsWriteOnly()` method is hard-coded to return `false` for provider attributes (as of v1.19.0); resource schemas support `WriteOnly` via hashicorp/terraform-plugin-framework#1044, but provider schemas do not. This PR adds a `TODO(TF-10)` comment on the `api_key` attribute marking where `WriteOnly: true` should be added once upstream support lands. A unit test documents the limitation. The `api_key` remains protected by `Sensitive: true` and the `HYPERPING_API_KEY` environment variable pattern in the meantime.

## What changed

| File | Change |
|---|---|
| `internal/provider/provider.go` | Added `TODO(TF-10)` comment on `api_key` attribute explaining the framework limitation and linking upstream context |
| `internal/provider/provider_api_key_write_only_test.go` | New: unit test `TestProviderSchema_APIKeyNotWriteOnly` documenting that the framework does not support `WriteOnly` on provider attributes |
| `CHANGELOG.md` | Added entry to Unreleased section documenting the tracking comment and current mitigation |

## Design reasoning

Provider schema attributes do not support `WriteOnly` in terraform-plugin-framework v1.19.0. The `api_key` attribute is protected by `Sensitive: true` (which masks it in plan output) and the recommended `HYPERPING_API_KEY` environment variable pattern (which avoids state storage entirely). These mitigations are sufficient until the framework adds provider-schema `WriteOnly` support. The TODO comment and unit test mark the exact location and reason for the future change, enabling a straightforward implementation once upstream support is available.

## Verification matrix

| Check | Result |
|---|---|
| `TestProviderSchema_APIKeyNotWriteOnly` | PASS |
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `go test -race -count=1 ./...` (full suite) | PASS |

## Acceptance criteria

- [x] `TODO(TF-10)` comment added to `api_key` attribute with upstream context
- [x] Unit test documents the framework limitation
- [x] CHANGELOG.md updated
- [x] Full test suite passes
- [x] No breaking changes

## Follow-up items

- **TF-10**: Once `terraform-plugin-framework` adds `WriteOnly` support for provider schema attributes, uncomment and set `WriteOnly: true` on `api_key`. The TODO comment marks the exact location. Check upstream issue (when filed) for details on the framework release.
