### PR TITLE
chore(deps): bump go directive to 1.26.5 to clear GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/develeap/terraform-provider-hyperping
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Summary

Bumps the go directive in `go.mod` from `1.26.4` to `1.26.5` so the module builds against the patched Go standard library.

## Why

The `Security` CI job runs `govulncheck ./...`, which flags **GO-2026-5856 / CVE-2026-42505** (crypto/tls Encrypted Client Hello de-anonymization), disclosed 2026-07-07 and fixed in **go1.26.5**. With the module pinned at `go 1.26.4`, every Security run after the disclosure fails, including the open Dependabot PRs (#153, #154). None of those PRs touch `crypto/tls`; the failure is purely the stdlib toolchain version.

## Verification

Locally, with the 1.26.5 toolchain:
- `go build ./...` succeeds.
- `govulncheck ./...` reports **No vulnerabilities found** (was: 1 finding, GO-2026-5856).

## Impact

- Unblocks the `Security` check on all branches once rebased onto this.
- No code changes; go.sum unchanged (no dependency graph change).